### PR TITLE
Allow ignoring updates for Copr boolean values

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -719,6 +719,7 @@ class PackitAPI:
             preserve_project=preserve_project,
             additional_packages=additional_packages,
             additional_repos=additional_repos,
+            request_admin_if_needed=request_admin_if_needed,
         )
         logger.debug(
             f"Submitting a build to copr build system,"

--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -78,8 +78,8 @@ class CoprHelper:
         owner: str = None,
         description: str = None,
         instructions: str = None,
-        list_on_homepage: bool = False,
-        preserve_project: bool = False,
+        list_on_homepage: Optional[bool] = False,
+        preserve_project: Optional[bool] = False,
         additional_packages: List[str] = None,
         additional_repos: List[str] = None,
         request_admin_if_needed: bool = False,
@@ -113,7 +113,9 @@ class CoprHelper:
             )
             return
 
-        delete_after_days = -1 if preserve_project else 60
+        delete_after_days: Optional[
+            int
+        ] = None if preserve_project is None else -1 if preserve_project else 60
 
         fields_to_change = self.get_fields_to_change(
             copr_proj=copr_proj,
@@ -194,18 +196,20 @@ class CoprHelper:
                     copr_proj.instructions,
                     instructions,
                 )
-        if "unlisted_on_hp" not in copr_proj:
-            logger.debug(
-                "The `unlisted_on_hp` key was not received from Copr. "
-                "We can't check that value to see if the update is needed."
-            )
-        elif copr_proj.unlisted_on_hp != (not list_on_homepage):
-            fields_to_change["unlisted_on_hp"] = (
-                copr_proj.unlisted_on_hp,
-                (not list_on_homepage),
-            )
 
-        if delete_after_days:
+        if list_on_homepage is not None:
+            if "unlisted_on_hp" not in copr_proj:
+                logger.debug(
+                    "The `unlisted_on_hp` key was not received from Copr. "
+                    "We can't check that value to see if the update is needed."
+                )
+            elif copr_proj.unlisted_on_hp != (not list_on_homepage):
+                fields_to_change["unlisted_on_hp"] = (
+                    copr_proj.unlisted_on_hp,
+                    (not list_on_homepage),
+                )
+
+        if delete_after_days is not None:
             if "delete_after_days" not in copr_proj:
                 logger.debug(
                     "The `delete_after_days` key was not received from Copr. "

--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -71,6 +71,13 @@ class CoprHelper:
         copr_url = self.copr_client.config.get("copr_url")
         return f"{copr_url}/coprs/build/{build.id}/"
 
+    def get_copr_settings_url(
+        self, owner: str, project: str, section: Optional[str] = None
+    ):
+        copr_url = self.copr_client.config.get("copr_url")
+        section = section or "edit"
+        return f"{copr_url}/coprs/{owner}/{project}/{section}/"
+
     def create_copr_project_if_not_exists(
         self,
         project: str,

--- a/tests/integration/test_copr_build.py
+++ b/tests/integration/test_copr_build.py
@@ -354,6 +354,60 @@ def test_copr_build_existing_project_munch_list_on_homepage_change(
     assert url == f"https://copr.fedorainfracloud.org/coprs/build/{build.id}/"
 
 
+def test_copr_build_existing_project_munch_do_not_update_booleans_by_default(
+    cwd_upstream_or_distgit, api_instance
+):
+    u, d, api = api_instance
+    owner = "the-owner"
+    project = "project-name"
+    chroots = ["fedora-rawhide-x86_64"]
+
+    flexmock(ProjectProxy).should_receive("get").and_return(
+        munchify(
+            {
+                "additional_repos": [],
+                "auto_prune": True,
+                "chroot_repos": {
+                    "fedora-rawhide-x86_64": "https://download.copr.fedorainfracloud.org/"
+                    "results/packit/packit-hello-world-127-stg/fedora-rawhide-x86_64/",
+                },
+                "contact": "https://github.com/packit-service/packit/issues",
+                "description": "Continuous builds initiated by packit service.\n"
+                "For more info check out https://packit.dev/",
+                "unlisted_on_hp": True,  # Value not present currently.
+                "devel_mode": False,
+                "enable_net": True,
+                "full_name": "packit/packit-hello-world-127-stg",
+                "homepage": "",
+                "id": 34245,
+            }
+        )
+    )
+
+    # Even if we receive this info from Copr, we can't edit that value if it is `None`.
+    flexmock(ProjectProxy).should_receive("edit").and_return().times(0)
+
+    flexmock(CoprHelper).should_receive("get_copr_client").and_return(
+        Client(config={"copr_url": "https://copr.fedorainfracloud.org"})
+    )
+
+    build = flexmock(id="1", ownername=owner, projectname=project,)
+    flexmock(BuildProxy).should_receive("create_from_file").and_return(build)
+    build_id, url = api.run_copr_build(
+        project=project,
+        chroots=chroots,
+        owner=owner,
+        description=None,
+        instructions=None,
+        list_on_homepage=None,
+        preserve_project=False,
+        additional_repos=None,
+    )
+
+    assert build_id == "1"
+    assert url == f"https://copr.fedorainfracloud.org/coprs/build/{build.id}/"
+
+
 def test_copr_build_existing_project_error_on_change_settings(
     cwd_upstream_or_distgit, api_instance
 ):


### PR DESCRIPTION
- Add method for getting Copr settings frontend URLs.
- Ignore boolean update of copr settings if the value is None.
- Together with https://github.com/packit/packit-service/pull/776 fixes https://github.com/packit/packit/issues/931