### PR TITLE
[srpm] Extend logging of paths and make path to archive explicit

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -380,7 +380,13 @@ class Upstream(PackitRepositoryBase):
         """
         if archive_path.parent.absolute() != self.absolute_specfile_dir:
             archive_in_spec_dir = self.absolute_specfile_dir / archive_path.name
-            logger.info(f"Linking to the specfile directory: {archive_in_spec_dir}")
+            relative_archive_path = archive_path.relative_to(self.absolute_specfile_dir)
+
+            logger.info(
+                "Linking to the specfile directory:"
+                f"{archive_in_spec_dir} -> {archive_path}"
+                f"(relative path to archive: {relative_archive_path})"
+            )
             archive_in_spec_dir.symlink_to(archive_path)
 
     def _get_archive_path_from_output(self, outputs: List[str]) -> Optional[Path]:
@@ -398,7 +404,9 @@ class Upstream(PackitRepositoryBase):
                         self._local_project.working_dir, archive_name.strip()
                     )
                     if archive_path.is_file():
-                        logger.info(f"Created archive: {archive_path}")
+                        archive_path_absolute = archive_path.absolute()
+                        logger.info(f"Created archive: {archive_path} (relative)")
+                        logger.info(f"\t{archive_path_absolute} (absolute)")
                         return archive_path
                 except OSError as ex:
                     # File too long

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -384,10 +384,10 @@ class Upstream(PackitRepositoryBase):
 
             logger.info(
                 "Linking to the specfile directory:"
-                f"{archive_in_spec_dir} -> {archive_path}"
-                f"(relative path to archive: {relative_archive_path})"
+                f" {archive_in_spec_dir} -> {relative_archive_path}"
+                f" (absolute path to archive: {archive_path})"
             )
-            archive_in_spec_dir.symlink_to(archive_path)
+            archive_in_spec_dir.symlink_to(relative_archive_path)
 
     def _get_archive_path_from_output(self, outputs: List[str]) -> Optional[Path]:
         """
@@ -405,9 +405,10 @@ class Upstream(PackitRepositoryBase):
                     )
                     if archive_path.is_file():
                         archive_path_absolute = archive_path.absolute()
-                        logger.info(f"Created archive: {archive_path} (relative)")
-                        logger.info(f"\t{archive_path_absolute} (absolute)")
-                        return archive_path
+                        logger.info("Created archive:")
+                        logger.info(f"\trelative path: {archive_path}")
+                        logger.info(f"\tabsolute path: {archive_path_absolute}")
+                        return archive_path_absolute
                 except OSError as ex:
                     # File too long
                     if ex.errno == 36:


### PR DESCRIPTION
*  logging
   *  extends symlinking of path to the linked archive
      also logs relative path to the linked archive
   *  prints both relative and absolute path to the created archive
*  has paths that could resolve problem with linking
   Before: `archive_in_specdir` (links to) `created_archive`
   Potential solution: `created_archive` is converted to absolute path and then converted to **relative to the** `specdir`