### PR TITLE
Call the method on right copr object

### DIFF
--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -146,7 +146,7 @@ class CoprHelper:
                             f"in order to be able to edit project settings. "
                             f"Requesting the admin rights for the copr '{owner}/{project}' project."
                         )
-                        copr_proj.request_permissions(
+                        self.copr_client.project_proxy.request_permissions(
                             ownername=owner,
                             projectname=project,
                             permissions={"admin": True},

--- a/tests/integration/test_copr_build.py
+++ b/tests/integration/test_copr_build.py
@@ -373,11 +373,11 @@ def test_copr_build_existing_project_error_on_change_settings(
             delete_after_days=60,
             additional_repos=[],
         )
-        .should_receive("request_permissions")
-        .with_args(ownername=owner, projectname=project, permissions={"admin": True})
-        .and_return()
-        .mock()
     )
+
+    flexmock(ProjectProxy).should_receive("request_permissions").with_args(
+        ownername=owner, projectname=project, permissions={"admin": True}
+    ).and_return()
 
     flexmock(ProjectProxy).should_receive("edit").and_raise(
         CoprRequestException, "Only owners and admins may update their projects."


### PR DESCRIPTION
- Use `ProjectProxy`, not the copr project object to request permissions.