### PR TITLE
improve action output logging

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -282,7 +282,7 @@ class PackitRepositoryBase:
             commands_to_run = self.get_commands_for_actions(action)
             logger.info(f"Using user-defined script for {action}: {commands_to_run}")
             for cmd in commands_to_run:
-                self.command_handler.run_command(command=cmd, env=env)
+                self.command_handler.run_command(command=cmd, env=env, print_live=True)
             return False
         logger.debug(f"Running default implementation for {action}.")
         return True
@@ -302,9 +302,10 @@ class PackitRepositoryBase:
         logger.info(f"Using user-defined script for {action}: {commands_to_run}")
         for cmd in commands_to_run:
             outputs.append(
-                self.command_handler.run_command(cmd, return_output=True, env=env)
+                self.command_handler.run_command(
+                    cmd, return_output=True, env=env, print_live=True
+                )
             )
-        logger.debug(f"Action command output: {outputs}")
         return outputs
 
     def specfile_add_patches(self, patch_list: List[PatchMetadata]) -> None:

--- a/tests/functional/spellbook.py
+++ b/tests/functional/spellbook.py
@@ -21,12 +21,16 @@
 # SOFTWARE.
 
 import subprocess
+from subprocess import STDOUT
 
 
-def call_real_packit(parameters=None, envs=None, cwd=None):
+def call_real_packit(parameters=None, envs=None, cwd=None, return_output=False):
     """ invoke packit in a subprocess """
     cmd = ["python3", "-m", "packit.cli.packit_base"] + parameters
-    return subprocess.check_call(cmd, env=envs, cwd=cwd)
+    if return_output:
+        return subprocess.check_output(cmd, env=envs, cwd=cwd, stderr=STDOUT)
+    else:
+        return subprocess.check_call(cmd, env=envs, cwd=cwd)
 
 
 def call_real_packit_and_return_exit_code(parameters=None, envs=None, cwd=None):


### PR DESCRIPTION
sandcastle: log output as INFO, split the long chain per lines

local: use print_live of run_command thus logging things as INFO

we use INFO because user's commands are important and they should see
the output by default