### PR TITLE
Make LocalProject.working_dir Path instead of str

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -30,7 +30,7 @@ import shutil
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Sequence, Callable, List, Tuple, Dict, Iterable, Optional
+from typing import Sequence, Callable, List, Tuple, Dict, Iterable, Optional, Union
 
 from ogr.abstract import PullRequest
 from pkg_resources import get_distribution, DistributionNotFound
@@ -415,9 +415,7 @@ class PackitAPI:
         self.init_kerberos_ticket()
 
         if from_upstream:
-            srpm_path = self.create_srpm(
-                srpm_dir=str(self.up.local_project.working_dir)
-            )
+            srpm_path = self.create_srpm(srpm_dir=self.up.local_project.working_dir)
             return self.up.koji_build(
                 scratch=scratch,
                 nowait=nowait,
@@ -463,7 +461,10 @@ class PackitAPI:
         )
 
     def create_srpm(
-        self, output_file: str = None, upstream_ref: str = None, srpm_dir: str = None
+        self,
+        output_file: str = None,
+        upstream_ref: str = None,
+        srpm_dir: Union[Path, str] = None,
     ) -> Path:
         """
         Create srpm from the upstream repo
@@ -702,7 +703,7 @@ class PackitAPI:
         :return: id of the created build and url to the build web page
         """
         srpm_path = self.create_srpm(
-            upstream_ref=upstream_ref, srpm_dir=str(self.up.local_project.working_dir)
+            upstream_ref=upstream_ref, srpm_dir=self.up.local_project.working_dir
         )
 
         owner = owner or self.copr_helper.configured_owner

--- a/packit/api.py
+++ b/packit/api.py
@@ -26,17 +26,16 @@ This is the official python interface for packit.
 
 import asyncio
 import logging
-import os
 import shutil
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Sequence, Callable, List, Tuple, Dict, Iterable, Optional
 
+from ogr.abstract import PullRequest
 from pkg_resources import get_distribution, DistributionNotFound
 from tabulate import tabulate
 
-from ogr.abstract import PullRequest
 from packit.actions import ActionName
 from packit.config import Config
 from packit.config.common_package_config import CommonPackageConfig
@@ -210,10 +209,11 @@ class PackitAPI:
                 f"Upstream commit: {self.up.local_project.commit_hexsha}\n"
             )
 
-            path = os.path.join(self.dg.local_project.working_dir, "README.packit")
-            logger.debug(f"Path of README: {path}")
-            with open(path, "w") as f:
-                f.write(SYNCING_NOTE.format(packit_version=get_packit_version()))
+            readme_path = self.dg.local_project.working_dir / "README.packit"
+            logger.debug(f"README: {readme_path}")
+            readme_path.write_text(
+                SYNCING_NOTE.format(packit_version=get_packit_version())
+            )
 
             files_to_sync = self.package_config.get_all_files_to_sync()
 
@@ -235,8 +235,8 @@ class PackitAPI:
                     )
 
                 raw_sync_files = files_to_sync.get_raw_files_to_sync(
-                    Path(self.up.local_project.working_dir),
-                    Path(self.dg.local_project.working_dir),
+                    self.up.local_project.working_dir,
+                    self.dg.local_project.working_dir,
                 )
 
                 # exclude spec, we have special plans for it
@@ -260,8 +260,8 @@ class PackitAPI:
             # when the action is defined, we still need to copy the files
             if self.up.has_action(action=ActionName.prepare_files):
                 raw_sync_files = files_to_sync.get_raw_files_to_sync(
-                    Path(self.up.local_project.working_dir),
-                    Path(self.dg.local_project.working_dir),
+                    self.up.local_project.working_dir,
+                    self.dg.local_project.working_dir,
                 )
                 sync_files(raw_sync_files)
 
@@ -328,8 +328,8 @@ class PackitAPI:
             self.up.checkout_branch(local_pr_branch)
 
         raw_sync_files = self.package_config.synced_files.get_raw_files_to_sync(
-            dest_dir=Path(self.dg.local_project.working_dir),
-            src_dir=Path(self.up.local_project.working_dir),
+            dest_dir=self.dg.local_project.working_dir,
+            src_dir=self.up.local_project.working_dir,
         )
 
         reverse_raw_sync_files = [
@@ -386,7 +386,7 @@ class PackitAPI:
         ):
             make_new_sources = True
         else:
-            sources_file = Path(self.dg.local_project.working_dir) / "sources"
+            sources_file = self.dg.local_project.working_dir / "sources"
             if self.dg.upstream_archive_name not in sources_file.read_text():
                 make_new_sources = True
         if make_new_sources:
@@ -415,7 +415,9 @@ class PackitAPI:
         self.init_kerberos_ticket()
 
         if from_upstream:
-            srpm_path = self.create_srpm(srpm_dir=self.up.local_project.working_dir)
+            srpm_path = self.create_srpm(
+                srpm_dir=str(self.up.local_project.working_dir)
+            )
             return self.up.koji_build(
                 scratch=scratch,
                 nowait=nowait,
@@ -700,7 +702,7 @@ class PackitAPI:
         :return: id of the created build and url to the build web page
         """
         srpm_path = self.create_srpm(
-            upstream_ref=upstream_ref, srpm_dir=self.up.local_project.working_dir
+            upstream_ref=upstream_ref, srpm_dir=str(self.up.local_project.working_dir)
         )
 
         owner = owner or self.copr_helper.configured_owner

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -82,13 +82,13 @@ class PackitRepositoryBase:
     @property
     def absolute_specfile_dir(self) -> Path:
         """ get dir where the spec file is"""
-        return Path(self.absolute_specfile_path).parent
+        return self.absolute_specfile_path.parent
 
     @property
     def absolute_specfile_path(self) -> Path:
         if not self._specfile_path:
-            self._specfile_path = Path(self.local_project.working_dir).joinpath(
-                self.package_config.specfile_path
+            self._specfile_path = (
+                self.local_project.working_dir / self.package_config.specfile_path
             )
             if not self._specfile_path.exists():
                 raise FileNotFoundError(f"Specfile {self._specfile_path} not found.")

--- a/packit/cli/init.py
+++ b/packit/cli/init.py
@@ -51,7 +51,7 @@ def init(path_or_url, force):
     Generate new packit config.
     """
 
-    working_dir = Path(path_or_url.working_dir)
+    working_dir = path_or_url.working_dir
     config_path = get_existing_config(working_dir)
     if config_path:
         if not force:

--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -23,6 +23,7 @@
 import functools
 import logging
 import sys
+from pathlib import Path
 from typing import List, Optional
 
 import click
@@ -117,7 +118,7 @@ def get_packit_api(
     if dist_git_path:
         package_config.dist_git_clone_path = dist_git_path
 
-    if dist_git_path and dist_git_path == local_project.working_dir:
+    if dist_git_path and Path(dist_git_path) == local_project.working_dir:
         PackitAPI(
             config=config,
             package_config=package_config,

--- a/packit/cli/validate_config.py
+++ b/packit/cli/validate_config.py
@@ -26,15 +26,14 @@ Validate PackageConfig
 
 import logging
 import os
-from pathlib import Path
 
 import click
-from packit.local_project import LocalProject
 
 from packit.api import PackitAPI
 from packit.cli.types import LocalProjectParameter
 from packit.cli.utils import cover_packit_exception
 from packit.config import get_context_settings
+from packit.local_project import LocalProject
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +52,6 @@ def validate_config(path_or_url: LocalProject):
     PATH_OR_URL argument is a local path or a URL to a git repository with packit configuration file
     """
     # we use PackageConfig.load_from_dict for the validation, hence we don't parse it here
-    output = PackitAPI.validate_package_config(Path(path_or_url.working_dir))
+    output = PackitAPI.validate_package_config(path_or_url.working_dir)
     logger.info(output)
     # TODO: print more if config.debug

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -278,8 +278,7 @@ class DistGit(PackitRepositoryBase):
         # TODO: can we check if the tarball is already uploaded so we don't have ot re-upload?
         logger.info("About to upload to lookaside cache.")
         f = FedPKG(
-            fas_username=self.config.fas_user,
-            directory=str(self.local_project.working_dir),
+            fas_username=self.config.fas_user, directory=self.local_project.working_dir,
         )
         try:
             f.new_sources(sources=archive_path)
@@ -326,7 +325,7 @@ class DistGit(PackitRepositoryBase):
         :param koji_target: koji target to pick (see `koji list-targets`)
         """
         fpkg = FedPKG(
-            fas_username=self.fas_user, directory=str(self.local_project.working_dir)
+            fas_username=self.fas_user, directory=self.local_project.working_dir
         )
         fpkg.build(scratch=scratch, nowait=nowait, koji_target=koji_target)
 

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -140,7 +140,7 @@ class DistGit(PackitRepositoryBase):
     def get_absolute_specfile_path(self) -> Path:
         """ provide the path, don't check it """
         return (
-            Path(self.local_project.working_dir)
+            self.local_project.working_dir
             / f"{self.package_config.downstream_package_name}.spec"
         )
 
@@ -278,7 +278,8 @@ class DistGit(PackitRepositoryBase):
         # TODO: can we check if the tarball is already uploaded so we don't have ot re-upload?
         logger.info("About to upload to lookaside cache.")
         f = FedPKG(
-            fas_username=self.config.fas_user, directory=self.local_project.working_dir
+            fas_username=self.config.fas_user,
+            directory=str(self.local_project.working_dir),
         )
         try:
             f.new_sources(sources=archive_path)
@@ -325,7 +326,7 @@ class DistGit(PackitRepositoryBase):
         :param koji_target: koji target to pick (see `koji list-targets`)
         """
         fpkg = FedPKG(
-            fas_username=self.fas_user, directory=self.local_project.working_dir
+            fas_username=self.fas_user, directory=str(self.local_project.working_dir)
         )
         fpkg.build(scratch=scratch, nowait=nowait, koji_target=koji_target)
 

--- a/packit/fedpkg.py
+++ b/packit/fedpkg.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 from packit.exceptions import PackitCommandFailedError
 
@@ -37,10 +37,13 @@ class FedPKG:
     """
 
     def __init__(
-        self, fas_username: str = None, directory: str = None, stage: bool = False
+        self,
+        fas_username: str = None,
+        directory: Union[Path, str] = None,
+        stage: bool = False,
     ):
         self.fas_username = fas_username
-        self.directory = directory
+        self.directory = Path(directory) if directory else None
         self.stage = stage
         self.fedpkg_exec = "fedpkg-stage" if stage else "fedpkg"
 
@@ -53,7 +56,7 @@ class FedPKG:
         )
 
     def new_sources(self, sources="", fail=True):
-        if not Path(self.directory).is_dir():
+        if not self.directory.is_dir():
             raise Exception("Cannot access fedpkg repository:")
 
         return commands.run_command_remote(

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -23,13 +23,14 @@
 import logging
 import shutil
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Optional, Union, Iterable
 
 import git
-
 from ogr.abstract import GitProject, GitService
 from ogr import GitlabService
 from ogr.parsing import parse_git_repo
+
 from packit.exceptions import PackitException
 from packit.utils.repo import is_git_repo, get_repo, is_a_git_ref
 
@@ -59,7 +60,7 @@ class LocalProject:
     def __init__(
         self,
         git_repo: git.Repo = None,
-        working_dir: str = "",
+        working_dir: Union[Path, str] = None,
         ref: str = "",
         git_project: GitProject = None,
         git_service: GitService = None,
@@ -75,7 +76,7 @@ class LocalProject:
         """
 
         :param git_repo: git.Repo
-        :param working_dir: str (working directory for the project)
+        :param working_dir: Path|str (working directory for the project)
         :param ref: str (git ref (branch/tag/commit) if set, then checked out)
         :param git_project: ogr.GitProject (remote API for project)
         :param git_service: ogr.GitService (tokens for remote API)
@@ -90,7 +91,7 @@ class LocalProject:
         """
         self.working_dir_temporary = False
         self.git_repo: git.Repo = git_repo
-        self.working_dir: str = working_dir
+        self.working_dir: Path = Path(working_dir) if working_dir else None
         self._ref = ref
         self.git_project = git_project
         self.git_service = git_service
@@ -290,7 +291,7 @@ class LocalProject:
 
     def _parse_working_dir_from_git_repo(self):
         if self.git_repo and not self.working_dir:
-            self.working_dir = self.git_repo.working_dir
+            self.working_dir = Path(self.git_repo.working_dir)
             logger.debug(
                 f"Parsed working directory {self.working_dir} from the repo {self.git_repo}."
             )

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -565,7 +565,9 @@ class Upstream(PackitRepositoryBase):
                 f"via {self.package_config.spec_source_id} nor Source."
             )
 
-    def create_srpm(self, srpm_path: str = None, srpm_dir: str = None) -> Path:
+    def create_srpm(
+        self, srpm_path: Union[Path, str] = None, srpm_dir: Union[Path, str] = None
+    ) -> Path:
         """
         Create SRPM from the actual content of the repo
 
@@ -575,13 +577,13 @@ class Upstream(PackitRepositoryBase):
         """
 
         if self.running_in_service():
-            srpm_dir = "."
-            rpmbuild_dir = os.path.relpath(
-                str(self.absolute_specfile_dir), str(self.local_project.working_dir)
+            srpm_dir = Path(".")
+            rpmbuild_dir = self.absolute_specfile_dir.relative_to(
+                self.local_project.working_dir
             )
         else:
-            srpm_dir = srpm_dir or os.getcwd()
-            rpmbuild_dir = str(self.absolute_specfile_dir)
+            srpm_dir = Path(srpm_dir) if srpm_dir else Path.cwd()
+            rpmbuild_dir = self.absolute_specfile_dir
 
         cmd = [
             "rpmbuild",
@@ -607,7 +609,7 @@ class Upstream(PackitRepositoryBase):
         ]
         escaped_command = " ".join(cmd)
         logger.debug(f"SRPM build command: {escaped_command}")
-        present_srpms = set(Path(srpm_dir).glob("*.src.rpm"))
+        present_srpms = set(srpm_dir.glob("*.src.rpm"))
         logger.debug(f"Present SRPMs: {present_srpms}")
         try:
             out = self.command_handler.run_command(cmd, return_output=True).strip()
@@ -634,7 +636,7 @@ class Upstream(PackitRepositoryBase):
             shutil.move(the_srpm, srpm_path)
             return Path(srpm_path)
         if self.running_in_service():
-            return Path(self.local_project.working_dir).joinpath(the_srpm)
+            return self.local_project.working_dir / the_srpm
         return Path(the_srpm)
 
     def _get_srpm_from_rpmbuild_output(self, output: str) -> str:

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -213,7 +213,7 @@ class Upstream(PackitRepositoryBase):
         sync_files_to_ignore = [
             str(sf.src.relative_to(self.local_project.working_dir))
             for sf in self.package_config.get_all_files_to_sync().get_raw_files_to_sync(
-                Path(self.local_project.working_dir),
+                self.local_project.working_dir,
                 Path(
                     # dest (downstream) is not important, we only care about src (upstream)
                     destination
@@ -280,7 +280,7 @@ class Upstream(PackitRepositoryBase):
             f"We're about to `git-describe` the upstream repository "
             f"{self.local_project.working_dir}."
         )
-        logger.debug(f"Content: {os.listdir(self.local_project.working_dir)}")
+        logger.debug(f"Content: {os.listdir(str(self.local_project.working_dir))}")
 
         # let's inspect tags in the repo and log our findings
         cmd = ["git", "--no-pager", "tag", "--list"]
@@ -401,8 +401,8 @@ class Upstream(PackitRepositoryBase):
         for output in reversed(outputs):
             for archive_name in reversed(output.splitlines()):
                 try:
-                    archive_path = Path(
-                        self._local_project.working_dir, archive_name.strip()
+                    archive_path = (
+                        self._local_project.working_dir / archive_name.strip()
                     )
                     if archive_path.is_file():
                         archive_path_absolute = archive_path.absolute()
@@ -577,7 +577,7 @@ class Upstream(PackitRepositoryBase):
         if self.running_in_service():
             srpm_dir = "."
             rpmbuild_dir = os.path.relpath(
-                str(self.absolute_specfile_dir), self.local_project.working_dir
+                str(self.absolute_specfile_dir), str(self.local_project.working_dir)
             )
         else:
             srpm_dir = srpm_dir or os.getcwd()

--- a/packit/utils/repo.py
+++ b/packit/utils/repo.py
@@ -4,38 +4,36 @@
 import logging
 import tempfile
 from pathlib import Path
-from typing import Tuple, Optional
+from typing import Tuple, Optional, Union
 
 import git
-
 from ogr.parsing import parse_git_repo
+
 from packit.exceptions import PackitException
 
 logger = logging.getLogger(__name__)
 
 
-def is_git_repo(directory: str) -> bool:
+def is_git_repo(directory: Union[Path, str]) -> bool:
     """
     Test, if the directory is a git repo.
     (Has .git subdirectory?)
     """
-    return Path(directory).joinpath(".git").is_dir()
+    return Path(directory, ".git").is_dir()
 
 
-def get_repo(url: str, directory: str = None) -> git.Repo:
+def get_repo(url: str, directory: Union[Path, str] = None) -> git.Repo:
     """
     Use directory as a git repo or clone repo to the tempdir.
     """
-    if not directory:
-        tempdir = tempfile.mkdtemp()
-        directory = tempdir
+    directory = str(directory) if directory else tempfile.mkdtemp()
 
-    # TODO: optimize cloning: single branch and last n commits?
     if is_git_repo(directory=directory):
         logger.debug(f"Repo already exists in {directory}.")
         repo = git.repo.Repo(directory)
     else:
         logger.debug(f"Cloning repo {url} -> {directory}")
+        # TODO: optimize cloning: single branch and last n commits?
         repo = git.repo.Repo.clone_from(url=url, to_path=directory, tags=True)
 
     return repo

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -64,7 +64,7 @@ def mock_downstream_remote_functionality(downstream_n_distgit):
     u, d = downstream_n_distgit
 
     dglp = LocalProject(
-        working_dir=str(d),
+        working_dir=d,
         git_url="https://packit.dev/rpms/beer",
         git_service=PagureService(),
     )
@@ -151,7 +151,7 @@ def mock_remote_functionality(distgit: Path, upstream: Path):
     flexmock(PagureUser, get_username=lambda: "packito")
 
     dglp = LocalProject(
-        working_dir=str(distgit),
+        working_dir=distgit,
         git_url="https://packit.dev/rpms/beer",
         git_service=PagureService(),
     )
@@ -232,7 +232,7 @@ def upstream_instance(upstream_and_remote, distgit_and_remote, tmp_path):
         pc = get_local_package_config(str(u))
         pc.upstream_project_url = str(u)
         pc.dist_git_clone_path = str(d)
-        lp = LocalProject(working_dir=str(u))
+        lp = LocalProject(working_dir=u)
 
         ups = Upstream(c, pc, lp)
         yield u, ups
@@ -267,9 +267,7 @@ def api_instance(upstream_and_remote, distgit_and_remote):
     d, _ = distgit_and_remote
 
     c = get_test_config()
-    api = get_packit_api(
-        config=c, local_project=LocalProject(working_dir=str(Path.cwd()))
-    )
+    api = get_packit_api(config=c, local_project=LocalProject(working_dir=Path.cwd()))
     return u, d, api
 
 
@@ -282,7 +280,7 @@ def api_instance_source_git(sourcegit_and_remote, distgit_and_remote):
         pc = get_local_package_config(str(sourcegit))
         pc.upstream_project_url = str(sourcegit)
         pc.dist_git_clone_path = str(distgit)
-        up_lp = LocalProject(working_dir=str(sourcegit))
+        up_lp = LocalProject(working_dir=sourcegit)
         api = PackitAPI(c, pc, up_lp)
         return api
 

--- a/tests/integration/test_base_git.py
+++ b/tests/integration/test_base_git.py
@@ -66,7 +66,7 @@ def test_get_output_from_action_defined_in_sandcastle():
     packit_repository_base = PackitRepositoryBase(
         config=c, package_config=PackageConfig(actions={ActionName.pre_sync: echo_cmd})
     )
-    packit_repository_base.local_project = LocalProject()
+    packit_repository_base.local_project = LocalProject(working_dir="/tmp")
 
     flexmock(Sandcastle).should_receive("run")
     flexmock(Sandcastle).should_receive("exec").and_return(echo_cmd)
@@ -95,7 +95,7 @@ def test_base_push_bad(distgit_and_remote):
 
     b = PackitRepositoryBase(config=Config(), package_config=PackageConfig())
     b.local_project = LocalProject(
-        working_dir=str(distgit), git_url="https://github.com/packit/lol"
+        working_dir=distgit, git_url="https://github.com/packit/lol"
     )
     flexmock(
         LocalProject,
@@ -113,7 +113,7 @@ def test_base_push_good(distgit_and_remote):
 
     b = PackitRepositoryBase(config=Config(), package_config=PackageConfig())
     b.local_project = LocalProject(
-        working_dir=str(distgit), git_url="https://github.com/packit/lol"
+        working_dir=distgit, git_url="https://github.com/packit/lol"
     )
     flexmock(
         LocalProject,

--- a/tests/integration/test_build.py
+++ b/tests/integration/test_build.py
@@ -35,7 +35,7 @@ def test_basic_build(
     flexmock(api).should_receive("init_kerberos_ticket").at_least().once()
     flexmock(commands).should_receive("run_command_remote").with_args(
         cmd=["fedpkg", "build", "--scratch", "--nowait", "--target", "asdqwe"],
-        cwd=str(api.dg.local_project.working_dir),
+        cwd=api.dg.local_project.working_dir,
         error_message="Submission of build to koji failed.",
         fail=True,
     ).once()

--- a/tests/integration/test_build.py
+++ b/tests/integration/test_build.py
@@ -35,7 +35,7 @@ def test_basic_build(
     flexmock(api).should_receive("init_kerberos_ticket").at_least().once()
     flexmock(commands).should_receive("run_command_remote").with_args(
         cmd=["fedpkg", "build", "--scratch", "--nowait", "--target", "asdqwe"],
-        cwd=api.dg.local_project.working_dir,
+        cwd=str(api.dg.local_project.working_dir),
         error_message="Submission of build to koji failed.",
         fail=True,
     ).once()

--- a/tests/integration/test_get_api.py
+++ b/tests/integration/test_get_api.py
@@ -35,23 +35,19 @@ from tests.spellbook import get_test_config, initiate_git_repo
 def test_is_upstream(upstream_and_remote):
     upstream, _ = upstream_and_remote
     c = get_test_config()
-    api = get_packit_api(
-        config=c, local_project=LocalProject(working_dir=str(upstream))
-    )
+    api = get_packit_api(config=c, local_project=LocalProject(working_dir=upstream))
     assert api.upstream_local_project
     assert not api.downstream_local_project
-    assert api.upstream_local_project.working_dir == str(upstream)
+    assert api.upstream_local_project.working_dir == upstream
 
 
 def test_is_downstream(distgit_and_remote):
     downstream, _ = distgit_and_remote
     c = get_test_config()
-    api = get_packit_api(
-        config=c, local_project=LocalProject(working_dir=str(downstream))
-    )
+    api = get_packit_api(config=c, local_project=LocalProject(working_dir=downstream))
     assert api.downstream_local_project
     assert not api.upstream_local_project
-    assert api.downstream_local_project.working_dir == str(downstream)
+    assert api.downstream_local_project.working_dir == downstream
 
 
 def test_url_is_downstream():

--- a/tests/integration/test_local_project.py
+++ b/tests/integration/test_local_project.py
@@ -32,7 +32,7 @@ def test_pr_id_and_ref(tmp_path: Path):
     subprocess.check_call(["git", "branch", "-D", local_tmp_branch], cwd=upstream_git)
 
     LocalProject(
-        working_dir=str(upstream_git),
+        working_dir=upstream_git,
         offline=True,
         pr_id=pr_id,
         ref=ref,
@@ -78,7 +78,7 @@ def test_pr_id_and_ref_gitlab(tmp_path: Path):
     subprocess.check_call(["git", "branch", "-D", local_tmp_branch], cwd=upstream_git)
 
     LocalProject(
-        working_dir=str(upstream_git),
+        working_dir=upstream_git,
         offline=True,
         pr_id=pr_id,
         ref=ref,

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -157,7 +157,7 @@ def test_basic_local_update_from_downstream(
 
     api.sync_from_downstream("master", "master", True)
 
-    new_upstream = Path(api.up.local_project.working_dir)
+    new_upstream = api.up.local_project.working_dir
     assert (new_upstream / "beer.spec").is_file()
     spec = Specfile(new_upstream / "beer.spec")
     assert spec.get_version() == "0.0.0"

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -121,7 +121,7 @@ def test_set_spec_ver_empty_changelog(tmp_path):
 
         pc = get_local_package_config(str(u))
         pc.upstream_project_url = str(u)
-        lp = LocalProject(working_dir=str(u))
+        lp = LocalProject(working_dir=u)
 
         ups = Upstream(c, pc, lp)
 

--- a/tests/integration/test_using_cockpit.py
+++ b/tests/integration/test_using_cockpit.py
@@ -79,7 +79,7 @@ def test_update_on_cockpit_ostree(cockpit_ostree):
     )
 
     pc = get_local_package_config(str(upstream_path))
-    up_lp = LocalProject(working_dir=str(upstream_path))
+    up_lp = LocalProject(working_dir=upstream_path)
     c = get_test_config()
     api = PackitAPI(c, pc, up_lp)
     api._dg = DistGit(c, pc)
@@ -99,7 +99,7 @@ def test_srpm_on_cockpit_ostree(cockpit_ostree):
     upstream_path, dist_git_path = cockpit_ostree
 
     pc = get_local_package_config(str(upstream_path))
-    up_lp = LocalProject(working_dir=str(upstream_path))
+    up_lp = LocalProject(working_dir=upstream_path)
     c = get_test_config()
     api = PackitAPI(c, pc, up_lp)
 

--- a/tests/integration/test_using_examples.py
+++ b/tests/integration/test_using_examples.py
@@ -59,9 +59,7 @@ def example_repo(request, tmp_path):
 
 def test_srpm_on_example(example_repo):
     c = get_test_config()
-    api = get_packit_api(
-        config=c, local_project=LocalProject(working_dir=str(example_repo))
-    )
+    api = get_packit_api(config=c, local_project=LocalProject(working_dir=example_repo))
     with cwd(example_repo):
         path = api.create_srpm()
     assert path.exists()

--- a/tests/unit/test_upstream.py
+++ b/tests/unit/test_upstream.py
@@ -52,7 +52,7 @@ def upstream_mock(local_project_mock, package_config_mock):
     upstream = Upstream(
         config=get_test_config(),
         package_config=package_config_mock,
-        local_project=LocalProject(working_dir=str("test")),
+        local_project=LocalProject(working_dir="test"),
     )
     flexmock(upstream)
     upstream.should_receive("local_project").and_return(local_project_mock)
@@ -61,8 +61,7 @@ def upstream_mock(local_project_mock, package_config_mock):
 
 @pytest.fixture
 def upstream_pr_mock():
-    mock = flexmock(url="test_pr_url")
-    return mock
+    return flexmock(url="test_pr_url")
 
 
 @pytest.mark.parametrize(

--- a/tests_recording/test_api.py
+++ b/tests_recording/test_api.py
@@ -20,16 +20,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import os
 import unittest
 from subprocess import check_output
 
 import rebasehelper
-from rebasehelper.exceptions import RebaseHelperError
-
 from flexmock import flexmock
-from packit.api import PackitAPI
+from rebasehelper.exceptions import RebaseHelperError
 from requre.cassette import DataTypes
+
+from packit.api import PackitAPI
 from tests_recording.testbase import PackitUnittestOgr
 
 
@@ -55,9 +54,8 @@ class ProposeUpdate(PackitUnittestOgr):
 
     def check_version_increase(self):
         # change specfile little bit to have there some change
-        specfile_location = os.path.join(self.lp.working_dir, "python-ogr.spec")
-        with open(specfile_location, "r") as myfile:
-            filedata = myfile.read()
+        specfile_location = self.lp.working_dir / "python-ogr.spec"
+        filedata = specfile_location.read_text()
         # Patch the specfile with new version
         version_increase = "0.0.0"
         for line in filedata.splitlines():
@@ -67,8 +65,7 @@ class ProposeUpdate(PackitUnittestOgr):
                 version_increase = ".".join([v1, str(int(v2) + 1), v3])
                 filedata = filedata.replace(version, version_increase)
                 break
-        with open(specfile_location, "w") as myfile:
-            myfile.write(filedata)
+        specfile_location.write_text(filedata)
         check_output(
             f"cd {self.lp.working_dir};"
             f"git commit -m 'test change' python-ogr.spec;"
@@ -81,10 +78,10 @@ class ProposeUpdate(PackitUnittestOgr):
         """
         change specfile little bit to have there some change, do not increase version
         """
-        specfile_location = os.path.join(self.lp.working_dir, "python-ogr.spec")
-        version_increase = "10.0.0"
-        with open(specfile_location, "a") as myfile:
+        specfile_location = self.lp.working_dir / "python-ogr.spec"
+        with specfile_location.open("a") as myfile:
             myfile.write("\n# comment\n")
+        version_increase = "10.0.0"
         check_output(
             f"cd {self.lp.working_dir};"
             f"git commit -m 'test change' python-ogr.spec;"

--- a/tests_recording/testbase.py
+++ b/tests_recording/testbase.py
@@ -20,12 +20,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import os
+
 import shutil
+from os import makedirs
 from subprocess import check_output, CalledProcessError
 
-from requre.helpers.tempfile import TempFile
 from requre.base_testclass import RequreTestCase
+from requre.helpers.tempfile import TempFile
 
 import packit.distgit
 import packit.upstream
@@ -34,9 +35,6 @@ from packit.exceptions import PackitException
 from packit.local_project import LocalProject
 
 DATA_DIR = "test_data"
-PERSISTENT_DATA_PREFIX = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)), DATA_DIR
-)
 
 
 class PackitUnittestOgr(RequreTestCase):
@@ -49,7 +47,8 @@ class PackitUnittestOgr(RequreTestCase):
         conf.dry_run = True
         return conf
 
-    def set_git_user(self):
+    @staticmethod
+    def set_git_user():
         try:
             check_output(["git", "config", "--global", "-l"])
         except CalledProcessError:
@@ -62,7 +61,7 @@ class PackitUnittestOgr(RequreTestCase):
         super().setUp()
         self.conf = self.get_test_config()
         self.static_tmp = "/tmp/packit_tmp"
-        os.makedirs(self.static_tmp, exist_ok=True)
+        makedirs(self.static_tmp, exist_ok=True)
         TempFile.root = self.static_tmp
         self.project_ogr = self.conf.get_project(url="https://github.com/packit/ogr")
 


### PR DESCRIPTION
This is related to already closed #733 

It's far from fixing #733 but this `LocalProject.working_dir` is used a lot so it's a huge part.
And I don't want any big rebases on any side.

I'd suggest reviewing both commits together since the second one reverts some changes done in the first.