### PR TITLE
Set REDIS_SERVICE_HOST in reverse-dep-p-s tests

### DIFF
--- a/files/zuul-reverse-dep-packit-service.yaml
+++ b/files/zuul-reverse-dep-packit-service.yaml
@@ -10,5 +10,7 @@
     - include_tasks: tasks/install-packit.yaml
     - name: Run unit, integration tests
       command: make check
+      environment:
+        REDIS_SERVICE_HOST: redis
       args:
         chdir: "{{ reverse_dir }}"


### PR DESCRIPTION
It has to be set explicitly since https://github.com/packit/packit-service/pull/800