### PR TITLE
copr settings updates

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -33,9 +33,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Sequence, Callable, List, Tuple, Dict, Iterable, Optional
 
-from ogr.abstract import PullRequest
 from tabulate import tabulate
 
+from ogr.abstract import PullRequest
 from packit import utils
 from packit.actions import ActionName
 from packit.config import Config
@@ -671,6 +671,7 @@ class PackitAPI:
         preserve_project: bool = False,
         additional_packages: List[str] = None,
         additional_repos: List[str] = None,
+        request_admin_if_needed: bool = False,
     ) -> Tuple[int, str]:
         """
         Submit a build to copr build system using an SRPM using the current checkout.
@@ -686,6 +687,8 @@ class PackitAPI:
         :param preserve_project: if set, project will not be created as temporary
         :param list additional_packages: buildroot packages for the chroot [DOES NOT WORK YET]
         :param list additional_repos: buildroot additional additional_repos
+        :param bool request_admin_if_needed: if we can't change the settings
+                                             and are not allowed to do so
         :return: id of the created build and url to the build web page
         """
         srpm_path = self.create_srpm(

--- a/packit/cli/copr_build.py
+++ b/packit/cli/copr_build.py
@@ -86,6 +86,13 @@ logger = logging.getLogger(__name__)
     "from which packit should generate patches "
     "(this option implies the repository is source-git).",
 )
+@click.option(
+    "--request-admin-if-needed",
+    help="Ask for admin permissions when we need to change settings of the copr project "
+    "and are not allowed to do so.",
+    default=False,
+    is_flag=True,
+)
 @click.argument("path_or_url", type=LocalProjectParameter(), default=os.path.curdir)
 @pass_config
 @cover_packit_exception
@@ -101,6 +108,7 @@ def copr_build(
     preserve_project,
     upstream_ref,
     additional_repos,
+    request_admin_if_needed,
     path_or_url,
 ):
     """
@@ -135,6 +143,7 @@ def copr_build(
         list_on_homepage=list_on_homepage,
         preserve_project=preserve_project,
         additional_repos=additional_repos_list,
+        request_admin_if_needed=request_admin_if_needed,
     )
     click.echo(f"Build id: {build_id}, repo url: {repo_url}")
     if not nowait:

--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -131,15 +131,12 @@ class CoprHelper:
                 logger.debug(f"{field}: {old} -> {new}")
 
             try:
+                kwargs: Dict[str, Any] = {
+                    arg_name: new for arg_name, (old, new) in fields_to_change.items()
+                }
+                logger.debug(f"Copr edit arguments: {kwargs}")
                 self.copr_client.project_proxy.edit(
-                    ownername=owner,
-                    projectname=project,
-                    chroots=chroots,
-                    description=description,
-                    instructions=instructions,
-                    unlisted_on_hp=not list_on_homepage,
-                    additional_repos=additional_repos,
-                    delete_after_days=delete_after_days,
+                    ownername=owner, projectname=project, **kwargs
                 )
             except CoprRequestException as ex:
                 if "Only owners and admins may update their projects." in str(ex):

--- a/packit/exceptions.py
+++ b/packit/exceptions.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Union
+from typing import Union, Any, Tuple, Dict
 
 from deprecated import deprecated
 
@@ -44,7 +44,7 @@ class PackitCommandFailedError(PackitException):
         self,
         *args,
         stdout_output: Union[str, bytes] = None,
-        stderr_output: Union[str, bytes] = None
+        stderr_output: Union[str, bytes] = None,
     ):
         super().__init__(*args)
         self.stdout_output = ensure_str(stdout_output)
@@ -61,6 +61,20 @@ class PackitCoprException(PackitException):
 
 class PackitCoprProjectException(PackitCoprException):
     pass
+
+
+class PackitCoprSettingsException(PackitException):
+    """
+    Raised when we can't edit the Copr project settings.
+
+    Contains the info about fields that we want to edit.
+    """
+
+    def __init__(
+        self, *args: object, fields_to_change: Dict[str, Tuple[Any, Any]]
+    ) -> None:
+        self.fields_to_change = fields_to_change
+        super().__init__(*args)
 
 
 class PackitInvalidConfigException(PackitConfigException):

--- a/tests/integration/test_copr_build.py
+++ b/tests/integration/test_copr_build.py
@@ -21,39 +21,172 @@
 # SOFTWARE.
 
 import pytest
-from copr.v3 import ProjectProxy, Client, BuildProxy, CoprNoResultException
-
+from copr.v3 import (
+    ProjectProxy,
+    Client,
+    BuildProxy,
+    CoprNoResultException,
+    CoprRequestException,
+)
 from flexmock import flexmock
+
 from packit.copr_helper import CoprHelper
-from packit.exceptions import PackitCoprException
+from packit.exceptions import PackitCoprException, PackitCoprSettingsException
 
 
 def test_copr_build_existing_project(cwd_upstream_or_distgit, api_instance):
     u, d, api = api_instance
     owner = "the-owner"
     project = "project-name"
+    description = "some description"
+    instructions = "the instructions"
+    chroots = ["fedora-rawhide-x86_64"]
 
     flexmock(ProjectProxy).should_receive("get").and_return(
-        flexmock(chroot_repos=flexmock(keys=lambda: {"fedora-rawhide-x86_64"}))
+        flexmock(
+            chroot_repos=flexmock(keys=lambda: chroots),
+            description=description,
+            instructions=instructions,
+            unlisted_on_hp=True,
+            delete_after_days=60,
+            additional_repos=[],
+        )
     )
-    flexmock(ProjectProxy).should_receive("edit").and_return(None)
+
+    # no change in settings => no edit
+    flexmock(ProjectProxy).should_receive("edit").times(0)
 
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(
         Client(config={"copr_url": "https://copr.fedorainfracloud.org"})
     )
 
-    build = flexmock(id="1", ownername=owner, projectname=project)
+    build = flexmock(id="1", ownername=owner, projectname=project,)
     flexmock(BuildProxy).should_receive("create_from_file").and_return(build)
     build_id, url = api.run_copr_build(
         project=project,
-        chroots="fedora-rawhide-x86_64",
         owner=owner,
-        description="some description",
-        instructions="the instructions",
+        chroots=chroots,
+        description=description,
+        instructions=instructions,
     )
 
     assert build_id == "1"
     assert url == f"https://copr.fedorainfracloud.org/coprs/build/{build.id}/"
+
+
+def test_copr_build_existing_project_change_settings(
+    cwd_upstream_or_distgit, api_instance
+):
+    u, d, api = api_instance
+    owner = "the-owner"
+    project = "project-name"
+    description = "some description"
+    instructions = "the instructions"
+    chroots = ["fedora-rawhide-x86_64"]
+
+    flexmock(ProjectProxy).should_receive("get").and_return(
+        flexmock(
+            chroot_repos=flexmock(keys=lambda: chroots),
+            description=description,
+            instructions=instructions,
+            unlisted_on_hp=True,
+            delete_after_days=60,
+            additional_repos=[],
+        )
+    )
+
+    flexmock(ProjectProxy).should_receive(
+        "edit"
+        # ).with_args(
+        # ownername="the-owner",
+        # projectname="project-name",
+        # chroots=["fedora-rawhide-x86_64"],
+        # description="different description",
+        # instructions="the instructions",
+        # unlisted_on_hp=True,
+        # additional_repos=None,
+        # delete_after_days=60,
+        #
+        # Does not work:
+        # flexmock.MethodSignatureError:
+        # edit(
+        #    <copr.v3.proxies.project.ProjectProxy object at 0x7fa53af2f3d0>,
+        #    ownername="the-owner",
+        #    projectname="project-name",
+        #    chroots=["fedora-rawhide-x86_64"],
+        #    description="different description",
+        #    instructions="the instructions",
+        #    unlisted_on_hp=True,
+        #    additional_repos=None,
+        #    delete_after_days=60,
+        # )
+    ).and_return().once()
+
+    flexmock(CoprHelper).should_receive("get_copr_client").and_return(
+        Client(config={"copr_url": "https://copr.fedorainfracloud.org"})
+    )
+
+    build = flexmock(id="1", ownername=owner, projectname=project,)
+    flexmock(BuildProxy).should_receive("create_from_file").and_return(build)
+    build_id, url = api.run_copr_build(
+        project=project,
+        chroots=chroots,
+        owner=owner,
+        description="different description",
+        instructions=instructions,
+    )
+
+    assert build_id == "1"
+    assert url == f"https://copr.fedorainfracloud.org/coprs/build/{build.id}/"
+
+
+def test_copr_build_existing_project_error_on_change_settings(
+    cwd_upstream_or_distgit, api_instance
+):
+    u, d, api = api_instance
+    owner = "the-owner"
+    project = "project-name"
+    description = "some description"
+    instructions = "the instructions"
+    chroots = ["fedora-rawhide-x86_64"]
+
+    flexmock(ProjectProxy).should_receive("get").and_return(
+        flexmock(
+            chroot_repos=flexmock(keys=lambda: chroots),
+            description=description,
+            instructions=instructions,
+            unlisted_on_hp=True,
+            delete_after_days=60,
+            additional_repos=[],
+        )
+        .should_receive("request_permissions")
+        .with_args(ownername=owner, projectname=project, permissions={"admin": True})
+        .and_return()
+        .mock()
+    )
+
+    flexmock(ProjectProxy).should_receive("edit").and_raise(
+        CoprRequestException, "Only owners and admins may update their projects."
+    ).once()
+
+    flexmock(CoprHelper).should_receive("get_copr_client").and_return(
+        Client(config={"copr_url": "https://copr.fedorainfracloud.org"})
+    )
+
+    build = flexmock(id="1", ownername=owner, projectname=project,)
+    flexmock(BuildProxy).should_receive("create_from_file").and_return(build)
+
+    with pytest.raises(PackitCoprSettingsException) as e_info:
+        api.run_copr_build(
+            project=project,
+            chroots=chroots,
+            owner=owner,
+            description="different description",
+            instructions=instructions,
+        )
+    assert e_info.value.fields_to_change == {
+        "description": ("some description", "different description")
+    }
 
 
 def test_copr_build_non_existing_project(cwd_upstream_or_distgit, api_instance):


### PR DESCRIPTION
- Ask for `admin` permissions and raise a better exception when we can't update the copr project settings. (The exception contains all fields that need to be changed with old and new values.)
- Will fix https://github.com/packit-service/packit/issues/902 once used in the packit-service.

TODO:
- [x] tests