### PR TITLE
patches: support git format-patch --no-prefix

### DIFF
--- a/tests/spellbook.py
+++ b/tests/spellbook.py
@@ -225,6 +225,27 @@ def create_git_am_style_history(sg: Path):
     git_add_and_commit(directory=sg, message=meta.commit_message)
 
 
+def create_patch_mixed_history(sg: Path):
+    """
+    create a git history where we mix prefix and no-prefix
+
+    :param sg: the repo
+    """
+    hops = sg.joinpath("hops")
+    hops.write_text("Amarillo\n")
+    meta = PatchMetadata(name="amarillo.patch", present_in_specfile=True)
+    git_add_and_commit(directory=sg, message=meta.commit_message)
+
+    hops.write_text("Citra\n")
+    meta = PatchMetadata(name="citra.patch", present_in_specfile=True, no_prefix=True)
+    git_add_and_commit(directory=sg, message=meta.commit_message)
+
+    malt = sg.joinpath("malt")
+    malt.write_text("Munich\n")
+    meta = PatchMetadata(name="malt.patch", present_in_specfile=True)
+    git_add_and_commit(directory=sg, message=meta.commit_message)
+
+
 def prepare_dist_git_repo(directory, push=True):
     subprocess.check_call(["git", "branch", "f30"], cwd=directory)
     if push:


### PR DESCRIPTION
some patches in dist-git are applied with -p0 which implies --no-prefix
option for format-patch

this commit enables that: packit is able generate a patch file with
format-patch without leading a/ and b/ in the patch diff

by default format-patch generates patches for -p1 application

🤦‍♂️

https://github.com/packit/dist-git-to-source-git/issues/85#issuecomment-698827925