### PR TITLE
cli: make --remote global

### DIFF
--- a/packit/cli/local_build.py
+++ b/packit/cli/local_build.py
@@ -34,14 +34,6 @@ logger = logging.getLogger("packit")
 
 @click.command("local-build", context_settings=get_context_settings())
 @click.option(
-    "--remote",
-    default=None,
-    help=(
-        "Name of the remote to discover upstream project URL, "
-        "If this is not specified, default to origin."
-    ),
-)
-@click.option(
     "--upstream-ref",
     default=None,
     help="Git ref of the last upstream commit in the current branch "
@@ -50,12 +42,12 @@ logger = logging.getLogger("packit")
 )
 @click.argument(
     "path_or_url",
-    type=LocalProjectParameter(remote_param_name="remote"),
+    type=LocalProjectParameter(),
     default=os.path.curdir,
 )
 @pass_config
 @cover_packit_exception
-def local_build(config, path_or_url, upstream_ref, remote):
+def local_build(config, path_or_url, upstream_ref):
     """
     Create RPMs using content of the upstream repository.
 

--- a/packit/cli/packit_base.py
+++ b/packit/cli/packit_base.py
@@ -60,6 +60,14 @@ class AliasedGroup(click.Group):
 @click.option("--fas-user", help="Fedora Account System username.")
 @click.option("-k", "--keytab", help="Path to FAS keytab file.")
 @click.option(
+    "--remote",
+    default=None,
+    help=(
+        "Name of the remote to discover upstream project URL, "
+        "If this is not specified, default to the first remote."
+    ),
+)
+@click.option(
     "--dry-run",
     is_flag=True,
     help="Do not perform any remote changes (pull requests or comments).",
@@ -68,7 +76,7 @@ class AliasedGroup(click.Group):
     version=get_distribution("packitos").version, message="%(version)s"
 )
 @click.pass_context
-def packit_base(ctx, debug, fas_user, keytab, dry_run):
+def packit_base(ctx, debug, fas_user, keytab, dry_run, remote):
     """Integrate upstream open source projects into Fedora operating system."""
     if debug:
         # to be able to logger.debug() also in get_user_config()
@@ -79,6 +87,7 @@ def packit_base(ctx, debug, fas_user, keytab, dry_run):
     c.dry_run = dry_run or c.dry_run
     c.fas_user = fas_user or c.fas_user
     c.keytab_path = keytab or c.keytab_path
+    c.upstream_git_remote = remote or c.upstream_git_remote
     ctx.obj = c
 
     if ctx.obj.debug:

--- a/packit/cli/srpm.py
+++ b/packit/cli/srpm.py
@@ -37,14 +37,6 @@ logger = logging.getLogger("packit")
     "--output", metavar="FILE", help="Write the SRPM to FILE instead of current dir."
 )
 @click.option(
-    "--remote",
-    default=None,
-    help=(
-        "Name of the remote to discover upstream project URL, "
-        "If this is not specified, default to origin."
-    ),
-)
-@click.option(
     "--upstream-ref",
     default=None,
     help="Git ref of the last upstream commit in the current branch "
@@ -53,7 +45,7 @@ logger = logging.getLogger("packit")
 )
 @click.argument(
     "path_or_url",
-    type=LocalProjectParameter(remote_param_name="remote"),
+    type=LocalProjectParameter(),
     default=os.path.curdir,
 )
 @pass_config
@@ -63,7 +55,6 @@ def srpm(
     output,
     path_or_url,
     upstream_ref,
-    remote,  # click introspects this in LocalProjectParameter
 ):
     """
     Create new SRPM (.src.rpm file) using content of the upstream repository.

--- a/packit/cli/sync_from_downstream.py
+++ b/packit/cli/sync_from_downstream.py
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
     help="Push to a fork before creating a pull request.",
 )
 @click.option(
-    "--remote",
+    "--remote-to-push",
     default=None,
     help=(
         "Name of the remote where packit should push. "
@@ -77,7 +77,7 @@ logger = logging.getLogger(__name__)
 @click.option("-x", "--exclude", help="File to exclude from sync", multiple=True)
 @click.argument(
     "path_or_url",
-    type=LocalProjectParameter(remote_param_name="remote"),
+    type=LocalProjectParameter(),
     default=os.path.curdir,
 )
 @cover_packit_exception
@@ -89,7 +89,7 @@ def sync_from_downstream(
     no_pr,
     path_or_url,
     fork,
-    remote,
+    remote_to_push,
     exclude,
     force,
 ):
@@ -110,7 +110,7 @@ def sync_from_downstream(
             upstream_branch=upstream_branch,
             no_pr=no_pr,
             fork=fork,
-            remote_name=remote,
+            remote_name=remote_to_push,
             exclude_files=exclude,
             force=force,
         )

--- a/packit/cli/types.py
+++ b/packit/cli/types.py
@@ -38,16 +38,12 @@ class LocalProjectParameter(click.ParamType):
 
     name = "path_or_url"
 
-    def __init__(
-        self, branch_param_name: str = None, remote_param_name: str = None
-    ) -> None:
+    def __init__(self, branch_param_name: str = None) -> None:
         """
         :param branch_param_name: name of the cli function parameter (not the option name)
-        :param remote_param_name: name of the remote cli function parameter (not the option name)
         """
         super().__init__()
         self.branch_param_name = branch_param_name
-        self.remote_param_name = remote_param_name
 
     def convert(self, value, param, ctx):
         try:
@@ -59,18 +55,19 @@ class LocalProjectParameter(click.ParamType):
                     for param in ctx.command.params:
                         if param.name == self.branch_param_name:
                             branch_name = param.default
-            remote_name = ctx.params.get(self.remote_param_name, None)
 
             if os.path.isdir(value):
                 absolute_path = os.path.abspath(value)
                 logger.debug(f"Input is a directory: {absolute_path}")
                 local_project = LocalProject(
-                    working_dir=absolute_path, ref=branch_name, remote=remote_name
+                    working_dir=absolute_path,
+                    ref=branch_name,
+                    remote=ctx.obj.upstream_git_remote,
                 )
             elif git_remote_url_to_https_url(value):
                 logger.debug(f"Input is a URL to a git repo: {value}")
                 local_project = LocalProject(
-                    git_url=value, ref=branch_name, remote=remote_name
+                    git_url=value, ref=branch_name, remote=ctx.obj.upstream_git_remote
                 )
             else:
                 self.fail(

--- a/packit/cli/update.py
+++ b/packit/cli/update.py
@@ -68,14 +68,6 @@ logger = logging.getLogger(__name__)
     help="Do not create a pull request to downstream repository.",
 )
 @click.option(
-    "--remote",
-    default=None,
-    help=(
-        "Name of the remote to discover upstream project URL, "
-        "If this is not specified, default to origin."
-    ),
-)
-@click.option(
     "--upstream-ref",
     default=None,
     help="Git ref of the last upstream commit in the current branch "
@@ -91,7 +83,7 @@ logger = logging.getLogger(__name__)
 )
 @click.argument(
     "path_or_url",
-    type=LocalProjectParameter(remote_param_name="remote"),
+    type=LocalProjectParameter(),
     default=os.path.curdir,
 )
 @click.argument("version", required=False)
@@ -107,7 +99,6 @@ def update(
     path_or_url,
     upstream_ref,
     version,
-    remote,  # click introspects this in LocalProjectParameter
     force,
 ):
     """

--- a/packit/config/config.py
+++ b/packit/config/config.py
@@ -55,6 +55,7 @@ class Config:
         dry_run: bool = False,
         fas_user: Optional[str] = None,
         keytab_path: Optional[str] = None,
+        upstream_git_remote: Optional[str] = None,
         command_handler: str = None,
         command_handler_work_dir: str = SANDCASTLE_WORK_DIR,
         command_handler_pvc_env_var: str = SANDCASTLE_PVC,
@@ -66,6 +67,7 @@ class Config:
         self.fas_user: Optional[str] = fas_user
         self.keytab_path: Optional[str] = keytab_path
         self.dry_run: bool = dry_run
+        self.upstream_git_remote = upstream_git_remote
 
         self.services: Set[GitService] = set()
 
@@ -104,6 +106,7 @@ class Config:
             f"debug='{self.debug}', "
             f"fas_user='{self.fas_user}', "
             f"keytab_path='{self.keytab_path}', "
+            f"upstream_git_remote='{self.upstream_git_remote}', "
             f"command_handler='{self.command_handler}', "
             f"command_handler_work_dir='{self.command_handler_work_dir}', "
             f"command_handler_pvc_env_var='{self.command_handler_pvc_env_var}', "

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -420,6 +420,7 @@ class UserConfigSchema(MM23Schema):
     dry_run = fields.Bool()
     fas_user = fields.String()
     keytab_path = fields.String()
+    upstream_git_remote = fields.String()
     github_token = fields.String()
     pagure_user_token = fields.String()
     pagure_fork_token = fields.String()

--- a/tests/functional/test_local_build.py
+++ b/tests/functional/test_local_build.py
@@ -24,6 +24,9 @@
 Functional tests for local-build command
 """
 from pathlib import Path
+from subprocess import CalledProcessError
+
+import pytest
 
 from tests.functional.spellbook import call_real_packit
 
@@ -35,6 +38,26 @@ def test_rpm_command(ogr_distgit_and_remote):
     rpm_paths = ogr_distgit_and_remote[0].glob("noarch/*.rpm")
 
     assert all([rpm_path.exists() for rpm_path in rpm_paths])
+
+
+def test_local_build_with_remote_good(ogr_distgit_and_remote):
+    call_real_packit(
+        parameters=["--debug", "--remote", "origin", "local-build"],
+        cwd=ogr_distgit_and_remote[0],
+    )
+    rpm_paths = ogr_distgit_and_remote[0].glob("noarch/*.rpm")
+
+    assert all([rpm_path.exists() for rpm_path in rpm_paths])
+
+
+def test_local_build_with_remote_bad(ogr_distgit_and_remote):
+    with pytest.raises(CalledProcessError) as ex:
+        call_real_packit(
+            parameters=["--debug", "--remote", "burcak", "local-build"],
+            cwd=ogr_distgit_and_remote[0],
+            return_output=True,
+        )
+    assert b"Remote named 'burcak' didn't exist" in ex.value.output
 
 
 def test_rpm_command_for_path(ogr_distgit_and_remote):


### PR DESCRIPTION
Multiple changes here:
* --remote option is now global and available to all the commands via
  the magic cli/types.py parsing and global LocalProject instantiation
* sync-from-downstream --remote was renamed to --remote-to-push because
  it was semantically different from the other --remote: let's make
  this clear to our users
* --remote can now be specified in user's config (via
  upstream_git_remote parameter)

Please mention the rename in the release notes.

Fixes #586