### PR TITLE
source-git: drop ensure_pnum

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -318,7 +318,6 @@ class PackitRepositoryBase:
 
         self.specfile.remove_applied_patches()
         self.specfile.add_patches(patch_list)
-        self.specfile.ensure_pnum()
 
         self.local_project.git_repo.index.write()
 

--- a/packit/specfile.py
+++ b/packit/specfile.py
@@ -160,7 +160,7 @@ class Specfile(SpecFile):
         if not patch_list:
             return
 
-        if all([p.present_in_specfile for p in patch_list]):
+        if all(p.present_in_specfile for p in patch_list):
             logger.debug(
                 "All patches are present in the spec file, nothing to do here 🚀"
             )

--- a/packit/specfile.py
+++ b/packit/specfile.py
@@ -213,35 +213,6 @@ class Specfile(SpecFile):
 
         logger.info(f"{len(patch_list)} patches added to {self.path!r}.")
 
-    @saves
-    def ensure_pnum(self, pnum: int = 1) -> None:
-        """
-        Make sure we use -p1 with %autosetup / %autopatch
-
-        :param pnum: use other prefix number than default 1
-        """
-        logger.debug(f"Making sure we apply patches with -p{pnum}.")
-        prep_lines = self.spec_content.section("%prep")
-
-        for i, line in enumerate(prep_lines):
-            if line.startswith(("%autosetup", "%autopatch")):
-                if re.search(r"\s-p\d", line):
-                    # -px is there, replace it with -p1
-                    prep_lines[i] = re.sub(r"-p\d", rf"-p{pnum}", line)
-                else:
-                    # -px is not there, add -p1
-                    prep_lines[i] = re.sub(
-                        r"(%auto(setup|patch))", rf"\1 -p{pnum}", line
-                    )
-            elif line.startswith("%setup"):
-                # %setup -> %autosetup -p1
-                prep_lines[i] = line.replace("%setup", f"%autosetup -p{pnum}")
-                # %autosetup does not accept -q, remove it
-                prep_lines[i] = re.sub(r"\s+-q", r"", prep_lines[i])
-
-            if prep_lines[i] != line:
-                logger.debug(f"{line!r} -> {prep_lines[i]!r}")
-
     def get_source(self, source_name: str) -> Optional[Tuple[int, str, str]]:
         """
         get specific Source from spec

--- a/tests/data/sourcegit/source_git/fedora/beer.spec
+++ b/tests/data/sourcegit/source_git/fedora/beer.spec
@@ -15,7 +15,7 @@ BuildArch:      noarch
 ...but not too happy.
 
 %prep
-%autosetup -n %{upstream_name}-%{version} -S patch
+%autosetup -p1 -n %{upstream_name}-%{version} -S patch
 
 %changelog
 * Mon Feb 25 2019 Tomas Tomecek <ttomecek@redhat.com> - 0.1.0-1

--- a/tests/integration/test_source_git.py
+++ b/tests/integration/test_source_git.py
@@ -134,13 +134,6 @@ def test_basic_local_update_patch_content(
     assert "Patch0004:" not in git_diff
 
     assert (
-        """ %prep
--%autosetup -n %{upstream_name}-%{version}
-+%autosetup -p1 -n %{upstream_name}-%{version}"""
-        in git_diff
-    )
-
-    assert (
         """ - 0.1.0-1
 +- new upstream release: 0.1.0
 +

--- a/tests/integration/test_spec.py
+++ b/tests/integration/test_spec.py
@@ -20,14 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from pathlib import Path
-from shutil import copy
-
-import pytest
 from rebasehelper.specfile import SpecContent
 
 from packit.specfile import Specfile
-from tests.spellbook import SPECFILE, UP_OSBUILD, UP_EDD, UP_VSFTPD
+from tests.spellbook import SPECFILE
 
 
 def test_write_spec_content():
@@ -43,20 +39,3 @@ def test_write_spec_content():
         assert "new line 1" in specfile.read()
         spec.spec_content = SpecContent(content)
         spec.write_spec_content()
-
-
-@pytest.mark.parametrize(
-    "input_spec",
-    [
-        UP_VSFTPD / "Fedora" / "vsftpd.spec",
-        UP_OSBUILD / "osbuild.spec",
-        UP_EDD / "edd.spec",
-    ],
-)
-def test_ensure_pnum(tmp_path, input_spec):
-    spec = Path(copy(input_spec, tmp_path))
-    Specfile(spec).ensure_pnum()
-    text = spec.read_text()
-    assert "%autosetup -p1" in text
-    # %autosetup does not accept -q
-    assert "-q" not in text


### PR DESCRIPTION
```
it's just too invasive and can't work with %setup + %autopatch

let's rely on people to do proper patching; also with patch metadata
we're covered well
```

needed to achieve https://github.com/packit/dist-git-to-source-git/pull/29#issuecomment-673545142