### PR TITLE
Use correct arguments in sync_release() from tests

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -133,8 +133,8 @@ class PackitAPI:
     def sync_release(
         self,
         dist_git_branch: str,
-        use_local_content=False,
         version: str = None,
+        use_local_content=False,
         force_new_sources=False,
         upstream_ref: str = None,
         create_pr: bool = True,

--- a/tests/integration/test_source_git.py
+++ b/tests/integration/test_source_git.py
@@ -51,7 +51,9 @@ def test_basic_local_update_without_patching(
     distgit, _ = distgit_and_remote
     mock_spec_download_remote_s(distgit)
 
-    api_instance_source_git.sync_release("master", "0.1.0", upstream_ref="0.1.0")
+    api_instance_source_git.sync_release(
+        dist_git_branch="master", version="0.1.0", upstream_ref="0.1.0"
+    )
 
     assert (distgit / TARBALL_NAME).is_file()
     spec = Specfile(distgit / "beer.spec")
@@ -69,7 +71,9 @@ def test_basic_local_update_empty_patch(
 
     distgit, _ = distgit_and_remote
     mock_spec_download_remote_s(distgit)
-    api_instance_source_git.sync_release("master", "0.1.0", upstream_ref=ref)
+    api_instance_source_git.sync_release(
+        dist_git_branch="master", version="0.1.0", upstream_ref=ref
+    )
 
     assert (distgit / TARBALL_NAME).is_file()
     spec = Specfile(distgit / "beer.spec")
@@ -106,7 +110,9 @@ def test_basic_local_update_patch_content(
     source_file.write_text(" And I am sad.")
     git_add_and_commit(directory=sourcegit, message="make a file sad")
 
-    api_instance_source_git.sync_release("master", "0.1.0", upstream_ref="0.1.0")
+    api_instance_source_git.sync_release(
+        dist_git_branch="master", version="0.1.0", upstream_ref="0.1.0"
+    )
 
     git_diff = subprocess.check_output(
         ["git", "diff", "HEAD~", "HEAD"], cwd=distgit
@@ -270,7 +276,9 @@ def test_basic_local_update_patch_content_with_metadata(
     source_file.write_text(" And I am sad.")
     git_add_and_commit(directory=sourcegit, message="make a file sad")
 
-    api_instance_source_git.sync_release("master", "0.1.0", upstream_ref="0.1.0")
+    api_instance_source_git.sync_release(
+        dist_git_branch="master", version="0.1.0", upstream_ref="0.1.0"
+    )
 
     git_diff = subprocess.check_output(
         ["git", "diff", "HEAD~", "HEAD"], cwd=distgit
@@ -323,7 +331,9 @@ def test_basic_local_update_patch_content_with_metadata_and_patch_ignored(
     source_file.write_text(" And I am sad.")
     git_add_and_commit(directory=sourcegit, message="make a file sad")
 
-    api_instance_source_git.sync_release("master", "0.1.0", upstream_ref="0.1.0")
+    api_instance_source_git.sync_release(
+        dist_git_branch="master", version="0.1.0", upstream_ref="0.1.0"
+    )
 
     git_diff = subprocess.check_output(
         ["git", "diff", "HEAD~", "HEAD"], cwd=distgit
@@ -364,7 +374,9 @@ def test_basic_local_update_patch_content_with_downstream_patch(
     source_file.write_text(" And I am sad.")
     git_add_and_commit(directory=sourcegit, message="make a file sad")
 
-    api_instance_source_git.sync_release("master", "0.1.0", upstream_ref="0.1.0")
+    api_instance_source_git.sync_release(
+        dist_git_branch="master", version="0.1.0", upstream_ref="0.1.0"
+    )
 
     git_diff = subprocess.check_output(
         ["git", "diff", "HEAD~", "HEAD"], cwd=distgit

--- a/tests/integration/test_source_git.py
+++ b/tests/integration/test_source_git.py
@@ -52,7 +52,10 @@ def test_basic_local_update_without_patching(
     mock_spec_download_remote_s(distgit)
 
     api_instance_source_git.sync_release(
-        dist_git_branch="master", version="0.1.0", upstream_ref="0.1.0"
+        dist_git_branch="master",
+        version="0.1.0",
+        use_local_content=True,
+        upstream_ref="0.1.0",
     )
 
     assert (distgit / TARBALL_NAME).is_file()
@@ -72,7 +75,10 @@ def test_basic_local_update_empty_patch(
     distgit, _ = distgit_and_remote
     mock_spec_download_remote_s(distgit)
     api_instance_source_git.sync_release(
-        dist_git_branch="master", version="0.1.0", upstream_ref=ref
+        dist_git_branch="master",
+        version="0.1.0",
+        use_local_content=True,
+        upstream_ref=ref,
     )
 
     assert (distgit / TARBALL_NAME).is_file()
@@ -111,7 +117,10 @@ def test_basic_local_update_patch_content(
     git_add_and_commit(directory=sourcegit, message="make a file sad")
 
     api_instance_source_git.sync_release(
-        dist_git_branch="master", version="0.1.0", upstream_ref="0.1.0"
+        dist_git_branch="master",
+        version="0.1.0",
+        use_local_content=True,
+        upstream_ref="0.1.0",
     )
 
     git_diff = subprocess.check_output(
@@ -277,7 +286,10 @@ def test_basic_local_update_patch_content_with_metadata(
     git_add_and_commit(directory=sourcegit, message="make a file sad")
 
     api_instance_source_git.sync_release(
-        dist_git_branch="master", version="0.1.0", upstream_ref="0.1.0"
+        dist_git_branch="master",
+        version="0.1.0",
+        use_local_content=True,
+        upstream_ref="0.1.0",
     )
 
     git_diff = subprocess.check_output(
@@ -332,7 +344,10 @@ def test_basic_local_update_patch_content_with_metadata_and_patch_ignored(
     git_add_and_commit(directory=sourcegit, message="make a file sad")
 
     api_instance_source_git.sync_release(
-        dist_git_branch="master", version="0.1.0", upstream_ref="0.1.0"
+        dist_git_branch="master",
+        version="0.1.0",
+        use_local_content=True,
+        upstream_ref="0.1.0",
     )
 
     git_diff = subprocess.check_output(
@@ -375,7 +390,10 @@ def test_basic_local_update_patch_content_with_downstream_patch(
     git_add_and_commit(directory=sourcegit, message="make a file sad")
 
     api_instance_source_git.sync_release(
-        dist_git_branch="master", version="0.1.0", upstream_ref="0.1.0"
+        dist_git_branch="master",
+        version="0.1.0",
+        use_local_content=True,
+        upstream_ref="0.1.0",
     )
 
     git_diff = subprocess.check_output(

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -64,7 +64,7 @@ def test_basic_local_update(
     mock_spec_download_remote_s(d)
     flexmock(api).should_receive("init_kerberos_ticket").at_least().once()
 
-    api.sync_release("master", "0.1.0")
+    api.sync_release(dist_git_branch="master", version="0.1.0")
 
     assert (d / TARBALL_NAME).is_file()
     spec = Specfile(d / "beer.spec")
@@ -83,7 +83,7 @@ def test_basic_local_update_using_distgit(
     u, d, api = api_instance
     mock_spec_download_remote_s(d)
 
-    api.sync_release("master", "0.1.0")
+    api.sync_release(dist_git_branch="master", version="0.1.0")
 
     assert (d / TARBALL_NAME).is_file()
     spec = Specfile(d / "beer.spec")
@@ -112,7 +112,7 @@ def test_basic_local_update_direct_push(
     _, distgit_remote = distgit_and_remote
     mock_spec_download_remote_s(d)
 
-    api.sync_release("master", "0.1.0", create_pr=False)
+    api.sync_release(dist_git_branch="master", version="0.1.0", create_pr=False)
 
     remote_dir_clone = Path(f"{distgit_remote}-clone")
     subprocess.check_call(
@@ -137,7 +137,7 @@ def test_basic_local_update_direct_push_no_dg_spec(
     _, distgit_remote = distgit_and_remote
     mock_spec_download_remote_s(d)
 
-    api.sync_release("master", "0.1.0", create_pr=False)
+    api.sync_release(dist_git_branch="master", version="0.1.0", create_pr=False)
 
     remote_dir_clone = Path(f"{distgit_remote}-clone")
     subprocess.check_call(

--- a/tests/integration/test_using_cockpit.py
+++ b/tests/integration/test_using_cockpit.py
@@ -87,7 +87,7 @@ def test_update_on_cockpit_ostree(cockpit_ostree):
 
     with cwd(upstream_path):
         api.sync_release(
-            "master",
+            dist_git_branch="master",
             use_local_content=False,
             version="179",
             force_new_sources=False,

--- a/tests_recording/test_api.py
+++ b/tests_recording/test_api.py
@@ -72,7 +72,7 @@ class ProposeUpdate(PackitUnittestOgr):
             f"git tag -a {version_increase} -m 'my version {version_increase}'",
             shell=True,
         )
-        self.api.sync_release("master")
+        self.api.sync_release(dist_git_branch="master")
 
     def test_comment_in_spec(self):
         """
@@ -88,7 +88,7 @@ class ProposeUpdate(PackitUnittestOgr):
             f"git tag -a {version_increase} -m 'my version {version_increase}'",
             shell=True,
         )
-        self.api.sync_release("master")
+        self.api.sync_release(dist_git_branch="master")
 
     @unittest.skipIf(
         hasattr(rebasehelper, "VERSION")


### PR DESCRIPTION
I was trying to fix the test failures in #934 and found out that the `sync_release` method in tests is called with wrong order of attributes, so `use_local_content="0.1.0"`,  `version=None` :
https://github.com/packit/packit/blob/7bc08fc8ec7cb413e6298d3278768aacfc4dccf6/tests/integration/test_update.py#L67

https://github.com/packit/packit/blob/7bc08fc8ec7cb413e6298d3278768aacfc4dccf6/tests/integration/test_source_git.py#L51