### PR TITLE
[files/zuul-tests*.yaml] set default project_dir

### DIFF
--- a/files/zuul-tests-session-recording.yaml
+++ b/files/zuul-tests-session-recording.yaml
@@ -1,6 +1,8 @@
 ---
 - name: This is a recipe for how to run packit tests
   hosts: all
+  vars:
+    project_dir: "{{ playbook_dir }}/.."
   tasks:
     - include_tasks: tasks/rpm-test-deps.yaml
     - include_tasks: tasks/install-packit.yaml

--- a/files/zuul-tests.yaml
+++ b/files/zuul-tests.yaml
@@ -1,6 +1,8 @@
 ---
 - name: This is a recipe for how to run packit tests
   hosts: all
+  vars:
+    project_dir: "{{ playbook_dir }}/.."
   tasks:
     - include_tasks: tasks/rpm-test-deps.yaml
     - include_tasks: tasks/install-packit.yaml


### PR DESCRIPTION
This should fix currently broken ogr-reverse-dep-packit-tests