### PR TITLE
Fix failing test in F33 and Rawhide

### DIFF
--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -89,7 +89,7 @@ def test_get_version_macro(upstream_instance):
         setup.write(data)
 
     data = u.joinpath("beer.spec").read_text()
-    data = data.replace("0.1.0", "%(python3 %{S:" + str(setup_path) + "} --version)")
+    data = data.replace("0.1.0", "%(python3 " + str(setup_path) + " --version)")
     with open(u.joinpath("beer.spec"), "w") as f:
         f.write(data)
 


### PR DESCRIPTION
Hello, this PR addresses a problem raised in https://github.com/rebase-helper/rebase-helper/issues/819

The test used `%{S: ...}` macro incorrectly - it's supposed to be used with a source number to get its path. Using it with an absolute path (which was the case in the test) is an undefined behaviour which changed in RPM 4.16 (that is now in beta and used in F33 and rawhide). The handling of the macro changed slightly with a bug fix (see https://github.com/rpm-software-management/rpm/commit/94623389ba61a3a93decc726ed63e52cca7b3d39).