### PR TITLE
Use archive in Upstream._fix_spec_prep

### DIFF
--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -70,6 +70,7 @@ class CommonPackageConfig:
         create_pr: bool = True,
         spec_source_id: str = "Source0",
         upstream_tag_template: str = "{version}",
+        archive_root_dir_template: str = "{upstream_pkg_name}-{version}",
         patch_generation_ignore_paths: List[str] = None,
         notifications: Optional[NotificationsConfig] = None,
     ):
@@ -106,6 +107,7 @@ class CommonPackageConfig:
         ] = current_version_command or get_current_version_command(glob_pattern="*")
         # template to create an upstream tag name (upstream may use different tagging scheme)
         self.upstream_tag_template = upstream_tag_template
+        self.archive_root_dir_template = archive_root_dir_template
 
     def __repr__(self):
         return (

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -165,6 +165,7 @@ class JobConfig(CommonPackageConfig):
         create_pr: bool = True,
         spec_source_id: str = "Source0",
         upstream_tag_template: str = "{version}",
+        archive_root_dir_template: str = "{upstream_pkg_name}-{version}",
         patch_generation_ignore_paths: List[str] = None,
         notifications: Optional[NotificationsConfig] = None,
     ):
@@ -186,6 +187,7 @@ class JobConfig(CommonPackageConfig):
             create_pr=create_pr,
             spec_source_id=spec_source_id,
             upstream_tag_template=upstream_tag_template,
+            archive_root_dir_template=archive_root_dir_template,
             patch_generation_ignore_paths=patch_generation_ignore_paths,
             notifications=notifications,
         )

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -65,6 +65,7 @@ class PackageConfig(CommonPackageConfig):
         create_pr: bool = True,
         spec_source_id: str = "Source0",
         upstream_tag_template: str = "{version}",
+        archive_root_dir_template: str = "{upstream_pkg_name}-{version}",
         patch_generation_ignore_paths: List[str] = None,
         notifications: Optional[NotificationsConfig] = None,
     ):
@@ -86,6 +87,7 @@ class PackageConfig(CommonPackageConfig):
             create_pr=create_pr,
             spec_source_id=spec_source_id,
             upstream_tag_template=upstream_tag_template,
+            archive_root_dir_template=archive_root_dir_template,
             patch_generation_ignore_paths=patch_generation_ignore_paths,
             notifications=notifications,
         )
@@ -112,6 +114,7 @@ class PackageConfig(CommonPackageConfig):
             f"create_pr='{self.create_pr}', "
             f"spec_source_id='{self.spec_source_id}', "
             f"upstream_tag_template='{self.upstream_tag_template}', "
+            f"archive_root_dir_template={self.archive_root_dir_template}', "
             f"patch_generation_ignore_paths='{self.patch_generation_ignore_paths}')"
         )
 

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -265,6 +265,7 @@ class CommonConfigSchema(MM23Schema):
     upstream_package_name = fields.String()
     upstream_ref = fields.String()
     upstream_tag_template = fields.String()
+    archive_root_dir_template = fields.String()
     dist_git_url = NotProcessedField(
         additional_message="it is generated from dist_git_base_url and downstream_package_name",
         load_only=True,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,8 +21,10 @@
 # SOFTWARE.
 
 import datetime
+import io
 import shutil
 import subprocess
+import tarfile
 from pathlib import Path
 from typing import Iterator, Optional
 
@@ -349,3 +351,19 @@ def upstream_without_config(tmp_path):
     subprocess.check_call(["git", "init", "--bare", "."], cwd=u_remote)
 
     return u_remote
+
+
+@pytest.fixture
+def create_archive():
+    def create_archive_factory(output_path):
+        out = io.BytesIO()
+        with tarfile.open(fileobj=out, mode="w:gz") as tar:
+            t = tarfile.TarInfo("dir1")
+            t.type = tarfile.DIRTYPE
+            tar.addfile(t)
+
+        out.seek(0)
+        with open(output_path, "bw") as archive:
+            archive.write(out.read())
+
+    return create_archive_factory

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -196,7 +196,8 @@ def test_fix_spec(upstream_instance):
     u, ups = upstream_instance
 
     ups.package_config.upstream_package_name = "beer"
-    ups.fix_spec(archive="asd.tar.gz", version="1.2.3", commit="abcdef123")
+    archive = ups.create_archive()
+    ups.fix_spec(archive=archive, version="_1.2.3", commit="_abcdef123")
 
     release = ups.specfile.get_release()
     # 1.20200710085501945230.master.0.g133ff39

--- a/tests/unit/test_upstream.py
+++ b/tests/unit/test_upstream.py
@@ -60,10 +60,11 @@ def upstream_mock(local_project_mock, package_config_mock):
         config=get_test_config(),
         package_config=package_config_mock,
         local_project=LocalProject(working_dir="test"),
-        # local_project=local_project_mock
     )
     flexmock(upstream)
     upstream.should_receive("local_project").and_return(local_project_mock)
+    upstream.should_receive("absolute_specfile_path").and_return("_spec_file_path")
+    upstream.should_receive("absolute_specfile_dir").and_return("_spec_file_dir")
     return upstream
 
 
@@ -90,6 +91,27 @@ def spec_mock():
         return spec_mock
 
     return spec_mock_factory
+
+
+@pytest.fixture
+def tar_mock():
+    def tar_mock_factory(archive_items=[], is_tarfile=True):
+        tarfile_mock = flexmock(packit.upstream.tarfile)
+        tarinfo_mock_list = [
+            flexmock(
+                **{
+                    "name": name,
+                    "isdir": lambda v=isdir: v,
+                    "isfile": lambda v=isdir: not isdir,
+                }
+            )
+            for name, isdir in archive_items
+        ]
+        tar_mock = flexmock(getmembers=lambda: tarinfo_mock_list)
+        tarfile_mock.should_receive("open").and_return(tar_mock)
+        tarfile_mock.should_receive("is_tarfile").and_return(is_tarfile)
+
+    return tar_mock_factory
 
 
 @pytest.mark.parametrize(
@@ -151,11 +173,10 @@ def test_get_commands_for_actions(action_config, result):
 
 
 @pytest.mark.parametrize(
-    "package_name, version, orig_setup_line, new_setup_line",
+    "inner_archive_dir, orig_setup_line, new_setup_line",
     [
         pytest.param(
-            "test_pkg_name",
-            "0.42",
+            "test_pkg_name-0.42",
             ["%setup -q -n %{srcname}-%{version}"],
             ["%setup -q -n test_pkg_name-0.42"],
             id="test1",
@@ -163,12 +184,12 @@ def test_get_commands_for_actions(action_config, result):
     ],
 )
 def test_fix_spec__setup_line(
-    version, package_name, orig_setup_line, new_setup_line, upstream_mock, spec_mock
+    inner_archive_dir, orig_setup_line, new_setup_line, upstream_mock, spec_mock
 ):
     flexmock(packit.upstream).should_receive("run_command").and_return("mocked")
 
-    upstream_mock.package_config.upstream_package_name = package_name
     upstream_mock.should_receive("_fix_spec_source")
+    upstream_mock.should_receive("get_inner_archive_dir").and_return(inner_archive_dir)
     upstream_mock.should_receive("specfile").and_return(
         spec_mock(setup_line=orig_setup_line)
     )
@@ -177,7 +198,7 @@ def test_fix_spec__setup_line(
         "%prep", new_setup_line
     ).once().and_return(flexmock())
 
-    upstream_mock.fix_spec("_archive", version, "_commit1234")
+    upstream_mock.fix_spec("_archive", "_version", "_commit1234")
 
 
 @pytest.mark.parametrize(
@@ -237,3 +258,55 @@ def test_get_version_from_tag(
     with expectation:
         upstream_mock.package_config.upstream_tag_template = tag_template
         assert upstream_mock.get_version_from_tag(tag) == expected_output
+
+
+@pytest.mark.parametrize(
+    "archive_type, expected_return_value",
+    [
+        pytest.param("tar", "_inner_archive_dir", id="tar_archive"),
+        pytest.param("unknown", None, id="unknown_archive"),
+    ],
+)
+def test_get_inner_archive_dir(
+    archive_type, expected_return_value, upstream_mock, tar_mock
+):
+    if archive_type == "tar":
+        tar_mock()
+        upstream_mock.should_receive("get_inner_tar_dir").and_return(
+            "_inner_tar_dir"
+        ).with_args("_archive").once()
+        assert upstream_mock.get_inner_archive_dir("_archive") == "_inner_tar_dir"
+    elif archive_type == "unknown":
+        tar_mock(is_tarfile=False)
+        assert upstream_mock.get_inner_archive_dir("_archive") is None
+
+
+@pytest.mark.parametrize(
+    "archive_items, expected_result",
+    [
+        pytest.param(
+            [("dir1", True), ("dir1/dir2", True), ("dir1/file1", False)],
+            "dir1",
+            id="valid_archive",
+        ),
+        pytest.param(
+            [("dir1/dir2", True), ("dir1/file1", False)],
+            "dir1",
+            id="valid_archive_no_separate_top_level",
+        ),
+        pytest.param([], None, id="invalid_archive_empty"),
+        pytest.param(
+            [("dir1", True), ("dir2", True), ("dir1/file1", False)],
+            None,
+            id="invalid_two_dirs",
+        ),
+        pytest.param(
+            [("dir1", True), ("dir1/dir2", True), ("file1", False)],
+            "dir1",
+            id="warning_file_in_root",
+        ),
+    ],
+)
+def test_get_inner_tar_dir(archive_items, expected_result, upstream_mock, tar_mock):
+    tar_mock(archive_items=archive_items)
+    assert upstream_mock.get_inner_tar_dir("_archive") == expected_result


### PR DESCRIPTION
This PR consists of 2 parts:

- [x] Primary approach to get inner archive dir will be extracted directly from the archive
- [x] Implement configuration option to define a template for archive root directory - archive_root_dir_template (is there a better name for it?)
- [x] Add unit tests.
- [x] Add integration tests.
- [x] Document archive_root_dir configuration option. [link](https://github.com/packit/packit.dev/pull/167)

Note:
In the case of unknown archive and template not provided we will try to use the current approach (`{self.package_config.upstream_package_name}-{version}`)