### PR TITLE
merge related commits into a single patch (git-am)

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -311,7 +311,7 @@ class PackitRepositoryBase:
         """
         Add the given list of (patch_name, msg) to the specfile.
 
-        :param patch_list: [(patch_name, msg)]
+        :param patch_list: [PatchMetadata, ...]
         """
         if not patch_list:
             return

--- a/packit/patches.py
+++ b/packit/patches.py
@@ -136,6 +136,9 @@ class PatchMetadata:
             commit=commit,
         )
 
+    def __repr__(self):
+        return f"Patch(name={self.name}, commit={self.commit})"
+
 
 class PatchGenerator:
     """

--- a/packit/patches.py
+++ b/packit/patches.py
@@ -245,7 +245,7 @@ class PatchGenerator:
         )
 
     @staticmethod
-    def process_patches(patches: Dict[str, str], commits: List[git.Commit]):
+    def process_patches(patches: Dict[str, bytes], commits: List[git.Commit]):
         """
         Pair commits (in a source-git repo) with a list patches generated with git-format-patch.
 
@@ -259,7 +259,7 @@ class PatchGenerator:
             for patch_name, patch_content in patches.items():
                 # `git format-patch` usually creates one patch for a merge commit,
                 # so some commits won't be covered by a dedicated patch file
-                if commit.hexsha in patch_content:
+                if commit.hexsha.encode() in patch_content:
                     path = Path(patch_name)
                     patch_metadata = PatchMetadata.from_commit(
                         commit=commit, patch_path=path
@@ -350,8 +350,9 @@ class PatchGenerator:
             ).strip()
 
             if git_format_patch_out:
-                patches = {
-                    patch_name: Path(patch_name).read_text()
+                patches: Dict[str, bytes] = {
+                    # we need to read bytes since we cannot decode whatever is inside patches
+                    patch_name: Path(patch_name).read_bytes()
                     for patch_name in git_format_patch_out.split("\n")
                 }
                 patch_list = self.process_patches(patches, commits)

--- a/packit/patches.py
+++ b/packit/patches.py
@@ -107,7 +107,7 @@ class PatchMetadata:
         return msg
 
     @staticmethod
-    def from_commit(commit: git.Commit, patch_path: Path):
+    def from_commit(commit: git.Commit, patch_path: Path) -> "PatchMetadata":
         metadata = get_metadata_from_message(commit) or {}
         if metadata:
             logger.debug(
@@ -244,7 +244,7 @@ class PatchGenerator:
         :param git_ref: start processing commits from this till HEAD
         :param destination: place the patch files here
         :param files_to_ignore: list of files to ignore when creating patches
-        :return: [(patch_path, msg)] list of created patches (tuple of the file path and commit msg)
+        :return: [PatchMetadata, ...] list of patches
         """
         contained = self.are_child_commits_contained(git_ref)
         if not contained:

--- a/packit/specfile.py
+++ b/packit/specfile.py
@@ -160,6 +160,12 @@ class Specfile(SpecFile):
         if not patch_list:
             return
 
+        if all([p.present_in_specfile for p in patch_list]):
+            logger.debug(
+                "All patches are present in the spec file, nothing to do here 🚀"
+            )
+            return
+
         logger.debug(f"About to add patches {patch_list} to specfile.")
         if [t.name for t in self.tags.filter(name="Patch*")]:
             logger.debug("This specfile already contains patches.")

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -205,7 +205,7 @@ class Upstream(PackitRepositoryBase):
 
         :param destination: str
         :param upstream: str -- git branch or tag
-        :return: [(patch_path, msg)] list of created patches (tuple of the file path and commit msg)
+        :return: [PatchMetadata, ...] list of patches
         """
         upstream = upstream or self.get_specfile_version()
         destination = destination or self.local_project.working_dir

--- a/tests/data/sourcegit/source_git/fedora/beer.spec
+++ b/tests/data/sourcegit/source_git/fedora/beer.spec
@@ -15,7 +15,7 @@ BuildArch:      noarch
 ...but not too happy.
 
 %prep
-%autosetup -n %{upstream_name}-%{version}
+%autosetup -n %{upstream_name}-%{version} -S patch
 
 %changelog
 * Mon Feb 25 2019 Tomas Tomecek <ttomecek@redhat.com> - 0.1.0-1

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,7 +24,7 @@ import datetime
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, Optional
 
 import pytest
 from flexmock import flexmock
@@ -93,15 +93,23 @@ def mock_remote_functionality_sourcegit(sourcegit_and_remote, distgit_and_remote
     return mock_remote_functionality(upstream=sourcegit, distgit=distgit)
 
 
-def mock_spec_download_remote_s(path: Path):
+def mock_spec_download_remote_s(
+    repo_path: Path, spec_dir_path: Optional[Path] = None, archive_ref: str = "HEAD"
+):
+    spec_dir_path = spec_dir_path or repo_path
+
     def mock_download_remote_sources():
         """ mock download of the remote archive and place it into dist-git repo """
-        beerware_dir = path / NAME_VERSION
-        beerware_dir.mkdir(exist_ok=True)
-        beerware_dir.joinpath("hops").write_text("Cascade\n")
-        subprocess.check_call(
-            ["tar", "-cf", str(path / TARBALL_NAME), NAME_VERSION], cwd=path
-        )
+        archive_cmd = [
+            "git",
+            "archive",
+            "--output",
+            str(spec_dir_path / TARBALL_NAME),
+            "--prefix",
+            f"{NAME_VERSION}/",
+            archive_ref,
+        ]
+        subprocess.check_call(archive_cmd, cwd=repo_path)
 
     flexmock(Specfile, download_remote_sources=mock_download_remote_sources)
 

--- a/tests/spellbook.py
+++ b/tests/spellbook.py
@@ -29,6 +29,7 @@ import subprocess
 from pathlib import Path
 
 from click.testing import CliRunner
+from packit.patches import PatchMetadata
 
 from packit.cli.packit_base import packit_base
 from packit.config import Config
@@ -185,6 +186,42 @@ def create_merge_commit_in_source_git(sg: Path, go_nuts=False):
         # o─┴─│─┘ sourcegit content
         # o ┌─┘ <0.1.0> commit with data
         # o─┘ empty commit #2
+
+
+def create_git_am_style_history(sg: Path):
+    """
+    create merge commit in the provided source-git repo
+
+    :param sg: the repo
+    """
+    hops = sg.joinpath("hops")
+    hops.write_text("Amarillo\n")
+    git_add_and_commit(directory=sg, message="switching to amarillo hops")
+
+    hops.write_text("Citra\n")
+    meta = PatchMetadata(
+        name="citra.patch", squash_commits=True, present_in_specfile=True
+    )
+    git_add_and_commit(directory=sg, message=meta.commit_message)
+
+    malt = sg.joinpath("malt")
+    malt.write_text("Munich\n")
+    meta = PatchMetadata(
+        name="malt.patch", squash_commits=True, present_in_specfile=True
+    )
+    git_add_and_commit(directory=sg, message=meta.commit_message)
+
+    malt.write_text("Pilsen\n")
+    git_add_and_commit(directory=sg, message="using Pilsen malt")
+
+    malt.write_text("Vienna\n")
+    git_add_and_commit(directory=sg, message="actually Vienna malt could be good")
+
+    malt.write_text("Weyermann\n")
+    meta = PatchMetadata(
+        name="0001-m04r-malt.patch", squash_commits=True, present_in_specfile=True
+    )
+    git_add_and_commit(directory=sg, message=meta.commit_message)
 
 
 def prepare_dist_git_repo(directory, push=True):


### PR DESCRIPTION
```
In the patch e-mail workflow, one can send a patch with multiple
commits, e.g. pacemaker is using this. These are then applied with
git-am. Packit did not understand this since only the HEAD commit of
such a contribution has patch metadata, the rest is `not
patch.present_in_specfile`.

With this change, we detect such situation and behave accordingly.

Example:

* c1 [HEAD] - some.patch, squash_commits: true
* c2 - [no metadata]
* c3 - [no metadata]
* c4 - beer.patch, squash_commits: true
* c5 - other3.patch, squash_commits: true
* c6 - [no metadata]

This should produce 3 patch files:

* some.patch, commits: [c1, c2, c3]
* beer.patch, commits: [c4, c5]
* hops.patch, commits: [c6]
```

TODO:
* [x] test case

Needed for https://github.com/packit/dist-git-to-source-git/pull/29
