### PR TITLE
Use 'create_pr' instead of 'pr_create'

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -231,7 +231,7 @@ class DistGit(PackitRepositoryBase):
             project_fork = project.get_fork()
 
         try:
-            dist_git_pr = project_fork.pr_create(
+            dist_git_pr = project_fork.create_pr(
                 title=pr_title,
                 body=pr_description,
                 source_branch=source_branch,

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -183,7 +183,7 @@ class Upstream(PackitRepositoryBase):
         project = self.local_project.git_project
 
         try:
-            upstream_pr = project.pr_create(
+            upstream_pr = project.create_pr(
                 title=pr_title,
                 body=pr_description,
                 source_branch=source_branch,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -107,7 +107,7 @@ def mock_spec_download_remote_s(path: Path):
 
 
 def mock_remote_functionality(distgit: Path, upstream: Path):
-    def mocked_pr_create(*args, **kwargs):
+    def mocked_create_pr(*args, **kwargs):
         return PullRequest(
             title="",
             id=42,
@@ -133,7 +133,7 @@ def mock_remote_functionality(distgit: Path, upstream: Path):
         get_git_urls=lambda: {"git": DOWNSTREAM_PROJECT_URL},
         fork_create=lambda: None,
         get_fork=lambda: PagureProject("", "", PagureService()),
-        pr_create=mocked_pr_create,
+        create_pr=mocked_create_pr,
     )
     flexmock(
         GithubProject,

--- a/tests/integration/test_pagure.py
+++ b/tests/integration/test_pagure.py
@@ -65,6 +65,6 @@ def test_basic_distgit_workflow(tmp_path):
         ["git", "push", "origin", f"{branch_name}:{branch_name}"], cwd=repo
     )
 
-    pr = fork.pr_create("testing PR", "serious description", "master", branch_name)
+    pr = fork.create_pr("testing PR", "serious description", "master", branch_name)
 
     proj.pr_comment(pr.id, "howdy!")

--- a/tests/unit/test_upstream.py
+++ b/tests/unit/test_upstream.py
@@ -73,7 +73,7 @@ def upstream_pr_mock():
     ],
 )
 def test_create_pull(upstream_mock, upstream_pr_mock, fork_username):
-    upstream_mock.local_project.git_project.should_receive("pr_create").with_args(
+    upstream_mock.local_project.git_project.should_receive("create_pr").with_args(
         title="test_title",
         body="test_description",
         source_branch="test_source",


### PR DESCRIPTION
'pr_create' is marked as deprecated in ogr.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>