### PR TITLE
Use upstream_tag_template to get version from tag

### DIFF
--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -52,10 +52,30 @@ def test_get_spec_version(upstream_instance):
     assert ups.get_specfile_version() == "0.1.0"
 
 
-def test_get_current_version(upstream_instance):
+@pytest.mark.parametrize(
+    "tag, tag_template, expected_output",
+    [
+        pytest.param(
+            "1.0.0",
+            "{version}",
+            "1.0.0",
+            id="pure_version-valid_template",
+        ),
+        pytest.param(
+            "test-1.0.0",
+            "test-{version}",
+            "1.0.0",
+            id="valid_string-valid_template",
+        ),
+    ],
+)
+def test_get_current_version(tag, tag_template, expected_output, upstream_instance):
     u, ups = upstream_instance
+    flexmock(ups)
+    ups.package_config.upstream_tag_template = tag_template
+    ups.should_receive("command_handler.run_command").and_return(tag)
 
-    assert ups.get_current_version() == "0.1.0"
+    assert ups.get_current_version() == expected_output
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_upstream.py
+++ b/tests/unit/test_upstream.py
@@ -20,9 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from contextlib import nullcontext as does_not_raise
+
 import pytest
 from flexmock import flexmock
 
+import packit
 from packit.actions import ActionName
 from packit.local_project import LocalProject
 from packit.upstream import Upstream
@@ -31,8 +34,12 @@ from tests.spellbook import get_test_config
 
 @pytest.fixture
 def package_config_mock():
-    mock = flexmock(synced_files=None)
-    return mock
+    def package_config_mock_factory(upstream_package_name="test_package_name"):
+        mock = flexmock(synced_files=None, upstream_package_name=upstream_package_name)
+        mock.should_receive("current_version_command")
+        return mock
+
+    return package_config_mock_factory
 
 
 @pytest.fixture
@@ -43,7 +50,9 @@ def git_project_mock():
 
 @pytest.fixture
 def local_project_mock(git_project_mock):
-    mock = flexmock(git_project=git_project_mock)
+    mock = flexmock(
+        git_project=git_project_mock, working_dir="/mock_dir", ref="mock_ref"
+    )
     return mock
 
 
@@ -51,8 +60,9 @@ def local_project_mock(git_project_mock):
 def upstream_mock(local_project_mock, package_config_mock):
     upstream = Upstream(
         config=get_test_config(),
-        package_config=package_config_mock,
+        package_config=package_config_mock(),
         local_project=LocalProject(working_dir="test"),
+        # local_project=local_project_mock
     )
     flexmock(upstream)
     upstream.should_receive("local_project").and_return(local_project_mock)
@@ -62,6 +72,26 @@ def upstream_mock(local_project_mock, package_config_mock):
 @pytest.fixture
 def upstream_pr_mock():
     return flexmock(url="test_pr_url")
+
+
+@pytest.fixture
+def spec_mock():
+    def spec_mock_factory(setup_line=""):
+        spec_content_mock = flexmock()
+        spec_content_mock.should_receive("section").and_return(setup_line)
+        spec_content_mock.should_receive("replace_section").with_args(
+            "%prep", setup_line
+        ).and_return(flexmock())
+
+        spec_mock = flexmock(
+            spec_content=spec_content_mock,
+            get_release_number=lambda: "1234567",
+            set_spec_version=lambda **_: None,
+            write_spec_content=flexmock(),
+        )
+        return spec_mock
+
+    return spec_mock_factory
 
 
 @pytest.mark.parametrize(
@@ -120,3 +150,92 @@ def test_get_commands_for_actions(action_config, result):
         local_project=flexmock(),
     )
     assert ups.get_commands_for_actions(action=ActionName.create_archive) == result
+
+
+@pytest.mark.parametrize(
+    "package_name, version, orig_setup_line, new_setup_line",
+    [
+        pytest.param(
+            "test_pkg_name",
+            "0.42",
+            ["%setup -q -n %{srcname}-%{version}"],
+            ["%setup -q -n test_pkg_name-0.42"],
+            id="test1",
+        )
+    ],
+)
+def test_fix_spec__setup_line(
+    version, package_name, orig_setup_line, new_setup_line, upstream_mock, spec_mock
+):
+    flexmock(packit.upstream).should_receive("run_command").and_return("mocked")
+
+    upstream_mock.package_config.upstream_package_name = package_name
+    upstream_mock.should_receive("_fix_spec_source")
+    upstream_mock.should_receive("specfile").and_return(
+        spec_mock(setup_line=orig_setup_line)
+    )
+
+    upstream_mock.specfile.spec_content.should_receive("replace_section").with_args(
+        "%prep", new_setup_line
+    ).once().and_return(flexmock())
+
+    upstream_mock.fix_spec("_archive", version, "_commit1234")
+
+
+@pytest.mark.parametrize(
+    "action_output, version, expected_result",
+    [
+        pytest.param(
+            ("some_action_output", "1.0.1"), "_", "1.0.1", id="with_action_output"
+        ),
+        pytest.param(None, "1.0.2", "1.0.2", id="valid_version"),
+        pytest.param(None, "1.0-3", "1.0.3", id="version_with_dash"),
+    ],
+)
+def test_get_current_version(action_output, version, expected_result, upstream_mock):
+    flexmock(packit.upstream.os).should_receive("listdir").and_return("mocked")
+    upstream_mock.should_receive("get_output_from_action").and_return(action_output)
+    upstream_mock.should_receive("command_handler.run_command").and_return("_mocked")
+    upstream_mock.should_receive("get_version_from_tag").and_return(version)
+    assert upstream_mock.get_current_version() == expected_result
+
+
+@pytest.mark.parametrize(
+    "tag, tag_template, expected_output, expectation",
+    [
+        pytest.param(
+            "1.0.0",
+            "{version}",
+            "1.0.0",
+            does_not_raise(),
+            id="pure_version-valid_template",
+        ),
+        pytest.param(
+            "test-1.0.0",
+            "test-{version}",
+            "1.0.0",
+            does_not_raise(),
+            id="valid-string-valid_template",
+        ),
+        pytest.param(
+            "1.0.0",
+            "tag-{random_field}",
+            "1.0.0",
+            pytest.raises(AttributeError),
+            id="missing_version_in_template",
+        ),
+        pytest.param(
+            "some_name-1.0.0",
+            "other_name-{version}",
+            "1.0.0",
+            pytest.raises(AttributeError),
+            id="no_match_found",
+        ),
+    ],
+)
+def test_get_version_from_tag(
+    tag, tag_template, expected_output, expectation, upstream_mock
+):
+    with expectation:
+        upstream_mock.package_config.upstream_tag_template = tag_template
+        assert upstream_mock.get_version_from_tag(tag) == expected_output


### PR DESCRIPTION
Use package config variable upstream_tag_template to extract version
from git tag.

TODO:
- [x] add integration tests
- [x] check and update documentation if necessary  (https://github.com/packit/packit.dev/pull/163)
