### PR TITLE
Add option to sync full content of the spec-file

### DIFF
--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -24,17 +24,16 @@
 Common package config attributes so they can be imported both in PackageConfig and JobConfig
 """
 import os
-from typing import Optional, List, Union, Dict
-
-from packit.sync import SyncFilesItem
+from typing import Dict, List, Optional, Union
 
 from packit.actions import ActionName
-from packit.config.sync_files_config import SyncFilesConfig
 from packit.config.notifications import (
     NotificationsConfig,
     PullRequestNotificationsConfig,
 )
+from packit.config.sync_files_config import SyncFilesConfig
 from packit.constants import PROD_DISTGIT_URL
+from packit.sync import SyncFilesItem
 from packit.utils.repo import get_current_version_command
 
 
@@ -155,7 +154,14 @@ class CommonPackageConfig:
         files = self.synced_files.files_to_sync
 
         if self.specfile_path not in (item.src for item in files):
-            files.append(SyncFilesItem(src=self.specfile_path, dest=self.specfile_path))
+            files.append(
+                SyncFilesItem(
+                    src=self.specfile_path,
+                    dest=f"{self.downstream_package_name}.spec"
+                    if self.downstream_package_name
+                    else self.specfile_path,
+                )
+            )
 
         if self.config_file_path and self.config_file_path not in (
             item.src for item in files

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -68,6 +68,7 @@ class CommonPackageConfig:
         upstream_ref: Optional[str] = None,
         allowed_gpg_keys: Optional[List[str]] = None,
         create_pr: bool = True,
+        sync_changelog: bool = False,
         spec_source_id: str = "Source0",
         upstream_tag_template: str = "{version}",
         archive_root_dir_template: str = "{upstream_pkg_name}-{version}",
@@ -93,6 +94,7 @@ class CommonPackageConfig:
         self.upstream_ref: Optional[str] = upstream_ref
         self.allowed_gpg_keys = allowed_gpg_keys
         self.create_pr: bool = create_pr
+        self.sync_changelog: bool = sync_changelog
         self.spec_source_id: str = spec_source_id
         self.notifications = notifications or NotificationsConfig(
             pull_request=PullRequestNotificationsConfig()
@@ -126,6 +128,7 @@ class CommonPackageConfig:
             f"upstream_ref='{self.upstream_ref}', "
             f"allowed_gpg_keys='{self.allowed_gpg_keys}', "
             f"create_pr='{self.create_pr}', "
+            f"synced_files='{self.synced_files}', "
             f"spec_source_id='{self.spec_source_id}', "
             f"upstream_tag_template='{self.upstream_tag_template}', "
             f"patch_generation_ignore_paths='{self.patch_generation_ignore_paths}')"

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -163,6 +163,7 @@ class JobConfig(CommonPackageConfig):
         upstream_ref: Optional[str] = None,
         allowed_gpg_keys: Optional[List[str]] = None,
         create_pr: bool = True,
+        sync_changelog: bool = False,
         spec_source_id: str = "Source0",
         upstream_tag_template: str = "{version}",
         archive_root_dir_template: str = "{upstream_pkg_name}-{version}",
@@ -185,6 +186,7 @@ class JobConfig(CommonPackageConfig):
             upstream_ref=upstream_ref,
             allowed_gpg_keys=allowed_gpg_keys,
             create_pr=create_pr,
+            sync_changelog=sync_changelog,
             spec_source_id=spec_source_id,
             upstream_tag_template=upstream_tag_template,
             archive_root_dir_template=archive_root_dir_template,
@@ -213,6 +215,7 @@ class JobConfig(CommonPackageConfig):
             f"upstream_ref='{self.upstream_ref}', "
             f"allowed_gpg_keys='{self.allowed_gpg_keys}', "
             f"create_pr='{self.create_pr}', "
+            f"sync_changelog='{self.sync_changelog}', "
             f"spec_source_id='{self.spec_source_id}', "
             f"upstream_tag_template='{self.upstream_tag_template}', "
             f"patch_generation_ignore_paths='{self.patch_generation_ignore_paths}')"
@@ -248,6 +251,7 @@ class JobConfig(CommonPackageConfig):
             and self.actions == other.actions
             and self.allowed_gpg_keys == other.allowed_gpg_keys
             and self.create_pr == other.create_pr
+            and self.sync_changelog == other.sync_changelog
             and self.spec_source_id == other.spec_source_id
             and self.upstream_tag_template == other.upstream_tag_template
         )

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -973,6 +973,23 @@ def test_get_package_config_from_repo_spec_file_not_defined(content):
             PackageConfig(
                 config_file_path="packit.yaml",
                 specfile_path="file.spec",
+                downstream_package_name="package",
+                synced_files=SyncFilesConfig(
+                    files_to_sync=[SyncFilesItem(src="file.spec", dest="package.spec")]
+                ),
+            ),
+            SyncFilesConfig(
+                files_to_sync=[
+                    SyncFilesItem(src="file.spec", dest="package.spec"),
+                    SyncFilesItem(src="packit.yaml", dest="packit.yaml"),
+                ]
+            ),
+        ),
+        (
+            PackageConfig(
+                config_file_path="packit.yaml",
+                specfile_path="file.spec",
+                downstream_package_name="package",
                 synced_files=SyncFilesConfig(
                     files_to_sync=[SyncFilesItem(src="file.txt", dest="file.txt")]
                 ),
@@ -980,7 +997,7 @@ def test_get_package_config_from_repo_spec_file_not_defined(content):
             SyncFilesConfig(
                 files_to_sync=[
                     SyncFilesItem(src="file.txt", dest="file.txt"),
-                    SyncFilesItem(src="file.spec", dest="file.spec"),
+                    SyncFilesItem(src="file.spec", dest="package.spec"),
                     SyncFilesItem(src="packit.yaml", dest="packit.yaml"),
                 ]
             ),
@@ -990,10 +1007,11 @@ def test_get_package_config_from_repo_spec_file_not_defined(content):
                 config_file_path="packit.yaml",
                 specfile_path="file.spec",
                 synced_files=SyncFilesConfig([]),
+                downstream_package_name="package",
             ),
             SyncFilesConfig(
                 files_to_sync=[
-                    SyncFilesItem(src="file.spec", dest="file.spec"),
+                    SyncFilesItem(src="file.spec", dest="package.spec"),
                     SyncFilesItem(src="packit.yaml", dest="packit.yaml"),
                 ]
             ),

--- a/tests_recording/test_data/test_api/tests_recording.test_api.ProposeUpdate.test_changelog_sync.yaml
+++ b/tests_recording/test_data/test_api/tests_recording.test_api.ProposeUpdate.test_changelog_sync.yaml
@@ -1,0 +1,5953 @@
+X:
+  file:
+    tar:
+      StoreFiles:
+        tests_recording.test_api.ProposeUpdate.test_changelog_sync.yaml:
+          target_path:
+            all:
+              metadata:
+                latency: 0
+              output: tests_recording.test_api.ProposeUpdate.test_changelog_sync.yaml.packit-dist-git_2_1.tar.xz
+          to_path:
+            all:
+              metadata:
+                latency: 0
+              output: tests_recording.test_api.ProposeUpdate.test_changelog_sync.yaml.static_tmp_1_1.tar.xz
+_requre:
+  DataTypes: 3
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 2
+git.remote:
+  fetch:
+    all:
+      metadata:
+        latency: 1.907271385192871
+        module_call_list:
+        - unittest.case
+        - requre.online_replacing
+        - tests_recording.test_api
+        - packit.api
+        - packit.distgit
+        - requre.objects
+        - requre.cassette
+        - git.remote
+        - fetch
+      output:
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'master           '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/1/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/10/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/11/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/12/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/13/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/14/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/15/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/16/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/17/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/18/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/19/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/2/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/20/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/21/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/22/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/23/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/24/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/25/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/26/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/27/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/28/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/29/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/3/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/30/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/31/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/32/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/33/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/34/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/35/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/36/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/37/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/38/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/39/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/4/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/40/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/41/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/42/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/43/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/44/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/5/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/6/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/7/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/8/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/9/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'f30              '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'f31              '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'f32              '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'f33              '
+  push:
+    all:
+      metadata:
+        latency: 7.235404968261719
+        module_call_list:
+        - unittest.case
+        - requre.online_replacing
+        - tests_recording.test_api
+        - packit.api
+        - packit.distgit
+        - packit.base_git
+        - packit.local_project
+        - requre.objects
+        - requre.helpers.git.pushinfo
+        - requre.objects
+        - requre.cassette
+        - git.remote
+        - push
+      output:
+      - _old_commit_sha: 13b71f6
+        flags: 128
+        local_ref:
+        - /tmp/packit_tmp/tests_recording.test_api.ProposeUpdate.test_changelog_sync.yaml/packit-dist-git_2/.git
+        - refs/heads/0.4.0-master-update
+        remote_ref_string: refs/heads/0.4.0-master-update
+        summary: '13b71f6...9c57753 (forced update)
+
+          '
+packit.fedpkg:
+  clone:
+    all:
+      metadata:
+        latency: 2.8125
+        module_call_list:
+        - unittest.case
+        - requre.online_replacing
+        - tests_recording.test_api
+        - packit.api
+        - packit.distgit
+        - requre.helpers.files
+        - requre.objects
+        - requre.cassette
+        - packit.fedpkg
+        - clone
+      output: null
+requests.sessions:
+  send:
+    GET:
+      https://api.github.com:443/repos/packit/requre:
+        all:
+          metadata:
+            latency: 0.2743570804595947
+            module_call_list:
+            - unittest.case
+            - requre.online_replacing
+            - tests_recording.test_api
+            - tests_recording.testbase
+            - packit.config.package_config
+            - ogr.services.github.project
+            - github.MainClass
+            - github.Requester
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+              allow_merge_commit: true
+              allow_rebase_merge: true
+              allow_squash_merge: true
+              archive_url: https://api.github.com/repos/packit/requre/{archive_format}{/ref}
+              archived: false
+              assignees_url: https://api.github.com/repos/packit/requre/assignees{/user}
+              blobs_url: https://api.github.com/repos/packit/requre/git/blobs{/sha}
+              branches_url: https://api.github.com/repos/packit/requre/branches{/branch}
+              clone_url: https://github.com/packit/requre.git
+              collaborators_url: https://api.github.com/repos/packit/requre/collaborators{/collaborator}
+              comments_url: https://api.github.com/repos/packit/requre/comments{/number}
+              commits_url: https://api.github.com/repos/packit/requre/commits{/sha}
+              compare_url: https://api.github.com/repos/packit/requre/compare/{base}...{head}
+              contents_url: https://api.github.com/repos/packit/requre/contents/{+path}
+              contributors_url: https://api.github.com/repos/packit/requre/contributors
+              created_at: '2019-09-11T09:49:47Z'
+              default_branch: master
+              delete_branch_on_merge: false
+              deployments_url: https://api.github.com/repos/packit/requre/deployments
+              description: Library for testing python code what allows store output
+                of various objects and use stored data for testing
+              disabled: false
+              downloads_url: https://api.github.com/repos/packit/requre/downloads
+              events_url: https://api.github.com/repos/packit/requre/events
+              fork: false
+              forks: 8
+              forks_count: 8
+              forks_url: https://api.github.com/repos/packit/requre/forks
+              full_name: packit/requre
+              git_commits_url: https://api.github.com/repos/packit/requre/git/commits{/sha}
+              git_refs_url: https://api.github.com/repos/packit/requre/git/refs{/sha}
+              git_tags_url: https://api.github.com/repos/packit/requre/git/tags{/sha}
+              git_url: git://github.com/packit/requre.git
+              has_downloads: true
+              has_issues: true
+              has_pages: false
+              has_projects: true
+              has_wiki: true
+              homepage: null
+              hooks_url: https://api.github.com/repos/packit/requre/hooks
+              html_url: https://github.com/packit/requre
+              id: 207778319
+              issue_comment_url: https://api.github.com/repos/packit/requre/issues/comments{/number}
+              issue_events_url: https://api.github.com/repos/packit/requre/issues/events{/number}
+              issues_url: https://api.github.com/repos/packit/requre/issues{/number}
+              keys_url: https://api.github.com/repos/packit/requre/keys{/key_id}
+              labels_url: https://api.github.com/repos/packit/requre/labels{/name}
+              language: Python
+              languages_url: https://api.github.com/repos/packit/requre/languages
+              license:
+                key: mit
+                name: MIT License
+                node_id: MDc6TGljZW5zZTEz
+                spdx_id: MIT
+                url: https://api.github.com/licenses/mit
+              merges_url: https://api.github.com/repos/packit/requre/merges
+              milestones_url: https://api.github.com/repos/packit/requre/milestones{/number}
+              mirror_url: null
+              name: requre
+              network_count: 8
+              node_id: MDEwOlJlcG9zaXRvcnkyMDc3NzgzMTk=
+              notifications_url: https://api.github.com/repos/packit/requre/notifications{?since,all,participating}
+              open_issues: 6
+              open_issues_count: 6
+              organization:
+                avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                events_url: https://api.github.com/users/packit/events{/privacy}
+                followers_url: https://api.github.com/users/packit/followers
+                following_url: https://api.github.com/users/packit/following{/other_user}
+                gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/packit
+                id: 46870917
+                login: packit
+                node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                organizations_url: https://api.github.com/users/packit/orgs
+                received_events_url: https://api.github.com/users/packit/received_events
+                repos_url: https://api.github.com/users/packit/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/packit/subscriptions
+                type: Organization
+                url: https://api.github.com/users/packit
+              owner:
+                avatar_url: https://avatars3.githubusercontent.com/u/46870917?v=4
+                events_url: https://api.github.com/users/packit/events{/privacy}
+                followers_url: https://api.github.com/users/packit/followers
+                following_url: https://api.github.com/users/packit/following{/other_user}
+                gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/packit
+                id: 46870917
+                login: packit
+                node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                organizations_url: https://api.github.com/users/packit/orgs
+                received_events_url: https://api.github.com/users/packit/received_events
+                repos_url: https://api.github.com/users/packit/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/packit/subscriptions
+                type: Organization
+                url: https://api.github.com/users/packit
+              permissions:
+                admin: true
+                pull: true
+                push: true
+              private: false
+              pulls_url: https://api.github.com/repos/packit/requre/pulls{/number}
+              pushed_at: '2020-10-21T12:18:11Z'
+              releases_url: https://api.github.com/repos/packit/requre/releases{/id}
+              size: 406
+              ssh_url: git@github.com:packit/requre.git
+              stargazers_count: 4
+              stargazers_url: https://api.github.com/repos/packit/requre/stargazers
+              statuses_url: https://api.github.com/repos/packit/requre/statuses/{sha}
+              subscribers_count: 8
+              subscribers_url: https://api.github.com/repos/packit/requre/subscribers
+              subscription_url: https://api.github.com/repos/packit/requre/subscription
+              svn_url: https://github.com/packit/requre
+              tags_url: https://api.github.com/repos/packit/requre/tags
+              teams_url: https://api.github.com/repos/packit/requre/teams
+              temp_clone_token: ''
+              trees_url: https://api.github.com/repos/packit/requre/git/trees{/sha}
+              updated_at: '2020-10-21T12:18:14Z'
+              url: https://api.github.com/repos/packit/requre
+              watchers: 4
+              watchers_count: 4
+            _next: null
+            elapsed: 0.268709
+            encoding: utf-8
+            headers:
+              Access-Control-Allow-Origin: '*'
+              Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+                X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Reset,
+                X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type,
+                Deprecation, Sunset
+              Cache-Control: private, max-age=60, s-maxage=60
+              Content-Encoding: gzip
+              Content-Security-Policy: default-src 'none'
+              Content-Type: application/json; charset=utf-8
+              Date: Thu, 22 Oct 2020 11:09:06 GMT
+              ETag: W/"6f02e1e8a9c6bd568caca9eadca3b810f904f0e050f189f63535b06993cbb9f9"
+              Last-Modified: Wed, 21 Oct 2020 12:18:14 GMT
+              Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+              Server: GitHub.com
+              Status: 200 OK
+              Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+              Transfer-Encoding: chunked
+              Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                Accept, X-Requested-With, Accept-Encoding
+              X-Accepted-OAuth-Scopes: repo
+              X-Content-Type-Options: nosniff
+              X-Frame-Options: deny
+              X-GitHub-Media-Type: github.v3; format=json
+              X-GitHub-Request-Id: AE9C:0EDB:120F4BE8:14D0C89D:5F916852
+              X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
+                admin:repo_hook, delete_repo, gist, notifications, repo, user, workflow,
+                write:discussion
+              X-RateLimit-Limit: '5000'
+              X-RateLimit-Remaining: '4999'
+              X-RateLimit-Reset: '1603368546'
+              X-RateLimit-Used: '1'
+              X-XSS-Protection: 1; mode=block
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      https://api.github.com:443/repos/packit/requre/contents/.packit.yaml?ref=master:
+        all:
+          metadata:
+            latency: 0.2056739330291748
+            module_call_list:
+            - unittest.case
+            - requre.online_replacing
+            - tests_recording.test_api
+            - tests_recording.testbase
+            - packit.config.package_config
+            - ogr.services.github.project
+            - github.Repository
+            - github.Requester
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+              _links:
+                git: https://api.github.com/repos/packit/requre/git/blobs/d115b8280494d3c9b288c0a739d1c8fa58da1e3b
+                html: https://github.com/packit/requre/blob/master/.packit.yaml
+                self: https://api.github.com/repos/packit/requre/contents/.packit.yaml?ref=master
+              content: 'LS0tCnNwZWNmaWxlX3BhdGg6IGZlZG9yYS9weXRob24tcmVxdXJlLnNwZWMK
+
+                c3luY2VkX2ZpbGVzOgogIC0gZmVkb3JhL2NoYW5nZWxvZwojIGh0dHBzOi8v
+
+                cGFja2l0LmRldi9kb2NzL2NvbmZpZ3VyYXRpb24vI3RvcC1sZXZlbC1rZXlz
+
+                CmRvd25zdHJlYW1fcGFja2FnZV9uYW1lOiBweXRob24tcmVxdXJlCnVwc3Ry
+
+                ZWFtX3Byb2plY3RfdXJsOiBodHRwczovL2dpdGh1Yi5jb20vcGFja2l0L3Jl
+
+                cXVyZQojIHdlIGFyZSBzZXR0aW5nIHRoaXMgc28gd2UgY2FuIHVzZSBwYWNr
+
+                aXQgZnJvbSByZXF1cmUncyBkaXN0LWdpdAojIHBhY2tpdCBjYW4ndCBrbm93
+
+                IHdoYXQncyB0aGUgdXBzdHJlYW0gbmFtZSB3aGVuIHJ1bm5pbmcgZnJvbSBk
+
+                aXN0Z2l0CnVwc3RyZWFtX3BhY2thZ2VfbmFtZTogcmVxdXJlCmFjdGlvbnM6
+
+                CiAgIyB3ZSBuZWVkIHRoaXMgYi9jIGBnaXQgYXJjaGl2ZWAgZG9lc24ndCBw
+
+                dXQgYWxsIHRoZSBtZXRhZGF0YSBpbiB0aGUgdGFyYmFsbDoKICAjICAgTG9v
+
+                a3VwRXJyb3I6IHNldHVwdG9vbHMtc2NtIHdhcyB1bmFibGUgdG8gZGV0ZWN0
+
+                IHZlcnNpb24gZm9yICcvYnVpbGRkaXIvYnVpbGQvQlVJTEQvcmVxdXJlLTAu
+
+                MTEuMScuCiAgIyAgIE1ha2Ugc3VyZSB5b3UncmUgZWl0aGVyIGJ1aWxkaW5n
+
+                IGZyb20gYSBmdWxseSBpbnRhY3QgZ2l0IHJlcG9zaXRvcnkgb3IgUHlQSSB0
+
+                YXJiYWxscy4KICBjcmVhdGUtYXJjaGl2ZToKICAgIC0gcHl0aG9uMyBzZXR1
+
+                cC5weSBzZGlzdCAtLWRpc3QtZGlyIC4vZmVkb3JhLwogICAgLSBiYXNoIC1j
+
+                ICJscyAtMXQgLi9mZWRvcmEvKi50YXIuZ3ogfCBoZWFkIC1uIDEiCiAgZ2V0
+
+                LWN1cnJlbnQtdmVyc2lvbjogcHl0aG9uMyBzZXR1cC5weSAtLXZlcnNpb24K
+
+                am9iczoKICAtIGpvYjogc3luY19mcm9tX2Rvd25zdHJlYW0KICAgIHRyaWdn
+
+                ZXI6IGNvbW1pdAogIC0gam9iOiBwcm9wb3NlX2Rvd25zdHJlYW0KICAgIHRy
+
+                aWdnZXI6IHJlbGVhc2UKICAgIG1ldGFkYXRhOgogICAgICBkaXN0X2dpdF9i
+
+                cmFuY2hlczogZmVkb3JhLWFsbAogIC0gam9iOiBjb3ByX2J1aWxkCiAgICB0
+
+                cmlnZ2VyOiBwdWxsX3JlcXVlc3QKICAgIG1ldGFkYXRhOgogICAgICB0YXJn
+
+                ZXRzOgogICAgICAgIC0gZmVkb3JhLWFsbAogIC0gam9iOiBjb3ByX2J1aWxk
+
+                CiAgICB0cmlnZ2VyOiBjb21taXQKICAgIG1ldGFkYXRhOgogICAgICBicmFu
+
+                Y2g6IG1hc3RlcgogICAgICB0YXJnZXRzOgogICAgICAgIC0gZmVkb3JhLWFs
+
+                bAogICAgICBsaXN0X29uX2hvbWVwYWdlOiBUcnVlCiAgICAgIHByZXNlcnZl
+
+                X3Byb2plY3Q6IFRydWUKICAtIGpvYjogY29wcl9idWlsZAogICAgdHJpZ2dl
+
+                cjogcmVsZWFzZQogICAgbWV0YWRhdGE6CiAgICAgIHRhcmdldHM6CiAgICAg
+
+                ICAgLSBmZWRvcmEtYWxsCiAgICAgIGxpc3Rfb25faG9tZXBhZ2U6IFRydWUK
+
+                ICAgICAgcHJlc2VydmVfcHJvamVjdDogVHJ1ZQo=
+
+                '
+              download_url: https://raw.githubusercontent.com/packit/requre/master/.packit.yaml
+              encoding: base64
+              git_url: https://api.github.com/repos/packit/requre/git/blobs/d115b8280494d3c9b288c0a739d1c8fa58da1e3b
+              html_url: https://github.com/packit/requre/blob/master/.packit.yaml
+              name: .packit.yaml
+              path: .packit.yaml
+              sha: d115b8280494d3c9b288c0a739d1c8fa58da1e3b
+              size: 1424
+              type: file
+              url: https://api.github.com/repos/packit/requre/contents/.packit.yaml?ref=master
+            _next: null
+            elapsed: 0.202308
+            encoding: utf-8
+            headers:
+              Access-Control-Allow-Origin: '*'
+              Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+                X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Reset,
+                X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type,
+                Deprecation, Sunset
+              Cache-Control: private, max-age=60, s-maxage=60
+              Content-Encoding: gzip
+              Content-Security-Policy: default-src 'none'
+              Content-Type: application/json; charset=utf-8
+              Date: Thu, 22 Oct 2020 11:09:07 GMT
+              ETag: W/"d115b8280494d3c9b288c0a739d1c8fa58da1e3b"
+              Last-Modified: Wed, 21 Oct 2020 12:18:10 GMT
+              Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+              Server: GitHub.com
+              Status: 200 OK
+              Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+              Transfer-Encoding: chunked
+              Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                Accept, X-Requested-With, Accept-Encoding
+              X-Accepted-OAuth-Scopes: ''
+              X-Content-Type-Options: nosniff
+              X-Frame-Options: deny
+              X-GitHub-Media-Type: github.v3; format=json
+              X-GitHub-Request-Id: AE9C:0EDB:120F4CC0:14D0C8C9:5F916852
+              X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
+                admin:repo_hook, delete_repo, gist, notifications, repo, user, workflow,
+                write:discussion
+              X-RateLimit-Limit: '5000'
+              X-RateLimit-Remaining: '4998'
+              X-RateLimit-Reset: '1603368546'
+              X-RateLimit-Used: '2'
+              X-XSS-Protection: 1; mode=block
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      https://api.github.com:443/repos/packit/requre/contents/?ref=master:
+        all:
+          metadata:
+            latency: 0.20084142684936523
+            module_call_list:
+            - unittest.case
+            - requre.online_replacing
+            - tests_recording.test_api
+            - tests_recording.testbase
+            - packit.config.package_config
+            - ogr.services.github.project
+            - github.Repository
+            - github.Requester
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/trees/0aa474ce2a82ce5a75d6cd9f24b708e0c4e53c9d
+                html: https://github.com/packit/requre/tree/master/.github
+                self: https://api.github.com/repos/packit/requre/contents/.github?ref=master
+              download_url: null
+              git_url: https://api.github.com/repos/packit/requre/git/trees/0aa474ce2a82ce5a75d6cd9f24b708e0c4e53c9d
+              html_url: https://github.com/packit/requre/tree/master/.github
+              name: .github
+              path: .github
+              sha: 0aa474ce2a82ce5a75d6cd9f24b708e0c4e53c9d
+              size: 0
+              type: dir
+              url: https://api.github.com/repos/packit/requre/contents/.github?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/blobs/894a44cc066a027465cd26d634948d56d13af9af
+                html: https://github.com/packit/requre/blob/master/.gitignore
+                self: https://api.github.com/repos/packit/requre/contents/.gitignore?ref=master
+              download_url: https://raw.githubusercontent.com/packit/requre/master/.gitignore
+              git_url: https://api.github.com/repos/packit/requre/git/blobs/894a44cc066a027465cd26d634948d56d13af9af
+              html_url: https://github.com/packit/requre/blob/master/.gitignore
+              name: .gitignore
+              path: .gitignore
+              sha: 894a44cc066a027465cd26d634948d56d13af9af
+              size: 1203
+              type: file
+              url: https://api.github.com/repos/packit/requre/contents/.gitignore?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/blobs/d115b8280494d3c9b288c0a739d1c8fa58da1e3b
+                html: https://github.com/packit/requre/blob/master/.packit.yaml
+                self: https://api.github.com/repos/packit/requre/contents/.packit.yaml?ref=master
+              download_url: https://raw.githubusercontent.com/packit/requre/master/.packit.yaml
+              git_url: https://api.github.com/repos/packit/requre/git/blobs/d115b8280494d3c9b288c0a739d1c8fa58da1e3b
+              html_url: https://github.com/packit/requre/blob/master/.packit.yaml
+              name: .packit.yaml
+              path: .packit.yaml
+              sha: d115b8280494d3c9b288c0a739d1c8fa58da1e3b
+              size: 1424
+              type: file
+              url: https://api.github.com/repos/packit/requre/contents/.packit.yaml?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/blobs/7fb3591cb03af08b19cc0c3b2bbb6d3cf544d8fb
+                html: https://github.com/packit/requre/blob/master/.pre-commit-config.yaml
+                self: https://api.github.com/repos/packit/requre/contents/.pre-commit-config.yaml?ref=master
+              download_url: https://raw.githubusercontent.com/packit/requre/master/.pre-commit-config.yaml
+              git_url: https://api.github.com/repos/packit/requre/git/blobs/7fb3591cb03af08b19cc0c3b2bbb6d3cf544d8fb
+              html_url: https://github.com/packit/requre/blob/master/.pre-commit-config.yaml
+              name: .pre-commit-config.yaml
+              path: .pre-commit-config.yaml
+              sha: 7fb3591cb03af08b19cc0c3b2bbb6d3cf544d8fb
+              size: 1159
+              type: file
+              url: https://api.github.com/repos/packit/requre/contents/.pre-commit-config.yaml?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/blobs/c84199ac2bf81c70e53aaf6701997b0d475e80ff
+                html: https://github.com/packit/requre/blob/master/.pre-commit-hooks.yaml
+                self: https://api.github.com/repos/packit/requre/contents/.pre-commit-hooks.yaml?ref=master
+              download_url: https://raw.githubusercontent.com/packit/requre/master/.pre-commit-hooks.yaml
+              git_url: https://api.github.com/repos/packit/requre/git/blobs/c84199ac2bf81c70e53aaf6701997b0d475e80ff
+              html_url: https://github.com/packit/requre/blob/master/.pre-commit-hooks.yaml
+              name: .pre-commit-hooks.yaml
+              path: .pre-commit-hooks.yaml
+              sha: c84199ac2bf81c70e53aaf6701997b0d475e80ff
+              size: 1608
+              type: file
+              url: https://api.github.com/repos/packit/requre/contents/.pre-commit-hooks.yaml?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/blobs/e9aa8051f60dcab00e294c406d7bd1cd0a4c7b26
+                html: https://github.com/packit/requre/blob/master/.zuul.yaml
+                self: https://api.github.com/repos/packit/requre/contents/.zuul.yaml?ref=master
+              download_url: https://raw.githubusercontent.com/packit/requre/master/.zuul.yaml
+              git_url: https://api.github.com/repos/packit/requre/git/blobs/e9aa8051f60dcab00e294c406d7bd1cd0a4c7b26
+              html_url: https://github.com/packit/requre/blob/master/.zuul.yaml
+              name: .zuul.yaml
+              path: .zuul.yaml
+              sha: e9aa8051f60dcab00e294c406d7bd1cd0a4c7b26
+              size: 697
+              type: file
+              url: https://api.github.com/repos/packit/requre/contents/.zuul.yaml?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/blobs/74a08b9f4ad3eb76690be44f2b8f75b2a04ef493
+                html: https://github.com/packit/requre/blob/master/CONTRIBUTING.md
+                self: https://api.github.com/repos/packit/requre/contents/CONTRIBUTING.md?ref=master
+              download_url: https://raw.githubusercontent.com/packit/requre/master/CONTRIBUTING.md
+              git_url: https://api.github.com/repos/packit/requre/git/blobs/74a08b9f4ad3eb76690be44f2b8f75b2a04ef493
+              html_url: https://github.com/packit/requre/blob/master/CONTRIBUTING.md
+              name: CONTRIBUTING.md
+              path: CONTRIBUTING.md
+              sha: 74a08b9f4ad3eb76690be44f2b8f75b2a04ef493
+              size: 238
+              type: file
+              url: https://api.github.com/repos/packit/requre/contents/CONTRIBUTING.md?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/blobs/8201f992154a14a7fcd95a5937d5c40c610990c9
+                html: https://github.com/packit/requre/blob/master/DCO
+                self: https://api.github.com/repos/packit/requre/contents/DCO?ref=master
+              download_url: https://raw.githubusercontent.com/packit/requre/master/DCO
+              git_url: https://api.github.com/repos/packit/requre/git/blobs/8201f992154a14a7fcd95a5937d5c40c610990c9
+              html_url: https://github.com/packit/requre/blob/master/DCO
+              name: DCO
+              path: DCO
+              sha: 8201f992154a14a7fcd95a5937d5c40c610990c9
+              size: 1421
+              type: file
+              url: https://api.github.com/repos/packit/requre/contents/DCO?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/blobs/3e3a7a6fc84303c6f3ec70f204430899eaec0a40
+                html: https://github.com/packit/requre/blob/master/Dockerfile.tests
+                self: https://api.github.com/repos/packit/requre/contents/Dockerfile.tests?ref=master
+              download_url: https://raw.githubusercontent.com/packit/requre/master/Dockerfile.tests
+              git_url: https://api.github.com/repos/packit/requre/git/blobs/3e3a7a6fc84303c6f3ec70f204430899eaec0a40
+              html_url: https://github.com/packit/requre/blob/master/Dockerfile.tests
+              name: Dockerfile.tests
+              path: Dockerfile.tests
+              sha: 3e3a7a6fc84303c6f3ec70f204430899eaec0a40
+              size: 206
+              type: file
+              url: https://api.github.com/repos/packit/requre/contents/Dockerfile.tests?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/blobs/5cb23a21a2a206185ec1b62429baec88b5198821
+                html: https://github.com/packit/requre/blob/master/LICENSE
+                self: https://api.github.com/repos/packit/requre/contents/LICENSE?ref=master
+              download_url: https://raw.githubusercontent.com/packit/requre/master/LICENSE
+              git_url: https://api.github.com/repos/packit/requre/git/blobs/5cb23a21a2a206185ec1b62429baec88b5198821
+              html_url: https://github.com/packit/requre/blob/master/LICENSE
+              name: LICENSE
+              path: LICENSE
+              sha: 5cb23a21a2a206185ec1b62429baec88b5198821
+              size: 1063
+              type: file
+              url: https://api.github.com/repos/packit/requre/contents/LICENSE?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/blobs/cd564a3994f077b6f9193e8322c93851395a8fa2
+                html: https://github.com/packit/requre/blob/master/Makefile
+                self: https://api.github.com/repos/packit/requre/contents/Makefile?ref=master
+              download_url: https://raw.githubusercontent.com/packit/requre/master/Makefile
+              git_url: https://api.github.com/repos/packit/requre/git/blobs/cd564a3994f077b6f9193e8322c93851395a8fa2
+              html_url: https://github.com/packit/requre/blob/master/Makefile
+              name: Makefile
+              path: Makefile
+              sha: cd564a3994f077b6f9193e8322c93851395a8fa2
+              size: 604
+              type: file
+              url: https://api.github.com/repos/packit/requre/contents/Makefile?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/blobs/da4c6034b0e3af8352884f9b7cd0941c0f2d4b5d
+                html: https://github.com/packit/requre/blob/master/README.md
+                self: https://api.github.com/repos/packit/requre/contents/README.md?ref=master
+              download_url: https://raw.githubusercontent.com/packit/requre/master/README.md
+              git_url: https://api.github.com/repos/packit/requre/git/blobs/da4c6034b0e3af8352884f9b7cd0941c0f2d4b5d
+              html_url: https://github.com/packit/requre/blob/master/README.md
+              name: README.md
+              path: README.md
+              sha: da4c6034b0e3af8352884f9b7cd0941c0f2d4b5d
+              size: 967
+              type: file
+              url: https://api.github.com/repos/packit/requre/contents/README.md?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/blobs/3332f2db67e65b2f48961dc799202177bcafc07f
+                html: https://github.com/packit/requre/blob/master/ci.fmf
+                self: https://api.github.com/repos/packit/requre/contents/ci.fmf?ref=master
+              download_url: https://raw.githubusercontent.com/packit/requre/master/ci.fmf
+              git_url: https://api.github.com/repos/packit/requre/git/blobs/3332f2db67e65b2f48961dc799202177bcafc07f
+              html_url: https://github.com/packit/requre/blob/master/ci.fmf
+              name: ci.fmf
+              path: ci.fmf
+              sha: 3332f2db67e65b2f48961dc799202177bcafc07f
+              size: 225
+              type: file
+              url: https://api.github.com/repos/packit/requre/contents/ci.fmf?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/trees/2c3a0d48563fb293102ba5e4a6cc27e44b18a06c
+                html: https://github.com/packit/requre/tree/master/docs
+                self: https://api.github.com/repos/packit/requre/contents/docs?ref=master
+              download_url: null
+              git_url: https://api.github.com/repos/packit/requre/git/trees/2c3a0d48563fb293102ba5e4a6cc27e44b18a06c
+              html_url: https://github.com/packit/requre/tree/master/docs
+              name: docs
+              path: docs
+              sha: 2c3a0d48563fb293102ba5e4a6cc27e44b18a06c
+              size: 0
+              type: dir
+              url: https://api.github.com/repos/packit/requre/contents/docs?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/trees/a47f49275991217d8bd05cb2f2baaec8bcdb9a8e
+                html: https://github.com/packit/requre/tree/master/examples
+                self: https://api.github.com/repos/packit/requre/contents/examples?ref=master
+              download_url: null
+              git_url: https://api.github.com/repos/packit/requre/git/trees/a47f49275991217d8bd05cb2f2baaec8bcdb9a8e
+              html_url: https://github.com/packit/requre/tree/master/examples
+              name: examples
+              path: examples
+              sha: a47f49275991217d8bd05cb2f2baaec8bcdb9a8e
+              size: 0
+              type: dir
+              url: https://api.github.com/repos/packit/requre/contents/examples?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/trees/f07d1341cc7f544f43dc395ed19e65a7e6c51b3b
+                html: https://github.com/packit/requre/tree/master/fedora
+                self: https://api.github.com/repos/packit/requre/contents/fedora?ref=master
+              download_url: null
+              git_url: https://api.github.com/repos/packit/requre/git/trees/f07d1341cc7f544f43dc395ed19e65a7e6c51b3b
+              html_url: https://github.com/packit/requre/tree/master/fedora
+              name: fedora
+              path: fedora
+              sha: f07d1341cc7f544f43dc395ed19e65a7e6c51b3b
+              size: 0
+              type: dir
+              url: https://api.github.com/repos/packit/requre/contents/fedora?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/trees/1c65764bf6541feeb65b1820a3b5be833dc62136
+                html: https://github.com/packit/requre/tree/master/files
+                self: https://api.github.com/repos/packit/requre/contents/files?ref=master
+              download_url: null
+              git_url: https://api.github.com/repos/packit/requre/git/trees/1c65764bf6541feeb65b1820a3b5be833dc62136
+              html_url: https://github.com/packit/requre/tree/master/files
+              name: files
+              path: files
+              sha: 1c65764bf6541feeb65b1820a3b5be833dc62136
+              size: 0
+              type: dir
+              url: https://api.github.com/repos/packit/requre/contents/files?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/trees/d50c2379a8c2dfd4316a91fb149229fd2c64d1ec
+                html: https://github.com/packit/requre/tree/master/requre
+                self: https://api.github.com/repos/packit/requre/contents/requre?ref=master
+              download_url: null
+              git_url: https://api.github.com/repos/packit/requre/git/trees/d50c2379a8c2dfd4316a91fb149229fd2c64d1ec
+              html_url: https://github.com/packit/requre/tree/master/requre
+              name: requre
+              path: requre
+              sha: d50c2379a8c2dfd4316a91fb149229fd2c64d1ec
+              size: 0
+              type: dir
+              url: https://api.github.com/repos/packit/requre/contents/requre?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/blobs/71615dbb8e91325f049c3822645862c06c4d4e0d
+                html: https://github.com/packit/requre/blob/master/setup.cfg
+                self: https://api.github.com/repos/packit/requre/contents/setup.cfg?ref=master
+              download_url: https://raw.githubusercontent.com/packit/requre/master/setup.cfg
+              git_url: https://api.github.com/repos/packit/requre/git/blobs/71615dbb8e91325f049c3822645862c06c4d4e0d
+              html_url: https://github.com/packit/requre/blob/master/setup.cfg
+              name: setup.cfg
+              path: setup.cfg
+              sha: 71615dbb8e91325f049c3822645862c06c4d4e0d
+              size: 1197
+              type: file
+              url: https://api.github.com/repos/packit/requre/contents/setup.cfg?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/blobs/3a63b8938864feaa6b8c4e2e0653eb0050bd32b6
+                html: https://github.com/packit/requre/blob/master/setup.py
+                self: https://api.github.com/repos/packit/requre/contents/setup.py?ref=master
+              download_url: https://raw.githubusercontent.com/packit/requre/master/setup.py
+              git_url: https://api.github.com/repos/packit/requre/git/blobs/3a63b8938864feaa6b8c4e2e0653eb0050bd32b6
+              html_url: https://github.com/packit/requre/blob/master/setup.py
+              name: setup.py
+              path: setup.py
+              sha: 3a63b8938864feaa6b8c4e2e0653eb0050bd32b6
+              size: 1191
+              type: file
+              url: https://api.github.com/repos/packit/requre/contents/setup.py?ref=master
+            - _links:
+                git: https://api.github.com/repos/packit/requre/git/trees/84c621e54729aae0b18c8698de0ece25acc697cf
+                html: https://github.com/packit/requre/tree/master/tests
+                self: https://api.github.com/repos/packit/requre/contents/tests?ref=master
+              download_url: null
+              git_url: https://api.github.com/repos/packit/requre/git/trees/84c621e54729aae0b18c8698de0ece25acc697cf
+              html_url: https://github.com/packit/requre/tree/master/tests
+              name: tests
+              path: tests
+              sha: 84c621e54729aae0b18c8698de0ece25acc697cf
+              size: 0
+              type: dir
+              url: https://api.github.com/repos/packit/requre/contents/tests?ref=master
+            _next: null
+            elapsed: 0.196576
+            encoding: utf-8
+            headers:
+              Access-Control-Allow-Origin: '*'
+              Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+                X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Reset,
+                X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type,
+                Deprecation, Sunset
+              Cache-Control: private, max-age=60, s-maxage=60
+              Content-Encoding: gzip
+              Content-Security-Policy: default-src 'none'
+              Content-Type: application/json; charset=utf-8
+              Date: Thu, 22 Oct 2020 11:09:07 GMT
+              ETag: W/"c5b8b774e456765e129ff2d31c58a8b39321aae9"
+              Last-Modified: Wed, 21 Oct 2020 12:18:14 GMT
+              Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+              Server: GitHub.com
+              Status: 200 OK
+              Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+              Transfer-Encoding: chunked
+              Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding,
+                Accept, X-Requested-With, Accept-Encoding
+              X-Accepted-OAuth-Scopes: ''
+              X-Content-Type-Options: nosniff
+              X-Frame-Options: deny
+              X-GitHub-Media-Type: github.v3; format=json
+              X-GitHub-Request-Id: AE9C:0EDB:120F4D0F:14D0C9CD:5F916853
+              X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
+                admin:repo_hook, delete_repo, gist, notifications, repo, user, workflow,
+                write:discussion
+              X-RateLimit-Limit: '5000'
+              X-RateLimit-Remaining: '4997'
+              X-RateLimit-Reset: '1603368546'
+              X-RateLimit-Used: '3'
+              X-XSS-Protection: 1; mode=block
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      https://release-monitoring.org/api/project/Fedora/python-requre:
+        all:
+          metadata:
+            latency: 0.561603307723999
+            module_call_list:
+            - unittest.case
+            - requre.online_replacing
+            - tests_recording.test_api
+            - packit.api
+            - packit.upstream
+            - packit.specfile
+            - rebasehelper.plugins.versioneers
+            - rebasehelper.plugins.versioneers.anitya
+            - rebasehelper.helpers.download_helper
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+              error: No package "python-requre" found in distro "Fedora"
+              output: notok
+            _next: null
+            elapsed: 0.555076
+            encoding: null
+            headers:
+              AppTime: D=13834
+              Cache-control: private
+              Connection: Keep-Alive
+              Content-Length: '85'
+              Content-Type: application/json
+              Date: Thu, 22 Oct 2020 11:09:13 GMT
+              Keep-Alive: timeout=15, max=500
+              Referrer-Policy: same-origin
+              Server: Apache/2.4.43 (Fedora) mod_wsgi/4.6.8 Python/3.8
+              Set-Cookie: c7f2af7958ac7bdd3fe2e687de986bfb=7cae610e4cf6736df18311d667aeabcc;
+                path=/; HttpOnly; Secure
+              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+              X-Content-Type-Options: nosniff
+              X-Fedora-ProxyServer: proxy10.iad2.fedoraproject.org
+              X-Fedora-RequestID: X5FoWZvH-J5sCNJQVusXEgAACs0
+              X-Frame-Options: SAMEORIGIN
+              X-Xss-Protection: 1; mode=block
+            raw: !!binary ""
+            reason: NOT FOUND
+            status_code: 404
+      https://release-monitoring.org/api/projects?pattern=python-requre:
+        all:
+          metadata:
+            latency: 1.1579477787017822
+            module_call_list:
+            - unittest.case
+            - requre.online_replacing
+            - tests_recording.test_api
+            - packit.api
+            - packit.upstream
+            - packit.specfile
+            - rebasehelper.plugins.versioneers
+            - rebasehelper.plugins.versioneers.anitya
+            - rebasehelper.helpers.download_helper
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+              projects: []
+              total: 0
+            _next: null
+            elapsed: 1.151768
+            encoding: null
+            headers:
+              AppTime: D=771802
+              Cache-control: private
+              Connection: Keep-Alive
+              Content-Length: '26'
+              Content-Type: application/json
+              Date: Thu, 22 Oct 2020 11:09:13 GMT
+              Keep-Alive: timeout=15, max=500
+              Referrer-Policy: same-origin
+              Server: Apache/2.4.43 (Fedora) mod_wsgi/4.6.8 Python/3.8
+              Set-Cookie: c7f2af7958ac7bdd3fe2e687de986bfb=7cae610e4cf6736df18311d667aeabcc;
+                path=/; HttpOnly; Secure
+              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+              X-Content-Type-Options: nosniff
+              X-Fedora-ProxyServer: proxy01.iad2.fedoraproject.org
+              X-Fedora-RequestID: X5FoWR0j4PPDee@G7BOqKAAACpI
+              X-Frame-Options: SAMEORIGIN
+              X-Xss-Protection: 1; mode=block
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      https://src.fedoraproject.org/api/0/fork/jscotka/rpms/python-requre:
+        all:
+          metadata:
+            latency: 0.49146103858947754
+            module_call_list:
+            - unittest.case
+            - requre.online_replacing
+            - tests_recording.test_api
+            - packit.api
+            - packit.distgit
+            - ogr.services.pagure.project
+            - ogr.services.pagure.service
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+              access_groups:
+                admin: []
+                collaborator: []
+                commit: []
+                ticket: []
+              access_users:
+                admin: []
+                collaborator: []
+                commit: []
+                owner:
+                - jscotka
+                ticket: []
+              close_status: []
+              custom_keys: []
+              date_created: '1600700802'
+              date_modified: '1600700802'
+              description: The python-requre package
+              fullname: forks/jscotka/rpms/python-requre
+              id: 45827
+              milestones: {}
+              name: python-requre
+              namespace: rpms
+              parent:
+                access_groups:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  ticket: []
+                access_users:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  owner:
+                  - jscotka
+                  ticket: []
+                close_status: []
+                custom_keys: []
+                date_created: '1586178839'
+                date_modified: '1586178846'
+                description: The python-requre package
+                fullname: rpms/python-requre
+                id: 41574
+                milestones: {}
+                name: python-requre
+                namespace: rpms
+                parent: null
+                priorities: {}
+                tags: []
+                url_path: rpms/python-requre
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              priorities: {}
+              tags: []
+              url_path: fork/jscotka/rpms/python-requre
+              user:
+                fullname: "Jan \u0160\u010Dotka"
+                name: jscotka
+                url_path: user/jscotka
+            _next: null
+            elapsed: 0.48986
+            encoding: null
+            headers:
+              Connection: Keep-Alive
+              Date: Thu, 22 Oct 2020 11:09:29 GMT
+              Keep-Alive: timeout=15, max=492
+              Referrer-Policy: same-origin
+              Server: Apache
+              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+              X-Content-Type-Options: nosniff
+              X-Fedora-ProxyServer: proxy01.iad2.fedoraproject.org
+              X-Fedora-RequestID: X5FoaRMw6wZpoU8gnSwcqAAABUM
+              X-Frame-Options: SAMEORIGIN
+              X-Xss-Protection: 1; mode=block
+              apptime: D=374248
+              content-length: '1578'
+              content-security-policy: default-src 'self'; script-src 'self' 'nonce-AvgzJJ00TJbGvB1PaAb5tEEqc'
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
+                'self' 'nonce-AvgzJJ00TJbGvB1PaAb5tEEqc'; object-src 'none'; base-uri
+                'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
+              content-type: application/json
+              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYmU2NmNiMDk2ZGU2YTAwZGQ5ODliOTE5YTIyZWY5OTc2MTRmNDQzOCJ9.EnL56Q.Dhjz5KoPq_h_fya6K1cmkXZkY_A;
+                Expires=Sun, 22-Nov-2020 11:09:29 GMT; Secure; HttpOnly; Path=/
+              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      https://src.fedoraproject.org/api/0/fork/lachmanfrantisek/rpms/python-requre:
+        all:
+          metadata:
+            latency: 0.28373122215270996
+            module_call_list:
+            - unittest.case
+            - requre.online_replacing
+            - tests_recording.test_api
+            - packit.api
+            - packit.distgit
+            - ogr.read_only
+            - ogr.services.pagure.project
+            - ogr.services.pagure.pull_request
+            - ogr.services.pagure.project
+            - ogr.services.pagure.service
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+              access_groups:
+                admin: []
+                collaborator: []
+                commit: []
+                ticket: []
+              access_users:
+                admin: []
+                collaborator: []
+                commit: []
+                owner:
+                - lachmanfrantisek
+                ticket: []
+              close_status: []
+              custom_keys: []
+              date_created: '1600763657'
+              date_modified: '1600763657'
+              description: The python-requre package
+              fullname: forks/lachmanfrantisek/rpms/python-requre
+              id: 45852
+              milestones: {}
+              name: python-requre
+              namespace: rpms
+              parent:
+                access_groups:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  ticket: []
+                access_users:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  owner:
+                  - jscotka
+                  ticket: []
+                close_status: []
+                custom_keys: []
+                date_created: '1586178839'
+                date_modified: '1586178846'
+                description: The python-requre package
+                fullname: rpms/python-requre
+                id: 41574
+                milestones: {}
+                name: python-requre
+                namespace: rpms
+                parent: null
+                priorities: {}
+                tags: []
+                url_path: rpms/python-requre
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              priorities: {}
+              tags: []
+              url_path: fork/lachmanfrantisek/rpms/python-requre
+              user:
+                fullname: "Franti\u0161ek Lachman"
+                name: lachmanfrantisek
+                url_path: user/lachmanfrantisek
+            _next: null
+            elapsed: 0.277721
+            encoding: null
+            headers:
+              Connection: Keep-Alive
+              Date: Thu, 22 Oct 2020 11:09:31 GMT
+              Keep-Alive: timeout=15, max=488
+              Referrer-Policy: same-origin
+              Server: Apache
+              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+              X-Content-Type-Options: nosniff
+              X-Fedora-ProxyServer: proxy01.iad2.fedoraproject.org
+              X-Fedora-RequestID: X5FoaxMw6wZpoU8gnSwcwgAABUA
+              X-Frame-Options: SAMEORIGIN
+              X-Xss-Protection: 1; mode=block
+              apptime: D=149526
+              content-length: '1625'
+              content-security-policy: default-src 'self'; script-src 'self' 'nonce-0vMVrFq9RWqQwDLLuDSQnpnIj'
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
+                'self' 'nonce-0vMVrFq9RWqQwDLLuDSQnpnIj'; object-src 'none'; base-uri
+                'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
+              content-type: application/json
+              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYmU2NmNiMDk2ZGU2YTAwZGQ5ODliOTE5YTIyZWY5OTc2MTRmNDQzOCJ9.EnL56w.xtBb5t3j5QlWi578ugNLGVeR1i0;
+                Expires=Sun, 22-Nov-2020 11:09:31 GMT; Secure; HttpOnly; Path=/
+              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      https://src.fedoraproject.org/api/0/fork/lachmanfrantisek/rpms/python-requre/git/urls:
+        all:
+          metadata:
+            latency: 0.20321226119995117
+            module_call_list:
+            - unittest.case
+            - requre.online_replacing
+            - tests_recording.test_api
+            - packit.api
+            - packit.distgit
+            - ogr.services.pagure.project
+            - ogr.services.pagure.service
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+              total_urls: 2
+              urls:
+                git: https://src.fedoraproject.org/forks/lachmanfrantisek/rpms/python-requre.git
+                ssh: ssh://lachmanfrantisek@pkgs.fedoraproject.org/forks/lachmanfrantisek/rpms/python-requre.git
+            _next: null
+            elapsed: 0.196947
+            encoding: null
+            headers:
+              Connection: Keep-Alive
+              Date: Thu, 22 Oct 2020 11:09:21 GMT
+              Keep-Alive: timeout=15, max=494
+              Referrer-Policy: same-origin
+              Server: Apache
+              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+              X-Content-Type-Options: nosniff
+              X-Fedora-ProxyServer: proxy01.iad2.fedoraproject.org
+              X-Fedora-RequestID: X5FoYRMw6wZpoU8gnSwcBAAABUs
+              X-Frame-Options: SAMEORIGIN
+              X-Xss-Protection: 1; mode=block
+              apptime: D=68987
+              content-length: '236'
+              content-security-policy: default-src 'self'; script-src 'self' 'nonce-LQyhJs1kETCB1eNPKZfBEo5pp'
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
+                'self' 'nonce-LQyhJs1kETCB1eNPKZfBEo5pp'; object-src 'none'; base-uri
+                'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
+              content-type: application/json
+              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYmU2NmNiMDk2ZGU2YTAwZGQ5ODliOTE5YTIyZWY5OTc2MTRmNDQzOCJ9.EnL54Q.1I3uUmqQQKlaCu70IgpeUemQ7MM;
+                Expires=Sun, 22-Nov-2020 11:09:21 GMT; Secure; HttpOnly; Path=/
+              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      https://src.fedoraproject.org/api/0/fork/packit/rpms/python-requre:
+        all:
+          metadata:
+            latency: 0.4982006549835205
+            module_call_list:
+            - unittest.case
+            - requre.online_replacing
+            - tests_recording.test_api
+            - packit.api
+            - packit.distgit
+            - ogr.services.pagure.project
+            - ogr.services.pagure.service
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+              access_groups:
+                admin: []
+                collaborator: []
+                commit: []
+                ticket: []
+              access_users:
+                admin: []
+                collaborator: []
+                commit: []
+                owner:
+                - packit
+                ticket: []
+              close_status: []
+              custom_keys: []
+              date_created: '1600761157'
+              date_modified: '1600761157'
+              description: The python-requre package
+              fullname: forks/packit/rpms/python-requre
+              id: 45851
+              milestones: {}
+              name: python-requre
+              namespace: rpms
+              parent:
+                access_groups:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  ticket: []
+                access_users:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  owner:
+                  - jscotka
+                  ticket: []
+                close_status: []
+                custom_keys: []
+                date_created: '1586178839'
+                date_modified: '1586178846'
+                description: The python-requre package
+                fullname: rpms/python-requre
+                id: 41574
+                milestones: {}
+                name: python-requre
+                namespace: rpms
+                parent: null
+                priorities: {}
+                tags: []
+                url_path: rpms/python-requre
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              priorities: {}
+              tags: []
+              url_path: fork/packit/rpms/python-requre
+              user:
+                fullname: Packit Bot
+                name: packit
+                url_path: user/packit
+            _next: null
+            elapsed: 0.491856
+            encoding: null
+            headers:
+              Connection: Keep-Alive
+              Date: Thu, 22 Oct 2020 11:09:29 GMT
+              Keep-Alive: timeout=15, max=491
+              Referrer-Policy: same-origin
+              Server: Apache
+              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+              X-Content-Type-Options: nosniff
+              X-Fedora-ProxyServer: proxy01.iad2.fedoraproject.org
+              X-Fedora-RequestID: X5FoaRMw6wZpoU8gnSwcsAAABVc
+              X-Frame-Options: SAMEORIGIN
+              X-Xss-Protection: 1; mode=block
+              apptime: D=362558
+              content-length: '1563'
+              content-security-policy: default-src 'self'; script-src 'self' 'nonce-Z5Ko4CMVnykbkqcFXZKnrM4gI'
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
+                'self' 'nonce-Z5Ko4CMVnykbkqcFXZKnrM4gI'; object-src 'none'; base-uri
+                'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
+              content-type: application/json
+              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYmU2NmNiMDk2ZGU2YTAwZGQ5ODliOTE5YTIyZWY5OTc2MTRmNDQzOCJ9.EnL56g.9bp9IrXQcmbUANzxG07rfWPs_DI;
+                Expires=Sun, 22-Nov-2020 11:09:30 GMT; Secure; HttpOnly; Path=/
+              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      https://src.fedoraproject.org/api/0/projects?fork=True&pattern=python-requre:
+        all:
+          metadata:
+            latency: 0.37447309494018555
+            module_call_list:
+            - unittest.case
+            - requre.online_replacing
+            - tests_recording.test_api
+            - packit.api
+            - packit.distgit
+            - ogr.services.pagure.project
+            - ogr.services.pagure.service
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+              args:
+                fork: true
+                namespace: null
+                owner: null
+                page: 1
+                pattern: python-requre
+                per_page: 20
+                short: false
+                tags: []
+                username: null
+              pagination:
+                first: https://src.fedoraproject.org/api/0/projects?per_page=20&fork=True&pattern=python-requre&page=1
+                last: https://src.fedoraproject.org/api/0/projects?per_page=20&fork=True&pattern=python-requre&page=1
+                next: null
+                page: 1
+                pages: 1
+                per_page: 20
+                prev: null
+              projects:
+              - access_groups:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  ticket: []
+                access_users:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  owner:
+                  - jscotka
+                  ticket: []
+                close_status: []
+                custom_keys: []
+                date_created: '1600700802'
+                date_modified: '1600700802'
+                description: The python-requre package
+                fullname: forks/jscotka/rpms/python-requre
+                id: 45827
+                milestones: {}
+                name: python-requre
+                namespace: rpms
+                parent:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                priorities: {}
+                tags: []
+                url_path: fork/jscotka/rpms/python-requre
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              - access_groups:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  ticket: []
+                access_users:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  owner:
+                  - packit
+                  ticket: []
+                close_status: []
+                custom_keys: []
+                date_created: '1600761157'
+                date_modified: '1600761157'
+                description: The python-requre package
+                fullname: forks/packit/rpms/python-requre
+                id: 45851
+                milestones: {}
+                name: python-requre
+                namespace: rpms
+                parent:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                priorities: {}
+                tags: []
+                url_path: fork/packit/rpms/python-requre
+                user:
+                  fullname: Packit Bot
+                  name: packit
+                  url_path: user/packit
+              - access_groups:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  ticket: []
+                access_users:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  owner:
+                  - lachmanfrantisek
+                  ticket: []
+                close_status: []
+                custom_keys: []
+                date_created: '1600763657'
+                date_modified: '1600763657'
+                description: The python-requre package
+                fullname: forks/lachmanfrantisek/rpms/python-requre
+                id: 45852
+                milestones: {}
+                name: python-requre
+                namespace: rpms
+                parent:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                priorities: {}
+                tags: []
+                url_path: fork/lachmanfrantisek/rpms/python-requre
+                user:
+                  fullname: "Franti\u0161ek Lachman"
+                  name: lachmanfrantisek
+                  url_path: user/lachmanfrantisek
+              - access_groups:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  ticket: []
+                access_users:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  owner:
+                  - lbarczio
+                  ticket: []
+                close_status: []
+                custom_keys: []
+                date_created: '1603187163'
+                date_modified: '1603187163'
+                description: The python-requre package
+                fullname: forks/lbarczio/rpms/python-requre
+                id: 46377
+                milestones: {}
+                name: python-requre
+                namespace: rpms
+                parent:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                priorities: {}
+                tags: []
+                url_path: fork/lbarczio/rpms/python-requre
+                user:
+                  fullname: "Laura Barcziov\xE1"
+                  name: lbarczio
+                  url_path: user/lbarczio
+              total_projects: 4
+            _next: null
+            elapsed: 0.367202
+            encoding: null
+            headers:
+              Connection: Keep-Alive
+              Date: Thu, 22 Oct 2020 11:09:28 GMT
+              Keep-Alive: timeout=15, max=493
+              Referrer-Policy: same-origin
+              Server: Apache
+              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+              X-Content-Type-Options: nosniff
+              X-Fedora-ProxyServer: proxy01.iad2.fedoraproject.org
+              X-Fedora-RequestID: X5FoaBMw6wZpoU8gnSwcngAABUE
+              X-Frame-Options: SAMEORIGIN
+              X-Xss-Protection: 1; mode=block
+              apptime: D=237748
+              content-length: '8088'
+              content-security-policy: default-src 'self'; script-src 'self' 'nonce-dcBb4MOWYy5u34jktsPUG5PIE'
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
+                'self' 'nonce-dcBb4MOWYy5u34jktsPUG5PIE'; object-src 'none'; base-uri
+                'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
+              content-type: application/json
+              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYmU2NmNiMDk2ZGU2YTAwZGQ5ODliOTE5YTIyZWY5OTc2MTRmNDQzOCJ9.EnL56A._dWnYJU7RZAyseg6iGaGlYMdZ0Y;
+                Expires=Sun, 22-Nov-2020 11:09:28 GMT; Secure; HttpOnly; Path=/
+              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      https://src.fedoraproject.org/api/0/rpms/python-requre/pull-requests?status=Open:
+        all:
+          metadata:
+            latency: 1.3942897319793701
+            module_call_list:
+            - unittest.case
+            - requre.online_replacing
+            - tests_recording.test_api
+            - packit.api
+            - packit.distgit
+            - ogr.services.pagure.project
+            - ogr.services.pagure.pull_request
+            - ogr.services.pagure.project
+            - ogr.services.pagure.service
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+              args:
+                assignee: null
+                author: null
+                page: 1
+                per_page: 20
+                status: Open
+                tags: []
+              pagination:
+                first: https://src.fedoraproject.org/api/0/rpms/python-requre/pull-requests?per_page=20&status=Open&page=1
+                last: https://src.fedoraproject.org/api/0/rpms/python-requre/pull-requests?per_page=20&status=Open&page=2
+                next: https://src.fedoraproject.org/api/0/rpms/python-requre/pull-requests?per_page=20&status=Open&page=2
+                page: 1
+                pages: 2
+                per_page: 20
+                prev: null
+              requests:
+              - assignee: null
+                branch: master
+                branch_from: 0.5.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments: []
+                commit_start: ec04725b32f8a10594bde0972930b60b1d336067
+                commit_stop: ec04725b32f8a10594bde0972930b60b1d336067
+                date_created: '1603190937'
+                id: 42
+                initial_comment: 'Upstream tag: 0.5.0
+
+                  Upstream commit: e815c39f'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - lbarczio
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1603187163'
+                  date_modified: '1603187163'
+                  description: The python-requre package
+                  fullname: forks/lbarczio/rpms/python-requre
+                  id: 46377
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/lbarczio/rpms/python-requre
+                  user:
+                    fullname: "Laura Barcziov\xE1"
+                    name: lbarczio
+                    url_path: user/lbarczio
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.5.0
+                uid: 63645772baac4205bafae497d9844ea5
+                updated_on: '1603190937'
+                user:
+                  fullname: "Laura Barcziov\xE1"
+                  name: lbarczio
+                  url_path: user/lbarczio
+              - assignee: null
+                branch: master
+                branch_from: 0.4.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments: []
+                commit_start: 4f91816ecedb9fa3c323313725d2e782ac166bce
+                commit_stop: 4f91816ecedb9fa3c323313725d2e782ac166bce
+                date_created: '1603190892'
+                id: 41
+                initial_comment: 'Upstream tag: 0.4.0
+
+                  Upstream commit: 6957453b'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - lbarczio
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1603187163'
+                  date_modified: '1603187163'
+                  description: The python-requre package
+                  fullname: forks/lbarczio/rpms/python-requre
+                  id: 46377
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/lbarczio/rpms/python-requre
+                  user:
+                    fullname: "Laura Barcziov\xE1"
+                    name: lbarczio
+                    url_path: user/lbarczio
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.4.0
+                uid: f876e7aa4d7e4f549169e2f85c3e948c
+                updated_on: '1603191025'
+                user:
+                  fullname: "Laura Barcziov\xE1"
+                  name: lbarczio
+                  url_path: user/lbarczio
+              - assignee: null
+                branch: master
+                branch_from: 0.5.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments: []
+                commit_start: ec04725b32f8a10594bde0972930b60b1d336067
+                commit_stop: ec04725b32f8a10594bde0972930b60b1d336067
+                date_created: '1603187330'
+                id: 40
+                initial_comment: 'Upstream tag: 0.5.0
+
+                  Upstream commit: e815c39f'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - lbarczio
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1603187163'
+                  date_modified: '1603187163'
+                  description: The python-requre package
+                  fullname: forks/lbarczio/rpms/python-requre
+                  id: 46377
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/lbarczio/rpms/python-requre
+                  user:
+                    fullname: "Laura Barcziov\xE1"
+                    name: lbarczio
+                    url_path: user/lbarczio
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.5.0
+                uid: e37eee1d48ea42cbaca4d9f2a83c7b44
+                updated_on: '1603187330'
+                user:
+                  fullname: "Laura Barcziov\xE1"
+                  name: lbarczio
+                  url_path: user/lbarczio
+              - assignee: null
+                branch: master
+                branch_from: 0.4.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto 4f91816ecedb9fa3c323313725d2e782ac166bce
+                  commit: null
+                  date_created: '1603190889'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 59021
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Laura Barcziov\xE1"
+                    name: lbarczio
+                    url_path: user/lbarczio
+                commit_start: 4f91816ecedb9fa3c323313725d2e782ac166bce
+                commit_stop: 4f91816ecedb9fa3c323313725d2e782ac166bce
+                date_created: '1603187176'
+                id: 39
+                initial_comment: 'Upstream tag: 0.4.0
+
+                  Upstream commit: 6957453b'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - lbarczio
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1603187163'
+                  date_modified: '1603187163'
+                  description: The python-requre package
+                  fullname: forks/lbarczio/rpms/python-requre
+                  id: 46377
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/lbarczio/rpms/python-requre
+                  user:
+                    fullname: "Laura Barcziov\xE1"
+                    name: lbarczio
+                    url_path: user/lbarczio
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.4.0
+                uid: 9997c6999d90495e9c7c3a97e044f017
+                updated_on: '1603191048'
+                user:
+                  fullname: "Laura Barcziov\xE1"
+                  name: lbarczio
+                  url_path: user/lbarczio
+              - assignee: null
+                branch: master
+                branch_from: 0.5.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                  commit: null
+                  date_created: '1602159230'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58312
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                commit_start: 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                commit_stop: 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                date_created: '1602156888'
+                id: 38
+                initial_comment: 'Upstream tag: 0.5.0
+
+                  Upstream commit: 87808f12'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600700802'
+                  date_modified: '1600700802'
+                  description: The python-requre package
+                  fullname: forks/jscotka/rpms/python-requre
+                  id: 45827
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/jscotka/rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.5.0
+                uid: 364674a92c2c442aae436ff7e81a09b3
+                updated_on: '1602159230'
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              - assignee: null
+                branch: master
+                branch_from: 0.4.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                  commit: null
+                  date_created: '1602159213'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58294
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                commit_start: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                commit_stop: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                date_created: '1602156845'
+                id: 37
+                initial_comment: 'Upstream tag: 0.4.0
+
+                  Upstream commit: 6957453b'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600700802'
+                  date_modified: '1600700802'
+                  description: The python-requre package
+                  fullname: forks/jscotka/rpms/python-requre
+                  id: 45827
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/jscotka/rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.4.0
+                uid: 10b7f68310f8485f9ed3c021526342e7
+                updated_on: '1602159525'
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              - assignee: null
+                branch: master
+                branch_from: 0.5.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto 9c3150bbc0676f0c279e2f589b9e99c2eb323aa9
+                  commit: null
+                  date_created: '1602156190'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58256
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 4cf77c217d59dbcea7bfdd4bb12f3bd4394c66b2
+                  commit: null
+                  date_created: '1602156885'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58280
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                  commit: null
+                  date_created: '1602159230'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58309
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                commit_start: 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                commit_stop: 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                date_created: '1602058076'
+                id: 36
+                initial_comment: 'Upstream tag: 0.5.0
+
+                  Upstream commit: 87808f12'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600700802'
+                  date_modified: '1600700802'
+                  description: The python-requre package
+                  fullname: forks/jscotka/rpms/python-requre
+                  id: 45827
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/jscotka/rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.5.0
+                uid: 4c9421d4b31f41d0b4e68879777cf79b
+                updated_on: '1602159230'
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              - assignee: null
+                branch: master
+                branch_from: 0.4.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto 42ff00213954ed2cd518e7bde7f13c71ff2f7768
+                  commit: null
+                  date_created: '1602156174'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58242
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 334d3538bc72136f3a2a2606d5d1385a237a8b88
+                  commit: null
+                  date_created: '1602156842'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58266
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                  commit: null
+                  date_created: '1602159213'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58295
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                commit_start: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                commit_stop: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                date_created: '1602058034'
+                id: 35
+                initial_comment: 'Upstream tag: 0.4.0
+
+                  Upstream commit: 6957453b'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600700802'
+                  date_modified: '1600700802'
+                  description: The python-requre package
+                  fullname: forks/jscotka/rpms/python-requre
+                  id: 45827
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/jscotka/rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.4.0
+                uid: 59c091aafde845e088a2904278dc3b0d
+                updated_on: '1602159525'
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              - assignee: null
+                branch: master
+                branch_from: 0.5.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto 268ef502395f86267de91ced5643affa6edf5434
+                  commit: null
+                  date_created: '1602058074'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58108
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 9c3150bbc0676f0c279e2f589b9e99c2eb323aa9
+                  commit: null
+                  date_created: '1602156191'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58257
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 4cf77c217d59dbcea7bfdd4bb12f3bd4394c66b2
+                  commit: null
+                  date_created: '1602156886'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58282
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                  commit: null
+                  date_created: '1602159230'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58311
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                commit_start: 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                commit_stop: 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                date_created: '1602000289'
+                id: 34
+                initial_comment: 'Upstream tag: 0.5.0
+
+                  Upstream commit: 87808f12'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600700802'
+                  date_modified: '1600700802'
+                  description: The python-requre package
+                  fullname: forks/jscotka/rpms/python-requre
+                  id: 45827
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/jscotka/rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.5.0
+                uid: 4f72184194cb48aa9130ab9e0da59b6c
+                updated_on: '1602159230'
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              - assignee: null
+                branch: master
+                branch_from: 0.4.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto d79b8d99ea4191535fd5bf77f13342d5defcbaf3
+                  commit: null
+                  date_created: '1602058032'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58095
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 42ff00213954ed2cd518e7bde7f13c71ff2f7768
+                  commit: null
+                  date_created: '1602156175'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58243
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 334d3538bc72136f3a2a2606d5d1385a237a8b88
+                  commit: null
+                  date_created: '1602156842'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58267
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                  commit: null
+                  date_created: '1602159214'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58297
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                commit_start: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                commit_stop: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                date_created: '1602000246'
+                id: 33
+                initial_comment: 'Upstream tag: 0.4.0
+
+                  Upstream commit: 6957453b'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600700802'
+                  date_modified: '1600700802'
+                  description: The python-requre package
+                  fullname: forks/jscotka/rpms/python-requre
+                  id: 45827
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/jscotka/rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.4.0
+                uid: 403087d8990e446287cc45249a7fddb1
+                updated_on: '1602159526'
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              - assignee: null
+                branch: master
+                branch_from: 0.4.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto 686ad232d9e929f36a0231deefb70f412b0e2b86
+                  commit: null
+                  date_created: '1602000242'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58021
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto d79b8d99ea4191535fd5bf77f13342d5defcbaf3
+                  commit: null
+                  date_created: '1602058032'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58096
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 42ff00213954ed2cd518e7bde7f13c71ff2f7768
+                  commit: null
+                  date_created: '1602156175'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58244
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 334d3538bc72136f3a2a2606d5d1385a237a8b88
+                  commit: null
+                  date_created: '1602156842'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58268
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                  commit: null
+                  date_created: '1602159213'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58296
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                commit_start: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                commit_stop: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                date_created: '1601999175'
+                id: 32
+                initial_comment: 'Upstream tag: 0.4.0
+
+                  Upstream commit: 6957453b'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600700802'
+                  date_modified: '1600700802'
+                  description: The python-requre package
+                  fullname: forks/jscotka/rpms/python-requre
+                  id: 45827
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/jscotka/rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.4.0
+                uid: 44d15dcb383d428e9d3343c988639f30
+                updated_on: '1602159213'
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              - assignee: null
+                branch: master
+                branch_from: 0.4.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto 2740c9191c27ad7c62f9c2b6952cdd50c45406da
+                  commit: null
+                  date_created: '1601999172'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58008
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 686ad232d9e929f36a0231deefb70f412b0e2b86
+                  commit: null
+                  date_created: '1602000243'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58024
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto d79b8d99ea4191535fd5bf77f13342d5defcbaf3
+                  commit: null
+                  date_created: '1602058032'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58098
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 42ff00213954ed2cd518e7bde7f13c71ff2f7768
+                  commit: null
+                  date_created: '1602156175'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58245
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 334d3538bc72136f3a2a2606d5d1385a237a8b88
+                  commit: null
+                  date_created: '1602156843'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58269
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                  commit: null
+                  date_created: '1602159214'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58298
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                commit_start: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                commit_stop: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                date_created: '1601998795'
+                id: 31
+                initial_comment: 'Upstream tag: 0.4.0
+
+                  Upstream commit: 6957453b'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600700802'
+                  date_modified: '1600700802'
+                  description: The python-requre package
+                  fullname: forks/jscotka/rpms/python-requre
+                  id: 45827
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/jscotka/rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.4.0
+                uid: b086a7cf4e2c478dab882662443e30cd
+                updated_on: '1602159214'
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              - assignee: null
+                branch: master
+                branch_from: 0.4.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto 2833e9f1a6fb729eebd8882334bb7aceb5147db1
+                  commit: null
+                  date_created: '1601998794'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57995
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 2740c9191c27ad7c62f9c2b6952cdd50c45406da
+                  commit: null
+                  date_created: '1601999173'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58009
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 686ad232d9e929f36a0231deefb70f412b0e2b86
+                  commit: null
+                  date_created: '1602000243'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58022
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto d79b8d99ea4191535fd5bf77f13342d5defcbaf3
+                  commit: null
+                  date_created: '1602058032'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58097
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 42ff00213954ed2cd518e7bde7f13c71ff2f7768
+                  commit: null
+                  date_created: '1602156175'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58246
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 334d3538bc72136f3a2a2606d5d1385a237a8b88
+                  commit: null
+                  date_created: '1602156843'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58270
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                  commit: null
+                  date_created: '1602159214'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58299
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                commit_start: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                commit_stop: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                date_created: '1601985920'
+                id: 30
+                initial_comment: 'Upstream tag: 0.4.0
+
+                  Upstream commit: 6957453b'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600700802'
+                  date_modified: '1600700802'
+                  description: The python-requre package
+                  fullname: forks/jscotka/rpms/python-requre
+                  id: 45827
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/jscotka/rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.4.0
+                uid: 181a8e995838427fa77af02aaf4924fd
+                updated_on: '1602159527'
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              - assignee: null
+                branch: master
+                branch_from: 0.4.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto d4262e05bf82a6732a1884d93b0d4a65271651ba
+                  commit: null
+                  date_created: '1601985918'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57947
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 2833e9f1a6fb729eebd8882334bb7aceb5147db1
+                  commit: null
+                  date_created: '1601998793'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57994
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 2740c9191c27ad7c62f9c2b6952cdd50c45406da
+                  commit: null
+                  date_created: '1601999173'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58010
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 686ad232d9e929f36a0231deefb70f412b0e2b86
+                  commit: null
+                  date_created: '1602000243'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58023
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto d79b8d99ea4191535fd5bf77f13342d5defcbaf3
+                  commit: null
+                  date_created: '1602058032'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58099
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 42ff00213954ed2cd518e7bde7f13c71ff2f7768
+                  commit: null
+                  date_created: '1602156176'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58247
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 334d3538bc72136f3a2a2606d5d1385a237a8b88
+                  commit: null
+                  date_created: '1602156843'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58271
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                  commit: null
+                  date_created: '1602159214'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58300
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                commit_start: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                commit_stop: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                date_created: '1601985184'
+                id: 29
+                initial_comment: 'Upstream tag: 0.4.0
+
+                  Upstream commit: 6957453b'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600700802'
+                  date_modified: '1600700802'
+                  description: The python-requre package
+                  fullname: forks/jscotka/rpms/python-requre
+                  id: 45827
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/jscotka/rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.4.0
+                uid: 074aaf5fca414c59a48bdf26267caaa0
+                updated_on: '1602159527'
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              - assignee: null
+                branch: master
+                branch_from: 0.5.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto 854125542da791e8df52c274d67752d208a3bdb1
+                  commit: null
+                  date_created: '1602000286'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58033
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 268ef502395f86267de91ced5643affa6edf5434
+                  commit: null
+                  date_created: '1602058074'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58109
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 9c3150bbc0676f0c279e2f589b9e99c2eb323aa9
+                  commit: null
+                  date_created: '1602156191'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58259
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 4cf77c217d59dbcea7bfdd4bb12f3bd4394c66b2
+                  commit: null
+                  date_created: '1602156885'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58281
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                  commit: null
+                  date_created: '1602159230'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58310
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                commit_start: 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                commit_stop: 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                date_created: '1601979103'
+                id: 28
+                initial_comment: 'Upstream tag: 0.5.0
+
+                  Upstream commit: 87808f12'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600700802'
+                  date_modified: '1600700802'
+                  description: The python-requre package
+                  fullname: forks/jscotka/rpms/python-requre
+                  id: 45827
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/jscotka/rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.5.0
+                uid: 4cefb11d82d7407ab300e4bddfe2635d
+                updated_on: '1602159230'
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              - assignee: null
+                branch: master
+                branch_from: 0.4.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto 0a64f99ed3ef05e58c18da2936af748d19c169b4
+                  commit: null
+                  date_created: '1601985141'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57928
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 7a77b7f7f4adec9aa0e82d3a350b851fbb56a40f
+                  commit: null
+                  date_created: '1601985181'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57937
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto d4262e05bf82a6732a1884d93b0d4a65271651ba
+                  commit: null
+                  date_created: '1601985918'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57950
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 2833e9f1a6fb729eebd8882334bb7aceb5147db1
+                  commit: null
+                  date_created: '1601998794'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57996
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 2740c9191c27ad7c62f9c2b6952cdd50c45406da
+                  commit: null
+                  date_created: '1601999173'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58011
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 686ad232d9e929f36a0231deefb70f412b0e2b86
+                  commit: null
+                  date_created: '1602000243'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58025
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto d79b8d99ea4191535fd5bf77f13342d5defcbaf3
+                  commit: null
+                  date_created: '1602058033'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58100
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 42ff00213954ed2cd518e7bde7f13c71ff2f7768
+                  commit: null
+                  date_created: '1602156176'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58248
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 334d3538bc72136f3a2a2606d5d1385a237a8b88
+                  commit: null
+                  date_created: '1602156844'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58272
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                  commit: null
+                  date_created: '1602159215'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58301
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                commit_start: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                commit_stop: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                date_created: '1601979057'
+                id: 27
+                initial_comment: 'Upstream tag: 0.4.0
+
+                  Upstream commit: 6957453b'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600700802'
+                  date_modified: '1600700802'
+                  description: The python-requre package
+                  fullname: forks/jscotka/rpms/python-requre
+                  id: 45827
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/jscotka/rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.4.0
+                uid: a13019b890fc48c991d1410c2f46decf
+                updated_on: '1602159528'
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              - assignee: null
+                branch: master
+                branch_from: 0.5.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto 605b4b249f5b32f5610f3877f9a8f9f872a2dca0
+                  commit: null
+                  date_created: '1601979101'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57905
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 854125542da791e8df52c274d67752d208a3bdb1
+                  commit: null
+                  date_created: '1602000287'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58035
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 268ef502395f86267de91ced5643affa6edf5434
+                  commit: null
+                  date_created: '1602058074'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58110
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 9c3150bbc0676f0c279e2f589b9e99c2eb323aa9
+                  commit: null
+                  date_created: '1602156191'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58258
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 4cf77c217d59dbcea7bfdd4bb12f3bd4394c66b2
+                  commit: null
+                  date_created: '1602156886'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58283
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                  commit: null
+                  date_created: '1602159231'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58313
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                commit_start: 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                commit_stop: 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                date_created: '1601630455'
+                id: 26
+                initial_comment: 'Upstream tag: 0.5.0
+
+                  Upstream commit: d0b1b9b5'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600700802'
+                  date_modified: '1600700802'
+                  description: The python-requre package
+                  fullname: forks/jscotka/rpms/python-requre
+                  id: 45827
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/jscotka/rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.5.0
+                uid: 195e7ca5ff644bea86666b6391223882
+                updated_on: '1602159231'
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              - assignee: null
+                branch: master
+                branch_from: 0.4.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto 103e8adbdf00cdeb619dda4f9b8d892a71085c04
+                  commit: null
+                  date_created: '1601979055'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57897
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 0a64f99ed3ef05e58c18da2936af748d19c169b4
+                  commit: null
+                  date_created: '1601985141'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57929
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 7a77b7f7f4adec9aa0e82d3a350b851fbb56a40f
+                  commit: null
+                  date_created: '1601985180'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57936
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto d4262e05bf82a6732a1884d93b0d4a65271651ba
+                  commit: null
+                  date_created: '1601985918'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57948
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 2833e9f1a6fb729eebd8882334bb7aceb5147db1
+                  commit: null
+                  date_created: '1601998794'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57997
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 2740c9191c27ad7c62f9c2b6952cdd50c45406da
+                  commit: null
+                  date_created: '1601999173'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58012
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 686ad232d9e929f36a0231deefb70f412b0e2b86
+                  commit: null
+                  date_created: '1602000243'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58026
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto d79b8d99ea4191535fd5bf77f13342d5defcbaf3
+                  commit: null
+                  date_created: '1602058033'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58101
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 42ff00213954ed2cd518e7bde7f13c71ff2f7768
+                  commit: null
+                  date_created: '1602156176'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58249
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 334d3538bc72136f3a2a2606d5d1385a237a8b88
+                  commit: null
+                  date_created: '1602156844'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58273
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                  commit: null
+                  date_created: '1602159215'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58302
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                commit_start: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                commit_stop: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                date_created: '1601630417'
+                id: 25
+                initial_comment: 'Upstream tag: 0.4.0
+
+                  Upstream commit: 6957453b'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600700802'
+                  date_modified: '1600700802'
+                  description: The python-requre package
+                  fullname: forks/jscotka/rpms/python-requre
+                  id: 45827
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/jscotka/rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.4.0
+                uid: c9949ef7286845389445086ff47eb122
+                updated_on: '1602159528'
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              - assignee: null
+                branch: master
+                branch_from: 0.5.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto 3f8503b11745e5d2767efde60e0512edf3815242
+                  commit: null
+                  date_created: '1601630452'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57636
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 605b4b249f5b32f5610f3877f9a8f9f872a2dca0
+                  commit: null
+                  date_created: '1601979101'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57904
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 854125542da791e8df52c274d67752d208a3bdb1
+                  commit: null
+                  date_created: '1602000286'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58034
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 268ef502395f86267de91ced5643affa6edf5434
+                  commit: null
+                  date_created: '1602058075'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58111
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 9c3150bbc0676f0c279e2f589b9e99c2eb323aa9
+                  commit: null
+                  date_created: '1602156191'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58260
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 4cf77c217d59dbcea7bfdd4bb12f3bd4394c66b2
+                  commit: null
+                  date_created: '1602156886'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58285
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                  commit: null
+                  date_created: '1602159231'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58314
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                commit_start: 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                commit_stop: 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
+                date_created: '1601541260'
+                id: 24
+                initial_comment: 'Upstream tag: 0.5.0
+
+                  Upstream commit: d0b1b9b5'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600700802'
+                  date_modified: '1600700802'
+                  description: The python-requre package
+                  fullname: forks/jscotka/rpms/python-requre
+                  id: 45827
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/jscotka/rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.5.0
+                uid: 8b3de993a8814d01811461f5cf0ee1b4
+                updated_on: '1602159231'
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              - assignee: null
+                branch: master
+                branch_from: 0.4.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto e5679437d476dbfd88dfc9038ddf477b5c7fdc36
+                  commit: null
+                  date_created: '1601630417'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57633
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 103e8adbdf00cdeb619dda4f9b8d892a71085c04
+                  commit: null
+                  date_created: '1601979055'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57898
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 0a64f99ed3ef05e58c18da2936af748d19c169b4
+                  commit: null
+                  date_created: '1601985142'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57930
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 7a77b7f7f4adec9aa0e82d3a350b851fbb56a40f
+                  commit: null
+                  date_created: '1601985181'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57938
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto d4262e05bf82a6732a1884d93b0d4a65271651ba
+                  commit: null
+                  date_created: '1601985918'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57949
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 2833e9f1a6fb729eebd8882334bb7aceb5147db1
+                  commit: null
+                  date_created: '1601998794'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 57998
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 2740c9191c27ad7c62f9c2b6952cdd50c45406da
+                  commit: null
+                  date_created: '1601999173'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58013
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 686ad232d9e929f36a0231deefb70f412b0e2b86
+                  commit: null
+                  date_created: '1602000244'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58027
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto d79b8d99ea4191535fd5bf77f13342d5defcbaf3
+                  commit: null
+                  date_created: '1602058033'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58102
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 42ff00213954ed2cd518e7bde7f13c71ff2f7768
+                  commit: null
+                  date_created: '1602156177'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58250
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 334d3538bc72136f3a2a2606d5d1385a237a8b88
+                  commit: null
+                  date_created: '1602156844'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58274
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                - comment: rebased onto 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                  commit: null
+                  date_created: '1602159215'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 58303
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                commit_start: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                commit_stop: 6f8b072c37de57111c0d823ceea25c2de524f2bd
+                date_created: '1601541218'
+                id: 23
+                initial_comment: 'Upstream tag: 0.4.0
+
+                  Upstream commit: 6957453b'
+                last_updated: '1603361900'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600700802'
+                  date_modified: '1600700802'
+                  description: The python-requre package
+                  fullname: forks/jscotka/rpms/python-requre
+                  id: 45827
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/jscotka/rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.4.0
+                uid: c9b782fffc254519a5f9bc10b21bc5ae
+                updated_on: '1602159566'
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              total_requests: 30
+            _next: null
+            elapsed: 0.98042
+            encoding: null
+            headers:
+              Connection: Keep-Alive
+              Date: Thu, 22 Oct 2020 11:09:18 GMT
+              Keep-Alive: timeout=15, max=500
+              Referrer-Policy: same-origin
+              Server: Apache
+              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+              X-Content-Type-Options: nosniff
+              X-Fedora-ProxyServer: proxy01.iad2.fedoraproject.org
+              X-Fedora-RequestID: X5FoXhMw6wZpoU8gnSwbrwAABUA
+              X-Frame-Options: SAMEORIGIN
+              X-Xss-Protection: 1; mode=block
+              apptime: D=603549
+              content-length: '132069'
+              content-security-policy: default-src 'self'; script-src 'self' 'nonce-Jh2QZpczmHQg1WqWxQrq9c27Q'
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
+                'self' 'nonce-Jh2QZpczmHQg1WqWxQrq9c27Q'; object-src 'none'; base-uri
+                'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
+              content-type: application/json
+              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYmU2NmNiMDk2ZGU2YTAwZGQ5ODliOTE5YTIyZWY5OTc2MTRmNDQzOCJ9.EnL53g.MrtqV7UGaOmm40z90OJxOWxt0ww;
+                Expires=Sun, 22-Nov-2020 11:09:18 GMT; Secure; HttpOnly; Path=/
+              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+    HEAD:
+      https://src.fedoraproject.org/lookaside/pkgs/python-requre/requre-0.4.0.tar.gz/:
+        all:
+          metadata:
+            latency: 0.4173398017883301
+            module_call_list:
+            - unittest.case
+            - requre.online_replacing
+            - tests_recording.test_api
+            - packit.api
+            - packit.distgit
+            - requests.api
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 1
+            _content: ''
+            _next: null
+            elapsed: 0.414653
+            encoding: ISO-8859-1
+            headers:
+              Connection: Keep-Alive
+              Date: Thu, 22 Oct 2020 11:09:17 GMT
+              Keep-Alive: timeout=15, max=500
+              Referrer-Policy: same-origin
+              Server: Apache
+              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+              X-Content-Type-Options: nosniff
+              X-Fedora-ProxyServer: proxy10.iad2.fedoraproject.org
+              X-Fedora-RequestID: X5FoXQH03vfcA4mHt4NTfAAAC0c
+              X-Frame-Options: SAMEORIGIN
+              X-Xss-Protection: 1; mode=block
+              apptime: D=6990
+              content-type: text/html;charset=ISO-8859-1
+              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+    POST:
+      https://src.fedoraproject.org/api/0/-/whoami:
+        all:
+          metadata:
+            latency: 0.1968834400177002
+            module_call_list:
+            - unittest.case
+            - requre.online_replacing
+            - tests_recording.test_api
+            - packit.api
+            - packit.distgit
+            - ogr.services.pagure.project
+            - ogr.services.pagure.user
+            - ogr.services.pagure.service
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+              username: lachmanfrantisek
+            _next: null
+            elapsed: 0.190317
+            encoding: null
+            headers:
+              Connection: Keep-Alive
+              Date: Thu, 22 Oct 2020 11:09:20 GMT
+              Keep-Alive: timeout=15, max=497
+              Referrer-Policy: same-origin
+              Server: Apache
+              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+              X-Content-Type-Options: nosniff
+              X-Fedora-ProxyServer: proxy01.iad2.fedoraproject.org
+              X-Fedora-RequestID: X5FoYBMw6wZpoU8gnSwb5AAABVc
+              X-Frame-Options: SAMEORIGIN
+              X-Xss-Protection: 1; mode=block
+              apptime: D=62886
+              content-length: '37'
+              content-security-policy: default-src 'self'; script-src 'self' 'nonce-PEbBE9cEKQyEtuMIHs8wMEu24'
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
+                'self' 'nonce-PEbBE9cEKQyEtuMIHs8wMEu24'; object-src 'none'; base-uri
+                'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
+              content-type: application/json
+              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYmU2NmNiMDk2ZGU2YTAwZGQ5ODliOTE5YTIyZWY5OTc2MTRmNDQzOCJ9.EnL54A.t8qSeZjDo9NlvHWYqz_BqLHjuAQ;
+                Expires=Sun, 22-Nov-2020 11:09:20 GMT; Secure; HttpOnly; Path=/
+              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      https://src.fedoraproject.org/api/0/rpms/python-requre/pull-request/new:
+        all:
+          metadata:
+            latency: 2.0469672679901123
+            module_call_list:
+            - unittest.case
+            - requre.online_replacing
+            - tests_recording.test_api
+            - packit.api
+            - packit.distgit
+            - ogr.read_only
+            - ogr.services.pagure.project
+            - ogr.services.pagure.pull_request
+            - ogr.services.pagure.project
+            - ogr.services.pagure.service
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+              assignee: null
+              branch: master
+              branch_from: 0.4.0-master-update
+              cached_merge_status: unknown
+              closed_at: null
+              closed_by: null
+              comments: []
+              commit_start: 9c57753e33e0d34bbbebfa395de8d6ee1accbc15
+              commit_stop: 9c57753e33e0d34bbbebfa395de8d6ee1accbc15
+              date_created: '1603364971'
+              id: 45
+              initial_comment: 'Upstream tag: 0.4.0
+
+                Upstream commit: 2d5ffe6b'
+              last_updated: '1603364971'
+              project:
+                access_groups:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  ticket: []
+                access_users:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  owner:
+                  - jscotka
+                  ticket: []
+                close_status: []
+                custom_keys: []
+                date_created: '1586178839'
+                date_modified: '1586178846'
+                description: The python-requre package
+                fullname: rpms/python-requre
+                id: 41574
+                milestones: {}
+                name: python-requre
+                namespace: rpms
+                parent: null
+                priorities: {}
+                tags: []
+                url_path: rpms/python-requre
+                user:
+                  fullname: "Jan \u0160\u010Dotka"
+                  name: jscotka
+                  url_path: user/jscotka
+              remote_git: null
+              repo_from:
+                access_groups:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  ticket: []
+                access_users:
+                  admin: []
+                  collaborator: []
+                  commit: []
+                  owner:
+                  - lachmanfrantisek
+                  ticket: []
+                close_status: []
+                custom_keys: []
+                date_created: '1600763657'
+                date_modified: '1600763657'
+                description: The python-requre package
+                fullname: forks/lachmanfrantisek/rpms/python-requre
+                id: 45852
+                milestones: {}
+                name: python-requre
+                namespace: rpms
+                parent:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                priorities: {}
+                tags: []
+                url_path: fork/lachmanfrantisek/rpms/python-requre
+                user:
+                  fullname: "Franti\u0161ek Lachman"
+                  name: lachmanfrantisek
+                  url_path: user/lachmanfrantisek
+              status: Open
+              tags: []
+              threshold_reached: null
+              title: Update to upstream release 0.4.0
+              uid: 3cc6fe2b20b84480b8cf01a576accc35
+              updated_on: '1603364971'
+              user:
+                fullname: "Franti\u0161ek Lachman"
+                name: lachmanfrantisek
+                url_path: user/lachmanfrantisek
+            _next: null
+            elapsed: 2.040896
+            encoding: null
+            headers:
+              Connection: Keep-Alive
+              Date: Thu, 22 Oct 2020 11:09:31 GMT
+              Keep-Alive: timeout=15, max=487
+              Referrer-Policy: same-origin
+              Server: Apache
+              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
+              X-Content-Type-Options: nosniff
+              X-Fedora-ProxyServer: proxy01.iad2.fedoraproject.org
+              X-Fedora-RequestID: X5FoaxMw6wZpoU8gnSwcyAAABU4
+              X-Frame-Options: SAMEORIGIN
+              X-Xss-Protection: 1; mode=block
+              apptime: D=1912041
+              content-length: '3421'
+              content-security-policy: default-src 'self'; script-src 'self' 'nonce-wNam0y1BDdDxR6VGn9zyisjkx'
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
+                'self' 'nonce-wNam0y1BDdDxR6VGn9zyisjkx'; object-src 'none'; base-uri
+                'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
+                https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
+              content-type: application/json
+              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYmU2NmNiMDk2ZGU2YTAwZGQ5ODliOTE5YTIyZWY5OTc2MTRmNDQzOCJ9.EnL57Q.9kRam-igP98H06OOxIsFPBr3G18;
+                Expires=Sun, 22-Nov-2020 11:09:33 GMT; Secure; HttpOnly; Path=/
+              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+unittest.case:
+  requre.online_replacing:
+    tests_recording.test_api:
+      tests_recording.testbase:
+        packit.local_project:
+          packit.utils.repo:
+            requre.helpers.files:
+              requre.objects:
+                requre.cassette:
+                  git.repo.base:
+                    clone_from:
+                      all:
+                        metadata:
+                          latency: 1.1063122749328613
+                          module_call_list:
+                          - unittest.case
+                          - requre.online_replacing
+                          - tests_recording.test_api
+                          - tests_recording.testbase
+                          - packit.local_project
+                          - packit.utils.repo
+                          - requre.helpers.files
+                          - requre.objects
+                          - requre.cassette
+                          - git.repo.base
+                          - clone_from
+                        output:
+                          _bare: false
+                          _common_dir: null
+                          _working_tree_dir: /tmp/packit_tmp/tests_recording.test_api.ProposeUpdate.test_changelog_sync.yaml/static_tmp_1
+                          git_dir: /tmp/packit_tmp/tests_recording.test_api.ProposeUpdate.test_changelog_sync.yaml/static_tmp_1/.git
+                          working_dir: /tmp/packit_tmp/tests_recording.test_api.ProposeUpdate.test_changelog_sync.yaml/static_tmp_1

--- a/tests_recording/test_data/test_api/tests_recording.test_api.ProposeUpdate.test_changelog_sync.yaml.packit-dist-git_2_1.tar.xz
+++ b/tests_recording/test_data/test_api/tests_recording.test_api.ProposeUpdate.test_changelog_sync.yaml.packit-dist-git_2_1.tar.xz
@@ -1,0 +1,1 @@
+../test_api/tests_recording.test_api.ProposeUpdate.test_version_change_mocked.yaml.packit-dist-git_2_1.tar.xz

--- a/tests_recording/test_data/test_api/tests_recording.test_api.ProposeUpdate.test_changelog_sync.yaml.static_tmp_1_1.tar.xz
+++ b/tests_recording/test_data/test_api/tests_recording.test_api.ProposeUpdate.test_changelog_sync.yaml.static_tmp_1_1.tar.xz
@@ -1,0 +1,1 @@
+../test_api/tests_recording.test_api.ProposeUpdate.test_version_change_exception.yaml.static_tmp_1_1.tar.xz

--- a/tests_recording/test_data/test_api/tests_recording.test_api.ProposeUpdate.test_comment_in_spec.yaml
+++ b/tests_recording/test_data/test_api/tests_recording.test_api.ProposeUpdate.test_comment_in_spec.yaml
@@ -21,7 +21,7 @@ git.remote:
   fetch:
     all:
       metadata:
-        latency: 2.2448012828826904
+        latency: 1.9568521976470947
         module_call_list:
         - unittest.case
         - requre.online_replacing
@@ -36,56 +36,235 @@ git.remote:
       - flags: 4
         note: ''
         old_commit: null
-        remote_ref_path: 'master    '
+        remote_ref_path: 'master           '
       - flags: 4
         note: ''
         old_commit: null
-        remote_ref_path: 'f30       '
+        remote_ref_path: 'refs/pull/1/head '
       - flags: 4
         note: ''
         old_commit: null
-        remote_ref_path: 'f31       '
+        remote_ref_path: refs/pull/10/head
       - flags: 4
         note: ''
         old_commit: null
-        remote_ref_path: 'f32       '
+        remote_ref_path: refs/pull/11/head
       - flags: 4
         note: ''
         old_commit: null
-        remote_ref_path: 'f33       '
-  push:
+        remote_ref_path: refs/pull/12/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/13/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/14/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/15/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/16/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/17/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/18/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/19/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/2/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/20/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/21/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/22/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/23/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/24/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/25/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/26/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/27/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/28/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/29/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/3/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/30/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/31/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/32/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/33/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/34/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/35/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/36/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/37/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/38/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/39/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/4/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/40/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/41/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/42/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/43/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/44/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/45/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: refs/pull/46/head
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/5/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/6/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/7/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/8/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'refs/pull/9/head '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'f30              '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'f31              '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'f32              '
+      - flags: 4
+        note: ''
+        old_commit: null
+        remote_ref_path: 'f33              '
+git.repo.base:
+  clone_from:
     all:
       metadata:
-        latency: 7.389948606491089
+        latency: 1.1148486137390137
         module_call_list:
         - unittest.case
         - requre.online_replacing
         - tests_recording.test_api
-        - packit.api
-        - packit.distgit
-        - packit.base_git
+        - tests_recording.testbase
         - packit.local_project
-        - requre.objects
-        - requre.helpers.git.pushinfo
+        - packit.utils.repo
+        - requre.helpers.files
         - requre.objects
         - requre.cassette
-        - git.remote
-        - push
+        - git.repo.base
+        - clone_from
       output:
-      - _old_commit_sha: c6a732c
-        flags: 128
-        local_ref:
-        - /tmp/packit_tmp/tests_recording.test_api.ProposeUpdate.test_comment_in_spec.yaml/packit-dist-git_2/.git
-        - refs/heads/0.4.0-master-update
-        remote_ref_string: refs/heads/0.4.0-master-update
-        summary: 'c6a732c...4f91816 (forced update)
-
-          '
+        _bare: false
+        _common_dir: null
+        _working_tree_dir: /tmp/packit_tmp/tests_recording.test_api.ProposeUpdate.test_comment_in_spec.yaml/static_tmp_1
+        git_dir: /tmp/packit_tmp/tests_recording.test_api.ProposeUpdate.test_comment_in_spec.yaml/static_tmp_1/.git
+        working_dir: /tmp/packit_tmp/tests_recording.test_api.ProposeUpdate.test_comment_in_spec.yaml/static_tmp_1
 packit.fedpkg:
   clone:
     all:
       metadata:
-        latency: 2.7929165363311768
+        latency: 2.621762752532959
         module_call_list:
         - unittest.case
         - requre.online_replacing
@@ -104,7 +283,7 @@ requests.sessions:
       https://api.github.com:443/repos/packit/requre:
         all:
           metadata:
-            latency: 0.41181015968322754
+            latency: 0.2874124050140381
             module_call_list:
             - unittest.case
             - requre.online_replacing
@@ -230,9 +409,9 @@ requests.sessions:
                 push: true
               private: false
               pulls_url: https://api.github.com/repos/packit/requre/pulls{/number}
-              pushed_at: '2020-10-09T11:46:25Z'
+              pushed_at: '2020-10-21T12:18:11Z'
               releases_url: https://api.github.com/repos/packit/requre/releases{/id}
-              size: 405
+              size: 406
               ssh_url: git@github.com:packit/requre.git
               stargazers_count: 4
               stargazers_url: https://api.github.com/repos/packit/requre/stargazers
@@ -245,12 +424,12 @@ requests.sessions:
               teams_url: https://api.github.com/repos/packit/requre/teams
               temp_clone_token: ''
               trees_url: https://api.github.com/repos/packit/requre/git/trees{/sha}
-              updated_at: '2020-10-09T11:46:27Z'
+              updated_at: '2020-10-21T12:18:14Z'
               url: https://api.github.com/repos/packit/requre
               watchers: 4
               watchers_count: 4
             _next: null
-            elapsed: 0.410896
+            elapsed: 0.283696
             encoding: utf-8
             headers:
               Access-Control-Allow-Origin: '*'
@@ -262,9 +441,9 @@ requests.sessions:
               Content-Encoding: gzip
               Content-Security-Policy: default-src 'none'
               Content-Type: application/json; charset=utf-8
-              Date: Tue, 20 Oct 2020 10:47:46 GMT
-              ETag: W/"8cb8af4164409bef9208afe94c2a953cca6975ad00065ddb435ab96dcf563eea"
-              Last-Modified: Fri, 09 Oct 2020 11:46:27 GMT
+              Date: Thu, 22 Oct 2020 12:16:36 GMT
+              ETag: W/"6f02e1e8a9c6bd568caca9eadca3b810f904f0e050f189f63535b06993cbb9f9"
+              Last-Modified: Wed, 21 Oct 2020 12:18:14 GMT
               Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
               Server: GitHub.com
               Status: 200 OK
@@ -276,11 +455,13 @@ requests.sessions:
               X-Content-Type-Options: nosniff
               X-Frame-Options: deny
               X-GitHub-Media-Type: github.v3; format=json
-              X-GitHub-Request-Id: F176:7C68:1DF2DDDC:22997D2B:5F8EC052
-              X-OAuth-Scopes: notifications, repo, workflow
+              X-GitHub-Request-Id: B39E:12BED:24063920:29AC1F93:5F917824
+              X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
+                admin:repo_hook, delete_repo, gist, notifications, repo, user, workflow,
+                write:discussion
               X-RateLimit-Limit: '5000'
               X-RateLimit-Remaining: '4999'
-              X-RateLimit-Reset: '1603194466'
+              X-RateLimit-Reset: '1603372596'
               X-RateLimit-Used: '1'
               X-XSS-Protection: 1; mode=block
             raw: !!binary ""
@@ -289,7 +470,7 @@ requests.sessions:
       https://api.github.com:443/repos/packit/requre/contents/.packit.yaml?ref=master:
         all:
           metadata:
-            latency: 0.18621182441711426
+            latency: 0.18927884101867676
             module_call_list:
             - unittest.case
             - requre.online_replacing
@@ -387,7 +568,7 @@ requests.sessions:
               type: file
               url: https://api.github.com/repos/packit/requre/contents/.packit.yaml?ref=master
             _next: null
-            elapsed: 0.185407
+            elapsed: 0.186748
             encoding: utf-8
             headers:
               Access-Control-Allow-Origin: '*'
@@ -399,9 +580,9 @@ requests.sessions:
               Content-Encoding: gzip
               Content-Security-Policy: default-src 'none'
               Content-Type: application/json; charset=utf-8
-              Date: Tue, 20 Oct 2020 10:47:49 GMT
+              Date: Thu, 22 Oct 2020 12:16:38 GMT
               ETag: W/"d115b8280494d3c9b288c0a739d1c8fa58da1e3b"
-              Last-Modified: Fri, 09 Oct 2020 11:46:24 GMT
+              Last-Modified: Wed, 21 Oct 2020 12:18:10 GMT
               Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
               Server: GitHub.com
               Status: 200 OK
@@ -413,11 +594,13 @@ requests.sessions:
               X-Content-Type-Options: nosniff
               X-Frame-Options: deny
               X-GitHub-Media-Type: github.v3; format=json
-              X-GitHub-Request-Id: F176:7C68:1DF2E15C:22997D90:5F8EC052
-              X-OAuth-Scopes: notifications, repo, workflow
+              X-GitHub-Request-Id: B39E:12BED:24063D5E:29AC201A:5F917824
+              X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
+                admin:repo_hook, delete_repo, gist, notifications, repo, user, workflow,
+                write:discussion
               X-RateLimit-Limit: '5000'
               X-RateLimit-Remaining: '4998'
-              X-RateLimit-Reset: '1603194466'
+              X-RateLimit-Reset: '1603372596'
               X-RateLimit-Used: '2'
               X-XSS-Protection: 1; mode=block
             raw: !!binary ""
@@ -426,7 +609,7 @@ requests.sessions:
       https://api.github.com:443/repos/packit/requre/contents/?ref=master:
         all:
           metadata:
-            latency: 0.1775052547454834
+            latency: 0.1738133430480957
             module_call_list:
             - unittest.case
             - requre.online_replacing
@@ -484,16 +667,16 @@ requests.sessions:
               type: file
               url: https://api.github.com/repos/packit/requre/contents/.packit.yaml?ref=master
             - _links:
-                git: https://api.github.com/repos/packit/requre/git/blobs/684cd8c27867e8e75e427aa6fd41861474d0844e
+                git: https://api.github.com/repos/packit/requre/git/blobs/7fb3591cb03af08b19cc0c3b2bbb6d3cf544d8fb
                 html: https://github.com/packit/requre/blob/master/.pre-commit-config.yaml
                 self: https://api.github.com/repos/packit/requre/contents/.pre-commit-config.yaml?ref=master
               download_url: https://raw.githubusercontent.com/packit/requre/master/.pre-commit-config.yaml
-              git_url: https://api.github.com/repos/packit/requre/git/blobs/684cd8c27867e8e75e427aa6fd41861474d0844e
+              git_url: https://api.github.com/repos/packit/requre/git/blobs/7fb3591cb03af08b19cc0c3b2bbb6d3cf544d8fb
               html_url: https://github.com/packit/requre/blob/master/.pre-commit-config.yaml
               name: .pre-commit-config.yaml
               path: .pre-commit-config.yaml
-              sha: 684cd8c27867e8e75e427aa6fd41861474d0844e
-              size: 1156
+              sha: 7fb3591cb03af08b19cc0c3b2bbb6d3cf544d8fb
+              size: 1159
               type: file
               url: https://api.github.com/repos/packit/requre/contents/.pre-commit-config.yaml?ref=master
             - _links:
@@ -718,7 +901,7 @@ requests.sessions:
               type: dir
               url: https://api.github.com/repos/packit/requre/contents/tests?ref=master
             _next: null
-            elapsed: 0.176567
+            elapsed: 0.170598
             encoding: utf-8
             headers:
               Access-Control-Allow-Origin: '*'
@@ -730,9 +913,9 @@ requests.sessions:
               Content-Encoding: gzip
               Content-Security-Policy: default-src 'none'
               Content-Type: application/json; charset=utf-8
-              Date: Tue, 20 Oct 2020 10:47:49 GMT
-              ETag: W/"97242393e2957f90e2e91fe324f905e8307f35c1"
-              Last-Modified: Fri, 09 Oct 2020 11:46:27 GMT
+              Date: Thu, 22 Oct 2020 12:16:38 GMT
+              ETag: W/"c5b8b774e456765e129ff2d31c58a8b39321aae9"
+              Last-Modified: Wed, 21 Oct 2020 12:18:14 GMT
               Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
               Server: GitHub.com
               Status: 200 OK
@@ -744,11 +927,13 @@ requests.sessions:
               X-Content-Type-Options: nosniff
               X-Frame-Options: deny
               X-GitHub-Media-Type: github.v3; format=json
-              X-GitHub-Request-Id: F176:7C68:1DF2E1AD:22998177:5F8EC055
-              X-OAuth-Scopes: notifications, repo, workflow
+              X-GitHub-Request-Id: B39E:12BED:24063DFD:29AC24B8:5F917826
+              X-OAuth-Scopes: admin:gpg_key, admin:org, admin:org_hook, admin:public_key,
+                admin:repo_hook, delete_repo, gist, notifications, repo, user, workflow,
+                write:discussion
               X-RateLimit-Limit: '5000'
               X-RateLimit-Remaining: '4997'
-              X-RateLimit-Reset: '1603194466'
+              X-RateLimit-Reset: '1603372596'
               X-RateLimit-Used: '3'
               X-XSS-Protection: 1; mode=block
             raw: !!binary ""
@@ -757,7 +942,7 @@ requests.sessions:
       https://release-monitoring.org/api/project/Fedora/python-requre:
         all:
           metadata:
-            latency: 0.4797556400299072
+            latency: 0.5082957744598389
             module_call_list:
             - unittest.case
             - requre.online_replacing
@@ -779,15 +964,15 @@ requests.sessions:
               error: No package "python-requre" found in distro "Fedora"
               output: notok
             _next: null
-            elapsed: 0.479024
+            elapsed: 0.502154
             encoding: null
             headers:
-              AppTime: D=29632
+              AppTime: D=18052
               Cache-control: private
               Connection: Keep-Alive
               Content-Length: '85'
               Content-Type: application/json
-              Date: Tue, 20 Oct 2020 10:47:52 GMT
+              Date: Thu, 22 Oct 2020 12:16:42 GMT
               Keep-Alive: timeout=15, max=500
               Referrer-Policy: same-origin
               Server: Apache/2.4.43 (Fedora) mod_wsgi/4.6.8 Python/3.8
@@ -795,8 +980,8 @@ requests.sessions:
                 path=/; HttpOnly; Secure
               Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
               X-Content-Type-Options: nosniff
-              X-Fedora-ProxyServer: proxy10.iad2.fedoraproject.org
-              X-Fedora-RequestID: X47AWF6HH9AwN5cexM-XFAAAAFU
+              X-Fedora-ProxyServer: proxy01.iad2.fedoraproject.org
+              X-Fedora-RequestID: X5F4KobJLabpIQ@ceVtzcQAACNE
               X-Frame-Options: SAMEORIGIN
               X-Xss-Protection: 1; mode=block
             raw: !!binary ""
@@ -805,7 +990,7 @@ requests.sessions:
       https://release-monitoring.org/api/projects?pattern=python-requre:
         all:
           metadata:
-            latency: 1.1928935050964355
+            latency: 1.131300687789917
             module_call_list:
             - unittest.case
             - requre.online_replacing
@@ -827,15 +1012,15 @@ requests.sessions:
               projects: []
               total: 0
             _next: null
-            elapsed: 1.192312
+            elapsed: 1.125377
             encoding: null
             headers:
-              AppTime: D=765547
+              AppTime: D=749047
               Cache-control: private
               Connection: Keep-Alive
               Content-Length: '26'
               Content-Type: application/json
-              Date: Tue, 20 Oct 2020 10:47:53 GMT
+              Date: Thu, 22 Oct 2020 12:16:42 GMT
               Keep-Alive: timeout=15, max=500
               Referrer-Policy: same-origin
               Server: Apache/2.4.43 (Fedora) mod_wsgi/4.6.8 Python/3.8
@@ -844,817 +1029,16 @@ requests.sessions:
               Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
               X-Content-Type-Options: nosniff
               X-Fedora-ProxyServer: proxy01.iad2.fedoraproject.org
-              X-Fedora-RequestID: X47AWQGRGwDfJwjiJHGdzQAAAEc
+              X-Fedora-RequestID: X5F4KnR--xIDY20s@iWvmQAACIw
               X-Frame-Options: SAMEORIGIN
               X-Xss-Protection: 1; mode=block
-            raw: !!binary ""
-            reason: OK
-            status_code: 200
-      https://src.fedoraproject.org/api/0/fork/jscotka/rpms/python-requre:
-        all:
-          metadata:
-            latency: 0.2891256809234619
-            module_call_list:
-            - unittest.case
-            - requre.online_replacing
-            - tests_recording.test_api
-            - packit.api
-            - packit.distgit
-            - ogr.services.pagure.project
-            - ogr.services.pagure.service
-            - requests.sessions
-            - requre.objects
-            - requre.cassette
-            - requests.sessions
-            - send
-          output:
-            __store_indicator: 2
-            _content:
-              access_groups:
-                admin: []
-                collaborator: []
-                commit: []
-                ticket: []
-              access_users:
-                admin: []
-                collaborator: []
-                commit: []
-                owner:
-                - jscotka
-                ticket: []
-              close_status: []
-              custom_keys: []
-              date_created: '1600700802'
-              date_modified: '1600700802'
-              description: The python-requre package
-              fullname: forks/jscotka/rpms/python-requre
-              id: 45827
-              milestones: {}
-              name: python-requre
-              namespace: rpms
-              parent:
-                access_groups:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  ticket: []
-                access_users:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  owner:
-                  - jscotka
-                  ticket: []
-                close_status: []
-                custom_keys: []
-                date_created: '1586178839'
-                date_modified: '1586178846'
-                description: The python-requre package
-                fullname: rpms/python-requre
-                id: 41574
-                milestones: {}
-                name: python-requre
-                namespace: rpms
-                parent: null
-                priorities: {}
-                tags: []
-                url_path: rpms/python-requre
-                user:
-                  fullname: "Jan \u0160\u010Dotka"
-                  name: jscotka
-                  url_path: user/jscotka
-              priorities: {}
-              tags: []
-              url_path: fork/jscotka/rpms/python-requre
-              user:
-                fullname: "Jan \u0160\u010Dotka"
-                name: jscotka
-                url_path: user/jscotka
-            _next: null
-            elapsed: 0.288428
-            encoding: null
-            headers:
-              Connection: Keep-Alive
-              Date: Tue, 20 Oct 2020 10:48:10 GMT
-              Keep-Alive: timeout=15, max=499
-              Referrer-Policy: same-origin
-              Server: Apache
-              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-              X-Content-Type-Options: nosniff
-              X-Fedora-ProxyServer: proxy10.iad2.fedoraproject.org
-              X-Fedora-RequestID: X47Aaqsq79ncW0mHIY9eogAAAkY
-              X-Frame-Options: SAMEORIGIN
-              X-Xss-Protection: 1; mode=block
-              apptime: D=134101
-              content-length: '1578'
-              content-security-policy: default-src 'self'; script-src 'self' 'nonce-BB9HMj1GoV7i4UBY7uCDbwW8C'
-                https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
-                'self' 'nonce-BB9HMj1GoV7i4UBY7uCDbwW8C'; object-src 'none'; base-uri
-                'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
-                https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
-              content-type: application/json
-              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiNzc0Mzc2Mjk3ODAyMTA0NTIxZTUwZmJhMTlkNjhjZjgxN2M0YmJhMyJ9.EnBR6g.zGVDuljbC0E_I10nBNv2Splorck;
-                Expires=Fri, 20-Nov-2020 10:48:10 GMT; Secure; HttpOnly; Path=/
-              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
-            raw: !!binary ""
-            reason: OK
-            status_code: 200
-      https://src.fedoraproject.org/api/0/fork/lachmanfrantisek/rpms/python-requre:
-        all:
-          metadata:
-            latency: 0.26529526710510254
-            module_call_list:
-            - unittest.case
-            - requre.online_replacing
-            - tests_recording.test_api
-            - packit.api
-            - packit.distgit
-            - ogr.services.pagure.project
-            - ogr.services.pagure.service
-            - requests.sessions
-            - requre.objects
-            - requre.cassette
-            - requests.sessions
-            - send
-          output:
-            __store_indicator: 2
-            _content:
-              access_groups:
-                admin: []
-                collaborator: []
-                commit: []
-                ticket: []
-              access_users:
-                admin: []
-                collaborator: []
-                commit: []
-                owner:
-                - lachmanfrantisek
-                ticket: []
-              close_status: []
-              custom_keys: []
-              date_created: '1600763657'
-              date_modified: '1600763657'
-              description: The python-requre package
-              fullname: forks/lachmanfrantisek/rpms/python-requre
-              id: 45852
-              milestones: {}
-              name: python-requre
-              namespace: rpms
-              parent:
-                access_groups:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  ticket: []
-                access_users:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  owner:
-                  - jscotka
-                  ticket: []
-                close_status: []
-                custom_keys: []
-                date_created: '1586178839'
-                date_modified: '1586178846'
-                description: The python-requre package
-                fullname: rpms/python-requre
-                id: 41574
-                milestones: {}
-                name: python-requre
-                namespace: rpms
-                parent: null
-                priorities: {}
-                tags: []
-                url_path: rpms/python-requre
-                user:
-                  fullname: "Jan \u0160\u010Dotka"
-                  name: jscotka
-                  url_path: user/jscotka
-              priorities: {}
-              tags: []
-              url_path: fork/lachmanfrantisek/rpms/python-requre
-              user:
-                fullname: "Franti\u0161ek Lachman"
-                name: lachmanfrantisek
-                url_path: user/lachmanfrantisek
-            _next: null
-            elapsed: 0.264623
-            encoding: null
-            headers:
-              Connection: Keep-Alive
-              Date: Tue, 20 Oct 2020 10:48:11 GMT
-              Keep-Alive: timeout=15, max=497
-              Referrer-Policy: same-origin
-              Server: Apache
-              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-              X-Content-Type-Options: nosniff
-              X-Fedora-ProxyServer: proxy10.iad2.fedoraproject.org
-              X-Fedora-RequestID: X47Aa6sq79ncW0mHIY9erwAAAkE
-              X-Frame-Options: SAMEORIGIN
-              X-Xss-Protection: 1; mode=block
-              apptime: D=147362
-              content-length: '1625'
-              content-security-policy: default-src 'self'; script-src 'self' 'nonce-8XfH5X2gprJFxRBpzM2Zwc4KS'
-                https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
-                'self' 'nonce-8XfH5X2gprJFxRBpzM2Zwc4KS'; object-src 'none'; base-uri
-                'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
-                https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
-              content-type: application/json
-              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiNzc0Mzc2Mjk3ODAyMTA0NTIxZTUwZmJhMTlkNjhjZjgxN2M0YmJhMyJ9.EnBR6w.MK4c2Ce8KVvbWAlMigURcYbEQMQ;
-                Expires=Fri, 20-Nov-2020 10:48:11 GMT; Secure; HttpOnly; Path=/
-              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
-            raw: !!binary ""
-            reason: OK
-            status_code: 200
-      https://src.fedoraproject.org/api/0/fork/lbarczio/rpms/python-requre:
-        all:
-          metadata:
-            latency: 0.2368168830871582
-            module_call_list:
-            - unittest.case
-            - requre.online_replacing
-            - tests_recording.test_api
-            - packit.api
-            - packit.distgit
-            - ogr.read_only
-            - ogr.services.pagure.project
-            - ogr.services.pagure.pull_request
-            - ogr.services.pagure.project
-            - ogr.services.pagure.service
-            - requests.sessions
-            - requre.objects
-            - requre.cassette
-            - requests.sessions
-            - send
-          output:
-            __store_indicator: 2
-            _content:
-              access_groups:
-                admin: []
-                collaborator: []
-                commit: []
-                ticket: []
-              access_users:
-                admin: []
-                collaborator: []
-                commit: []
-                owner:
-                - lbarczio
-                ticket: []
-              close_status: []
-              custom_keys: []
-              date_created: '1603187163'
-              date_modified: '1603187163'
-              description: The python-requre package
-              fullname: forks/lbarczio/rpms/python-requre
-              id: 46377
-              milestones: {}
-              name: python-requre
-              namespace: rpms
-              parent:
-                access_groups:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  ticket: []
-                access_users:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  owner:
-                  - jscotka
-                  ticket: []
-                close_status: []
-                custom_keys: []
-                date_created: '1586178839'
-                date_modified: '1586178846'
-                description: The python-requre package
-                fullname: rpms/python-requre
-                id: 41574
-                milestones: {}
-                name: python-requre
-                namespace: rpms
-                parent: null
-                priorities: {}
-                tags: []
-                url_path: rpms/python-requre
-                user:
-                  fullname: "Jan \u0160\u010Dotka"
-                  name: jscotka
-                  url_path: user/jscotka
-              priorities: {}
-              tags: []
-              url_path: fork/lbarczio/rpms/python-requre
-              user:
-                fullname: "Laura Barcziov\xE1"
-                name: lbarczio
-                url_path: user/lbarczio
-            _next: null
-            elapsed: 0.236161
-            encoding: null
-            headers:
-              Connection: Keep-Alive
-              Date: Tue, 20 Oct 2020 10:48:12 GMT
-              Keep-Alive: timeout=15, max=494
-              Referrer-Policy: same-origin
-              Server: Apache
-              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-              X-Content-Type-Options: nosniff
-              X-Fedora-ProxyServer: proxy10.iad2.fedoraproject.org
-              X-Fedora-RequestID: X47AbKsq79ncW0mHIY9eyQAAAlg
-              X-Frame-Options: SAMEORIGIN
-              X-Xss-Protection: 1; mode=block
-              apptime: D=115638
-              content-length: '1583'
-              content-security-policy: default-src 'self'; script-src 'self' 'nonce-ibNfSjVYWx6TnpzywuFDaReXW'
-                https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
-                'self' 'nonce-ibNfSjVYWx6TnpzywuFDaReXW'; object-src 'none'; base-uri
-                'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
-                https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
-              content-type: application/json
-              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiNzc0Mzc2Mjk3ODAyMTA0NTIxZTUwZmJhMTlkNjhjZjgxN2M0YmJhMyJ9.EnBR7A.TdZzsTSriK4rocwrd8YLiIGLYz4;
-                Expires=Fri, 20-Nov-2020 10:48:12 GMT; Secure; HttpOnly; Path=/
-              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
-            raw: !!binary ""
-            reason: OK
-            status_code: 200
-      https://src.fedoraproject.org/api/0/fork/lbarczio/rpms/python-requre/git/urls:
-        all:
-          metadata:
-            latency: 0.20279693603515625
-            module_call_list:
-            - unittest.case
-            - requre.online_replacing
-            - tests_recording.test_api
-            - packit.api
-            - packit.distgit
-            - ogr.services.pagure.project
-            - ogr.services.pagure.service
-            - requests.sessions
-            - requre.objects
-            - requre.cassette
-            - requests.sessions
-            - send
-          output:
-            __store_indicator: 2
-            _content:
-              total_urls: 2
-              urls:
-                git: https://src.fedoraproject.org/forks/lbarczio/rpms/python-requre.git
-                ssh: ssh://lbarczio@pkgs.fedoraproject.org/forks/lbarczio/rpms/python-requre.git
-            _next: null
-            elapsed: 0.202038
-            encoding: null
-            headers:
-              Connection: Keep-Alive
-              Date: Tue, 20 Oct 2020 10:48:01 GMT
-              Keep-Alive: timeout=15, max=493
-              Referrer-Policy: same-origin
-              Server: Apache
-              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-              X-Content-Type-Options: nosniff
-              X-Fedora-ProxyServer: proxy01.iad2.fedoraproject.org
-              X-Fedora-RequestID: X47AYcPQdRj6M9GzC2ZrHAAAAdI
-              X-Frame-Options: SAMEORIGIN
-              X-Xss-Protection: 1; mode=block
-              apptime: D=84671
-              content-length: '212'
-              content-security-policy: default-src 'self'; script-src 'self' 'nonce-YcyrfQFDehF8Ix6sVHYOtBvUD'
-                https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
-                'self' 'nonce-YcyrfQFDehF8Ix6sVHYOtBvUD'; object-src 'none'; base-uri
-                'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
-                https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
-              content-type: application/json
-              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiNzc0Mzc2Mjk3ODAyMTA0NTIxZTUwZmJhMTlkNjhjZjgxN2M0YmJhMyJ9.EnBR4Q.DgUnNodt5dsLi1N6VmfcLMGWqxk;
-                Expires=Fri, 20-Nov-2020 10:48:01 GMT; Secure; HttpOnly; Path=/
-              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
-            raw: !!binary ""
-            reason: OK
-            status_code: 200
-      https://src.fedoraproject.org/api/0/fork/packit/rpms/python-requre:
-        all:
-          metadata:
-            latency: 0.31372690200805664
-            module_call_list:
-            - unittest.case
-            - requre.online_replacing
-            - tests_recording.test_api
-            - packit.api
-            - packit.distgit
-            - ogr.services.pagure.project
-            - ogr.services.pagure.service
-            - requests.sessions
-            - requre.objects
-            - requre.cassette
-            - requests.sessions
-            - send
-          output:
-            __store_indicator: 2
-            _content:
-              access_groups:
-                admin: []
-                collaborator: []
-                commit: []
-                ticket: []
-              access_users:
-                admin: []
-                collaborator: []
-                commit: []
-                owner:
-                - packit
-                ticket: []
-              close_status: []
-              custom_keys: []
-              date_created: '1600761157'
-              date_modified: '1600761157'
-              description: The python-requre package
-              fullname: forks/packit/rpms/python-requre
-              id: 45851
-              milestones: {}
-              name: python-requre
-              namespace: rpms
-              parent:
-                access_groups:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  ticket: []
-                access_users:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  owner:
-                  - jscotka
-                  ticket: []
-                close_status: []
-                custom_keys: []
-                date_created: '1586178839'
-                date_modified: '1586178846'
-                description: The python-requre package
-                fullname: rpms/python-requre
-                id: 41574
-                milestones: {}
-                name: python-requre
-                namespace: rpms
-                parent: null
-                priorities: {}
-                tags: []
-                url_path: rpms/python-requre
-                user:
-                  fullname: "Jan \u0160\u010Dotka"
-                  name: jscotka
-                  url_path: user/jscotka
-              priorities: {}
-              tags: []
-              url_path: fork/packit/rpms/python-requre
-              user:
-                fullname: Packit Bot
-                name: packit
-                url_path: user/packit
-            _next: null
-            elapsed: 0.312867
-            encoding: null
-            headers:
-              Connection: Keep-Alive
-              Date: Tue, 20 Oct 2020 10:48:10 GMT
-              Keep-Alive: timeout=15, max=498
-              Referrer-Policy: same-origin
-              Server: Apache
-              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-              X-Content-Type-Options: nosniff
-              X-Fedora-ProxyServer: proxy10.iad2.fedoraproject.org
-              X-Fedora-RequestID: X47Aaqsq79ncW0mHIY9eqwAAAko
-              X-Frame-Options: SAMEORIGIN
-              X-Xss-Protection: 1; mode=block
-              apptime: D=192967
-              content-length: '1563'
-              content-security-policy: default-src 'self'; script-src 'self' 'nonce-gH9r6LO3Ws3K0XRDHOcmaKZ1Z'
-                https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
-                'self' 'nonce-gH9r6LO3Ws3K0XRDHOcmaKZ1Z'; object-src 'none'; base-uri
-                'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
-                https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
-              content-type: application/json
-              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiNzc0Mzc2Mjk3ODAyMTA0NTIxZTUwZmJhMTlkNjhjZjgxN2M0YmJhMyJ9.EnBR6g.zGVDuljbC0E_I10nBNv2Splorck;
-                Expires=Fri, 20-Nov-2020 10:48:10 GMT; Secure; HttpOnly; Path=/
-              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
-            raw: !!binary ""
-            reason: OK
-            status_code: 200
-      https://src.fedoraproject.org/api/0/projects?fork=True&pattern=python-requre:
-        all:
-          metadata:
-            latency: 0.894395112991333
-            module_call_list:
-            - unittest.case
-            - requre.online_replacing
-            - tests_recording.test_api
-            - packit.api
-            - packit.distgit
-            - ogr.services.pagure.project
-            - ogr.services.pagure.service
-            - requests.sessions
-            - requre.objects
-            - requre.cassette
-            - requests.sessions
-            - send
-          output:
-            __store_indicator: 2
-            _content:
-              args:
-                fork: true
-                namespace: null
-                owner: null
-                page: 1
-                pattern: python-requre
-                per_page: 20
-                short: false
-                tags: []
-                username: null
-              pagination:
-                first: https://src.fedoraproject.org/api/0/projects?per_page=20&fork=True&pattern=python-requre&page=1
-                last: https://src.fedoraproject.org/api/0/projects?per_page=20&fork=True&pattern=python-requre&page=1
-                next: null
-                page: 1
-                pages: 1
-                per_page: 20
-                prev: null
-              projects:
-              - access_groups:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  ticket: []
-                access_users:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  owner:
-                  - jscotka
-                  ticket: []
-                close_status: []
-                custom_keys: []
-                date_created: '1600700802'
-                date_modified: '1600700802'
-                description: The python-requre package
-                fullname: forks/jscotka/rpms/python-requre
-                id: 45827
-                milestones: {}
-                name: python-requre
-                namespace: rpms
-                parent:
-                  access_groups:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    ticket: []
-                  access_users:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    owner:
-                    - jscotka
-                    ticket: []
-                  close_status: []
-                  custom_keys: []
-                  date_created: '1586178839'
-                  date_modified: '1586178846'
-                  description: The python-requre package
-                  fullname: rpms/python-requre
-                  id: 41574
-                  milestones: {}
-                  name: python-requre
-                  namespace: rpms
-                  parent: null
-                  priorities: {}
-                  tags: []
-                  url_path: rpms/python-requre
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                priorities: {}
-                tags: []
-                url_path: fork/jscotka/rpms/python-requre
-                user:
-                  fullname: "Jan \u0160\u010Dotka"
-                  name: jscotka
-                  url_path: user/jscotka
-              - access_groups:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  ticket: []
-                access_users:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  owner:
-                  - packit
-                  ticket: []
-                close_status: []
-                custom_keys: []
-                date_created: '1600761157'
-                date_modified: '1600761157'
-                description: The python-requre package
-                fullname: forks/packit/rpms/python-requre
-                id: 45851
-                milestones: {}
-                name: python-requre
-                namespace: rpms
-                parent:
-                  access_groups:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    ticket: []
-                  access_users:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    owner:
-                    - jscotka
-                    ticket: []
-                  close_status: []
-                  custom_keys: []
-                  date_created: '1586178839'
-                  date_modified: '1586178846'
-                  description: The python-requre package
-                  fullname: rpms/python-requre
-                  id: 41574
-                  milestones: {}
-                  name: python-requre
-                  namespace: rpms
-                  parent: null
-                  priorities: {}
-                  tags: []
-                  url_path: rpms/python-requre
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                priorities: {}
-                tags: []
-                url_path: fork/packit/rpms/python-requre
-                user:
-                  fullname: Packit Bot
-                  name: packit
-                  url_path: user/packit
-              - access_groups:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  ticket: []
-                access_users:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  owner:
-                  - lachmanfrantisek
-                  ticket: []
-                close_status: []
-                custom_keys: []
-                date_created: '1600763657'
-                date_modified: '1600763657'
-                description: The python-requre package
-                fullname: forks/lachmanfrantisek/rpms/python-requre
-                id: 45852
-                milestones: {}
-                name: python-requre
-                namespace: rpms
-                parent:
-                  access_groups:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    ticket: []
-                  access_users:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    owner:
-                    - jscotka
-                    ticket: []
-                  close_status: []
-                  custom_keys: []
-                  date_created: '1586178839'
-                  date_modified: '1586178846'
-                  description: The python-requre package
-                  fullname: rpms/python-requre
-                  id: 41574
-                  milestones: {}
-                  name: python-requre
-                  namespace: rpms
-                  parent: null
-                  priorities: {}
-                  tags: []
-                  url_path: rpms/python-requre
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                priorities: {}
-                tags: []
-                url_path: fork/lachmanfrantisek/rpms/python-requre
-                user:
-                  fullname: "Franti\u0161ek Lachman"
-                  name: lachmanfrantisek
-                  url_path: user/lachmanfrantisek
-              - access_groups:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  ticket: []
-                access_users:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  owner:
-                  - lbarczio
-                  ticket: []
-                close_status: []
-                custom_keys: []
-                date_created: '1603187163'
-                date_modified: '1603187163'
-                description: The python-requre package
-                fullname: forks/lbarczio/rpms/python-requre
-                id: 46377
-                milestones: {}
-                name: python-requre
-                namespace: rpms
-                parent:
-                  access_groups:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    ticket: []
-                  access_users:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    owner:
-                    - jscotka
-                    ticket: []
-                  close_status: []
-                  custom_keys: []
-                  date_created: '1586178839'
-                  date_modified: '1586178846'
-                  description: The python-requre package
-                  fullname: rpms/python-requre
-                  id: 41574
-                  milestones: {}
-                  name: python-requre
-                  namespace: rpms
-                  parent: null
-                  priorities: {}
-                  tags: []
-                  url_path: rpms/python-requre
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                priorities: {}
-                tags: []
-                url_path: fork/lbarczio/rpms/python-requre
-                user:
-                  fullname: "Laura Barcziov\xE1"
-                  name: lbarczio
-                  url_path: user/lbarczio
-              total_projects: 4
-            _next: null
-            elapsed: 0.892922
-            encoding: null
-            headers:
-              Connection: Keep-Alive
-              Date: Tue, 20 Oct 2020 10:48:10 GMT
-              Keep-Alive: timeout=15, max=500
-              Referrer-Policy: same-origin
-              Server: Apache
-              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-              X-Content-Type-Options: nosniff
-              X-Fedora-ProxyServer: proxy10.iad2.fedoraproject.org
-              X-Fedora-RequestID: X47Aaqsq79ncW0mHIY9eigAAAkU
-              X-Frame-Options: SAMEORIGIN
-              X-Xss-Protection: 1; mode=block
-              apptime: D=277818
-              content-length: '8088'
-              content-security-policy: default-src 'self'; script-src 'self' 'nonce-rGrHs4eBmZWQxwQIYIaIv9Oj9'
-                https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
-                'self' 'nonce-rGrHs4eBmZWQxwQIYIaIv9Oj9'; object-src 'none'; base-uri
-                'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
-                https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
-              content-type: application/json
-              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiNzc0Mzc2Mjk3ODAyMTA0NTIxZTUwZmJhMTlkNjhjZjgxN2M0YmJhMyJ9.EnBR6g.zGVDuljbC0E_I10nBNv2Splorck;
-                Expires=Fri, 20-Nov-2020 10:48:10 GMT; Secure; HttpOnly; Path=/
-              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
             raw: !!binary ""
             reason: OK
             status_code: 200
       https://src.fedoraproject.org/api/0/rpms/python-requre/pull-requests?status=Open:
         all:
           metadata:
-            latency: 1.8772811889648438
+            latency: 1.3923227787017822
             module_call_list:
             - unittest.case
             - requre.online_replacing
@@ -1691,19 +1075,507 @@ requests.sessions:
               requests:
               - assignee: null
                 branch: master
-                branch_from: 0.5.0-master-update
-                cached_merge_status: FFORWARD
+                branch_from: 0.4.0-master-update
+                cached_merge_status: unknown
                 closed_at: null
                 closed_by: null
                 comments: []
-                commit_start: 4a3a9c8a45e387e7c50f0e1f10c914649f1cdfff
-                commit_stop: 4a3a9c8a45e387e7c50f0e1f10c914649f1cdfff
+                commit_start: 9f8dd9632ef2cb4ed263edb068c866860ca5d10f
+                commit_stop: 9f8dd9632ef2cb4ed263edb068c866860ca5d10f
+                date_created: '1603368005'
+                id: 46
+                initial_comment: 'Upstream tag: 0.4.0
+
+                  Upstream commit: 38cd5bb6'
+                last_updated: '1603368005'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - lachmanfrantisek
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600763657'
+                  date_modified: '1600763657'
+                  description: The python-requre package
+                  fullname: forks/lachmanfrantisek/rpms/python-requre
+                  id: 45852
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/lachmanfrantisek/rpms/python-requre
+                  user:
+                    fullname: "Franti\u0161ek Lachman"
+                    name: lachmanfrantisek
+                    url_path: user/lachmanfrantisek
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.4.0
+                uid: 59423c84c54a40a79bdb2b65b9939ece
+                updated_on: '1603368005'
+                user:
+                  fullname: "Franti\u0161ek Lachman"
+                  name: lachmanfrantisek
+                  url_path: user/lachmanfrantisek
+              - assignee: null
+                branch: master
+                branch_from: 0.4.0-master-update
+                cached_merge_status: FFORWARD
+                closed_at: null
+                closed_by: null
+                comments:
+                - comment: rebased onto 9f8dd9632ef2cb4ed263edb068c866860ca5d10f
+                  commit: null
+                  date_created: '1603368001'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 59157
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Franti\u0161ek Lachman"
+                    name: lachmanfrantisek
+                    url_path: user/lachmanfrantisek
+                commit_start: 9f8dd9632ef2cb4ed263edb068c866860ca5d10f
+                commit_stop: 9f8dd9632ef2cb4ed263edb068c866860ca5d10f
+                date_created: '1603364971'
+                id: 45
+                initial_comment: 'Upstream tag: 0.4.0
+
+                  Upstream commit: 2d5ffe6b'
+                last_updated: '1603368134'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - lachmanfrantisek
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1600763657'
+                  date_modified: '1600763657'
+                  description: The python-requre package
+                  fullname: forks/lachmanfrantisek/rpms/python-requre
+                  id: 45852
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/lachmanfrantisek/rpms/python-requre
+                  user:
+                    fullname: "Franti\u0161ek Lachman"
+                    name: lachmanfrantisek
+                    url_path: user/lachmanfrantisek
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.4.0
+                uid: 3cc6fe2b20b84480b8cf01a576accc35
+                updated_on: '1603368134'
+                user:
+                  fullname: "Franti\u0161ek Lachman"
+                  name: lachmanfrantisek
+                  url_path: user/lachmanfrantisek
+              - assignee: null
+                branch: master
+                branch_from: 0.5.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments: []
+                commit_start: ec04725b32f8a10594bde0972930b60b1d336067
+                commit_stop: ec04725b32f8a10594bde0972930b60b1d336067
+                date_created: '1603190937'
+                id: 42
+                initial_comment: 'Upstream tag: 0.5.0
+
+                  Upstream commit: e815c39f'
+                last_updated: '1603368000'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - lbarczio
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1603187163'
+                  date_modified: '1603187163'
+                  description: The python-requre package
+                  fullname: forks/lbarczio/rpms/python-requre
+                  id: 46377
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/lbarczio/rpms/python-requre
+                  user:
+                    fullname: "Laura Barcziov\xE1"
+                    name: lbarczio
+                    url_path: user/lbarczio
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.5.0
+                uid: 63645772baac4205bafae497d9844ea5
+                updated_on: '1603190937'
+                user:
+                  fullname: "Laura Barcziov\xE1"
+                  name: lbarczio
+                  url_path: user/lbarczio
+              - assignee: null
+                branch: master
+                branch_from: 0.4.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments: []
+                commit_start: 4f91816ecedb9fa3c323313725d2e782ac166bce
+                commit_stop: 4f91816ecedb9fa3c323313725d2e782ac166bce
+                date_created: '1603190892'
+                id: 41
+                initial_comment: 'Upstream tag: 0.4.0
+
+                  Upstream commit: 6957453b'
+                last_updated: '1603368000'
+                project:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - jscotka
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1586178839'
+                  date_modified: '1586178846'
+                  description: The python-requre package
+                  fullname: rpms/python-requre
+                  id: 41574
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent: null
+                  priorities: {}
+                  tags: []
+                  url_path: rpms/python-requre
+                  user:
+                    fullname: "Jan \u0160\u010Dotka"
+                    name: jscotka
+                    url_path: user/jscotka
+                remote_git: null
+                repo_from:
+                  access_groups:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    ticket: []
+                  access_users:
+                    admin: []
+                    collaborator: []
+                    commit: []
+                    owner:
+                    - lbarczio
+                    ticket: []
+                  close_status: []
+                  custom_keys: []
+                  date_created: '1603187163'
+                  date_modified: '1603187163'
+                  description: The python-requre package
+                  fullname: forks/lbarczio/rpms/python-requre
+                  id: 46377
+                  milestones: {}
+                  name: python-requre
+                  namespace: rpms
+                  parent:
+                    access_groups:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      ticket: []
+                    access_users:
+                      admin: []
+                      collaborator: []
+                      commit: []
+                      owner:
+                      - jscotka
+                      ticket: []
+                    close_status: []
+                    custom_keys: []
+                    date_created: '1586178839'
+                    date_modified: '1586178846'
+                    description: The python-requre package
+                    fullname: rpms/python-requre
+                    id: 41574
+                    milestones: {}
+                    name: python-requre
+                    namespace: rpms
+                    parent: null
+                    priorities: {}
+                    tags: []
+                    url_path: rpms/python-requre
+                    user:
+                      fullname: "Jan \u0160\u010Dotka"
+                      name: jscotka
+                      url_path: user/jscotka
+                  priorities: {}
+                  tags: []
+                  url_path: fork/lbarczio/rpms/python-requre
+                  user:
+                    fullname: "Laura Barcziov\xE1"
+                    name: lbarczio
+                    url_path: user/lbarczio
+                status: Open
+                tags: []
+                threshold_reached: null
+                title: Update to upstream release 0.4.0
+                uid: f876e7aa4d7e4f549169e2f85c3e948c
+                updated_on: '1603191025'
+                user:
+                  fullname: "Laura Barcziov\xE1"
+                  name: lbarczio
+                  url_path: user/lbarczio
+              - assignee: null
+                branch: master
+                branch_from: 0.5.0-master-update
+                cached_merge_status: unknown
+                closed_at: null
+                closed_by: null
+                comments: []
+                commit_start: ec04725b32f8a10594bde0972930b60b1d336067
+                commit_stop: ec04725b32f8a10594bde0972930b60b1d336067
                 date_created: '1603187330'
                 id: 40
                 initial_comment: 'Upstream tag: 0.5.0
 
                   Upstream commit: e815c39f'
-                last_updated: '1603187351'
+                last_updated: '1603368000'
                 project:
                   access_groups:
                     admin: []
@@ -1810,18 +1682,34 @@ requests.sessions:
               - assignee: null
                 branch: master
                 branch_from: 0.4.0-master-update
-                cached_merge_status: FFORWARD
+                cached_merge_status: unknown
                 closed_at: null
                 closed_by: null
-                comments: []
-                commit_start: c6a732cfbbd05e5b65281992cb5df1a8d8502b7f
-                commit_stop: c6a732cfbbd05e5b65281992cb5df1a8d8502b7f
+                comments:
+                - comment: rebased onto 4f91816ecedb9fa3c323313725d2e782ac166bce
+                  commit: null
+                  date_created: '1603190889'
+                  edited_on: null
+                  editor: null
+                  filename: null
+                  id: 59021
+                  line: null
+                  notification: true
+                  parent: null
+                  reactions: {}
+                  tree: null
+                  user:
+                    fullname: "Laura Barcziov\xE1"
+                    name: lbarczio
+                    url_path: user/lbarczio
+                commit_start: 4f91816ecedb9fa3c323313725d2e782ac166bce
+                commit_stop: 4f91816ecedb9fa3c323313725d2e782ac166bce
                 date_created: '1603187176'
                 id: 39
                 initial_comment: 'Upstream tag: 0.4.0
 
                   Upstream commit: 6957453b'
-                last_updated: '1603187351'
+                last_updated: '1603368000'
                 project:
                   access_groups:
                     admin: []
@@ -1920,7 +1808,7 @@ requests.sessions:
                 threshold_reached: null
                 title: Update to upstream release 0.4.0
                 uid: 9997c6999d90495e9c7c3a97e044f017
-                updated_on: '1603187176'
+                updated_on: '1603191048'
                 user:
                   fullname: "Laura Barcziov\xE1"
                   name: lbarczio
@@ -1955,7 +1843,7 @@ requests.sessions:
                 initial_comment: 'Upstream tag: 0.5.0
 
                   Upstream commit: 87808f12'
-                last_updated: '1603187326'
+                last_updated: '1603368000'
                 project:
                   access_groups:
                     admin: []
@@ -2089,7 +1977,7 @@ requests.sessions:
                 initial_comment: 'Upstream tag: 0.4.0
 
                   Upstream commit: 6957453b'
-                last_updated: '1603187326'
+                last_updated: '1603368000'
                 project:
                   access_groups:
                     admin: []
@@ -2255,7 +2143,7 @@ requests.sessions:
                 initial_comment: 'Upstream tag: 0.5.0
 
                   Upstream commit: 87808f12'
-                last_updated: '1603187326'
+                last_updated: '1603368000'
                 project:
                   access_groups:
                     admin: []
@@ -2421,7 +2309,7 @@ requests.sessions:
                 initial_comment: 'Upstream tag: 0.4.0
 
                   Upstream commit: 6957453b'
-                last_updated: '1603187326'
+                last_updated: '1603368000'
                 project:
                   access_groups:
                     admin: []
@@ -2603,7 +2491,7 @@ requests.sessions:
                 initial_comment: 'Upstream tag: 0.5.0
 
                   Upstream commit: 87808f12'
-                last_updated: '1603187326'
+                last_updated: '1603368000'
                 project:
                   access_groups:
                     admin: []
@@ -2785,7 +2673,7 @@ requests.sessions:
                 initial_comment: 'Upstream tag: 0.4.0
 
                   Upstream commit: 6957453b'
-                last_updated: '1603187326'
+                last_updated: '1603368000'
                 project:
                   access_groups:
                     admin: []
@@ -2983,7 +2871,7 @@ requests.sessions:
                 initial_comment: 'Upstream tag: 0.4.0
 
                   Upstream commit: 6957453b'
-                last_updated: '1603187326'
+                last_updated: '1603368000'
                 project:
                   access_groups:
                     admin: []
@@ -3197,7 +3085,7 @@ requests.sessions:
                 initial_comment: 'Upstream tag: 0.4.0
 
                   Upstream commit: 6957453b'
-                last_updated: '1603187326'
+                last_updated: '1603368000'
                 project:
                   access_groups:
                     admin: []
@@ -3427,7 +3315,7 @@ requests.sessions:
                 initial_comment: 'Upstream tag: 0.4.0
 
                   Upstream commit: 6957453b'
-                last_updated: '1603187326'
+                last_updated: '1603368000'
                 project:
                   access_groups:
                     admin: []
@@ -3673,7 +3561,7 @@ requests.sessions:
                 initial_comment: 'Upstream tag: 0.4.0
 
                   Upstream commit: 6957453b'
-                last_updated: '1603187326'
+                last_updated: '1603368000'
                 project:
                   access_groups:
                     admin: []
@@ -3871,7 +3759,7 @@ requests.sessions:
                 initial_comment: 'Upstream tag: 0.5.0
 
                   Upstream commit: 87808f12'
-                last_updated: '1603187326'
+                last_updated: '1603368000'
                 project:
                   access_groups:
                     admin: []
@@ -4149,7 +4037,7 @@ requests.sessions:
                 initial_comment: 'Upstream tag: 0.4.0
 
                   Upstream commit: 6957453b'
-                last_updated: '1603187326'
+                last_updated: '1603368000'
                 project:
                   access_groups:
                     admin: []
@@ -4363,7 +4251,7 @@ requests.sessions:
                 initial_comment: 'Upstream tag: 0.5.0
 
                   Upstream commit: d0b1b9b5'
-                last_updated: '1603187326'
+                last_updated: '1603368000'
                 project:
                   access_groups:
                     admin: []
@@ -4657,7 +4545,7 @@ requests.sessions:
                 initial_comment: 'Upstream tag: 0.4.0
 
                   Upstream commit: 6957453b'
-                last_updated: '1603187326'
+                last_updated: '1603368000'
                 project:
                   access_groups:
                     admin: []
@@ -4761,1128 +4649,32 @@ requests.sessions:
                   fullname: "Jan \u0160\u010Dotka"
                   name: jscotka
                   url_path: user/jscotka
-              - assignee: null
-                branch: master
-                branch_from: 0.5.0-master-update
-                cached_merge_status: unknown
-                closed_at: null
-                closed_by: null
-                comments:
-                - comment: rebased onto 3f8503b11745e5d2767efde60e0512edf3815242
-                  commit: null
-                  date_created: '1601630452'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57636
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 605b4b249f5b32f5610f3877f9a8f9f872a2dca0
-                  commit: null
-                  date_created: '1601979101'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57904
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 854125542da791e8df52c274d67752d208a3bdb1
-                  commit: null
-                  date_created: '1602000286'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58034
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 268ef502395f86267de91ced5643affa6edf5434
-                  commit: null
-                  date_created: '1602058075'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58111
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 9c3150bbc0676f0c279e2f589b9e99c2eb323aa9
-                  commit: null
-                  date_created: '1602156191'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58260
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 4cf77c217d59dbcea7bfdd4bb12f3bd4394c66b2
-                  commit: null
-                  date_created: '1602156886'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58285
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
-                  commit: null
-                  date_created: '1602159231'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58314
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                commit_start: 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
-                commit_stop: 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
-                date_created: '1601541260'
-                id: 24
-                initial_comment: 'Upstream tag: 0.5.0
-
-                  Upstream commit: d0b1b9b5'
-                last_updated: '1603187326'
-                project:
-                  access_groups:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    ticket: []
-                  access_users:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    owner:
-                    - jscotka
-                    ticket: []
-                  close_status: []
-                  custom_keys: []
-                  date_created: '1586178839'
-                  date_modified: '1586178846'
-                  description: The python-requre package
-                  fullname: rpms/python-requre
-                  id: 41574
-                  milestones: {}
-                  name: python-requre
-                  namespace: rpms
-                  parent: null
-                  priorities: {}
-                  tags: []
-                  url_path: rpms/python-requre
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                remote_git: null
-                repo_from:
-                  access_groups:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    ticket: []
-                  access_users:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    owner:
-                    - jscotka
-                    ticket: []
-                  close_status: []
-                  custom_keys: []
-                  date_created: '1600700802'
-                  date_modified: '1600700802'
-                  description: The python-requre package
-                  fullname: forks/jscotka/rpms/python-requre
-                  id: 45827
-                  milestones: {}
-                  name: python-requre
-                  namespace: rpms
-                  parent:
-                    access_groups:
-                      admin: []
-                      collaborator: []
-                      commit: []
-                      ticket: []
-                    access_users:
-                      admin: []
-                      collaborator: []
-                      commit: []
-                      owner:
-                      - jscotka
-                      ticket: []
-                    close_status: []
-                    custom_keys: []
-                    date_created: '1586178839'
-                    date_modified: '1586178846'
-                    description: The python-requre package
-                    fullname: rpms/python-requre
-                    id: 41574
-                    milestones: {}
-                    name: python-requre
-                    namespace: rpms
-                    parent: null
-                    priorities: {}
-                    tags: []
-                    url_path: rpms/python-requre
-                    user:
-                      fullname: "Jan \u0160\u010Dotka"
-                      name: jscotka
-                      url_path: user/jscotka
-                  priorities: {}
-                  tags: []
-                  url_path: fork/jscotka/rpms/python-requre
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                status: Open
-                tags: []
-                threshold_reached: null
-                title: Update to upstream release 0.5.0
-                uid: 8b3de993a8814d01811461f5cf0ee1b4
-                updated_on: '1602159231'
-                user:
-                  fullname: "Jan \u0160\u010Dotka"
-                  name: jscotka
-                  url_path: user/jscotka
-              - assignee: null
-                branch: master
-                branch_from: 0.4.0-master-update
-                cached_merge_status: unknown
-                closed_at: null
-                closed_by: null
-                comments:
-                - comment: rebased onto e5679437d476dbfd88dfc9038ddf477b5c7fdc36
-                  commit: null
-                  date_created: '1601630417'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57633
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 103e8adbdf00cdeb619dda4f9b8d892a71085c04
-                  commit: null
-                  date_created: '1601979055'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57898
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 0a64f99ed3ef05e58c18da2936af748d19c169b4
-                  commit: null
-                  date_created: '1601985142'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57930
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 7a77b7f7f4adec9aa0e82d3a350b851fbb56a40f
-                  commit: null
-                  date_created: '1601985181'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57938
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto d4262e05bf82a6732a1884d93b0d4a65271651ba
-                  commit: null
-                  date_created: '1601985918'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57949
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 2833e9f1a6fb729eebd8882334bb7aceb5147db1
-                  commit: null
-                  date_created: '1601998794'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57998
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 2740c9191c27ad7c62f9c2b6952cdd50c45406da
-                  commit: null
-                  date_created: '1601999173'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58013
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 686ad232d9e929f36a0231deefb70f412b0e2b86
-                  commit: null
-                  date_created: '1602000244'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58027
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto d79b8d99ea4191535fd5bf77f13342d5defcbaf3
-                  commit: null
-                  date_created: '1602058033'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58102
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 42ff00213954ed2cd518e7bde7f13c71ff2f7768
-                  commit: null
-                  date_created: '1602156177'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58250
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 334d3538bc72136f3a2a2606d5d1385a237a8b88
-                  commit: null
-                  date_created: '1602156844'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58274
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 6f8b072c37de57111c0d823ceea25c2de524f2bd
-                  commit: null
-                  date_created: '1602159215'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58303
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                commit_start: 6f8b072c37de57111c0d823ceea25c2de524f2bd
-                commit_stop: 6f8b072c37de57111c0d823ceea25c2de524f2bd
-                date_created: '1601541218'
-                id: 23
-                initial_comment: 'Upstream tag: 0.4.0
-
-                  Upstream commit: 6957453b'
-                last_updated: '1603187326'
-                project:
-                  access_groups:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    ticket: []
-                  access_users:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    owner:
-                    - jscotka
-                    ticket: []
-                  close_status: []
-                  custom_keys: []
-                  date_created: '1586178839'
-                  date_modified: '1586178846'
-                  description: The python-requre package
-                  fullname: rpms/python-requre
-                  id: 41574
-                  milestones: {}
-                  name: python-requre
-                  namespace: rpms
-                  parent: null
-                  priorities: {}
-                  tags: []
-                  url_path: rpms/python-requre
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                remote_git: null
-                repo_from:
-                  access_groups:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    ticket: []
-                  access_users:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    owner:
-                    - jscotka
-                    ticket: []
-                  close_status: []
-                  custom_keys: []
-                  date_created: '1600700802'
-                  date_modified: '1600700802'
-                  description: The python-requre package
-                  fullname: forks/jscotka/rpms/python-requre
-                  id: 45827
-                  milestones: {}
-                  name: python-requre
-                  namespace: rpms
-                  parent:
-                    access_groups:
-                      admin: []
-                      collaborator: []
-                      commit: []
-                      ticket: []
-                    access_users:
-                      admin: []
-                      collaborator: []
-                      commit: []
-                      owner:
-                      - jscotka
-                      ticket: []
-                    close_status: []
-                    custom_keys: []
-                    date_created: '1586178839'
-                    date_modified: '1586178846'
-                    description: The python-requre package
-                    fullname: rpms/python-requre
-                    id: 41574
-                    milestones: {}
-                    name: python-requre
-                    namespace: rpms
-                    parent: null
-                    priorities: {}
-                    tags: []
-                    url_path: rpms/python-requre
-                    user:
-                      fullname: "Jan \u0160\u010Dotka"
-                      name: jscotka
-                      url_path: user/jscotka
-                  priorities: {}
-                  tags: []
-                  url_path: fork/jscotka/rpms/python-requre
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                status: Open
-                tags: []
-                threshold_reached: null
-                title: Update to upstream release 0.4.0
-                uid: c9b782fffc254519a5f9bc10b21bc5ae
-                updated_on: '1602159566'
-                user:
-                  fullname: "Jan \u0160\u010Dotka"
-                  name: jscotka
-                  url_path: user/jscotka
-              - assignee: null
-                branch: master
-                branch_from: 0.5.0-master-update
-                cached_merge_status: unknown
-                closed_at: null
-                closed_by: null
-                comments:
-                - comment: rebased onto dc0a74235c39cf2cd31b2dc71fcbb357c0fd2537
-                  commit: null
-                  date_created: '1601541257'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57486
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 3f8503b11745e5d2767efde60e0512edf3815242
-                  commit: null
-                  date_created: '1601630453'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57638
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 605b4b249f5b32f5610f3877f9a8f9f872a2dca0
-                  commit: null
-                  date_created: '1601979101'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57906
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 268ef502395f86267de91ced5643affa6edf5434
-                  commit: null
-                  date_created: '1602058075'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58112
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 9c3150bbc0676f0c279e2f589b9e99c2eb323aa9
-                  commit: null
-                  date_created: '1602156191'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58261
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 4cf77c217d59dbcea7bfdd4bb12f3bd4394c66b2
-                  commit: null
-                  date_created: '1602156886'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58284
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
-                  commit: null
-                  date_created: '1602159231'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58315
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                commit_start: 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
-                commit_stop: 3a90c5cdcd6100ada23d88af50b7e098d083b7d9
-                date_created: '1601539476'
-                id: 22
-                initial_comment: 'Upstream tag: 0.5.0
-
-                  Upstream commit: d0b1b9b5'
-                last_updated: '1603187326'
-                project:
-                  access_groups:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    ticket: []
-                  access_users:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    owner:
-                    - jscotka
-                    ticket: []
-                  close_status: []
-                  custom_keys: []
-                  date_created: '1586178839'
-                  date_modified: '1586178846'
-                  description: The python-requre package
-                  fullname: rpms/python-requre
-                  id: 41574
-                  milestones: {}
-                  name: python-requre
-                  namespace: rpms
-                  parent: null
-                  priorities: {}
-                  tags: []
-                  url_path: rpms/python-requre
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                remote_git: null
-                repo_from:
-                  access_groups:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    ticket: []
-                  access_users:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    owner:
-                    - jscotka
-                    ticket: []
-                  close_status: []
-                  custom_keys: []
-                  date_created: '1600700802'
-                  date_modified: '1600700802'
-                  description: The python-requre package
-                  fullname: forks/jscotka/rpms/python-requre
-                  id: 45827
-                  milestones: {}
-                  name: python-requre
-                  namespace: rpms
-                  parent:
-                    access_groups:
-                      admin: []
-                      collaborator: []
-                      commit: []
-                      ticket: []
-                    access_users:
-                      admin: []
-                      collaborator: []
-                      commit: []
-                      owner:
-                      - jscotka
-                      ticket: []
-                    close_status: []
-                    custom_keys: []
-                    date_created: '1586178839'
-                    date_modified: '1586178846'
-                    description: The python-requre package
-                    fullname: rpms/python-requre
-                    id: 41574
-                    milestones: {}
-                    name: python-requre
-                    namespace: rpms
-                    parent: null
-                    priorities: {}
-                    tags: []
-                    url_path: rpms/python-requre
-                    user:
-                      fullname: "Jan \u0160\u010Dotka"
-                      name: jscotka
-                      url_path: user/jscotka
-                  priorities: {}
-                  tags: []
-                  url_path: fork/jscotka/rpms/python-requre
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                status: Open
-                tags: []
-                threshold_reached: null
-                title: Update to upstream release 0.5.0
-                uid: 81757d78e6824ae89184afa0fb8ebf4f
-                updated_on: '1602159231'
-                user:
-                  fullname: "Jan \u0160\u010Dotka"
-                  name: jscotka
-                  url_path: user/jscotka
-              - assignee: null
-                branch: master
-                branch_from: 0.4.0-master-update
-                cached_merge_status: unknown
-                closed_at: null
-                closed_by: null
-                comments:
-                - comment: rebased onto f87d8478a994cd10b0e1ef2fa8ae839c369ddf24
-                  commit: null
-                  date_created: '1601541216'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57481
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto e5679437d476dbfd88dfc9038ddf477b5c7fdc36
-                  commit: null
-                  date_created: '1601630416'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57630
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 103e8adbdf00cdeb619dda4f9b8d892a71085c04
-                  commit: null
-                  date_created: '1601979055'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57900
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 0a64f99ed3ef05e58c18da2936af748d19c169b4
-                  commit: null
-                  date_created: '1601985142'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57931
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 7a77b7f7f4adec9aa0e82d3a350b851fbb56a40f
-                  commit: null
-                  date_created: '1601985181'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57939
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto d4262e05bf82a6732a1884d93b0d4a65271651ba
-                  commit: null
-                  date_created: '1601985919'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57951
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 2833e9f1a6fb729eebd8882334bb7aceb5147db1
-                  commit: null
-                  date_created: '1601998794'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 57999
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 2740c9191c27ad7c62f9c2b6952cdd50c45406da
-                  commit: null
-                  date_created: '1601999174'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58014
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 686ad232d9e929f36a0231deefb70f412b0e2b86
-                  commit: null
-                  date_created: '1602000244'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58028
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto d79b8d99ea4191535fd5bf77f13342d5defcbaf3
-                  commit: null
-                  date_created: '1602058033'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58103
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 42ff00213954ed2cd518e7bde7f13c71ff2f7768
-                  commit: null
-                  date_created: '1602156177'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58251
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 334d3538bc72136f3a2a2606d5d1385a237a8b88
-                  commit: null
-                  date_created: '1602156845'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58275
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                - comment: rebased onto 6f8b072c37de57111c0d823ceea25c2de524f2bd
-                  commit: null
-                  date_created: '1602159215'
-                  edited_on: null
-                  editor: null
-                  filename: null
-                  id: 58304
-                  line: null
-                  notification: true
-                  parent: null
-                  reactions: {}
-                  tree: null
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                commit_start: 6f8b072c37de57111c0d823ceea25c2de524f2bd
-                commit_stop: 6f8b072c37de57111c0d823ceea25c2de524f2bd
-                date_created: '1601539436'
-                id: 21
-                initial_comment: 'Upstream tag: 0.4.0
-
-                  Upstream commit: 6957453b'
-                last_updated: '1603187326'
-                project:
-                  access_groups:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    ticket: []
-                  access_users:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    owner:
-                    - jscotka
-                    ticket: []
-                  close_status: []
-                  custom_keys: []
-                  date_created: '1586178839'
-                  date_modified: '1586178846'
-                  description: The python-requre package
-                  fullname: rpms/python-requre
-                  id: 41574
-                  milestones: {}
-                  name: python-requre
-                  namespace: rpms
-                  parent: null
-                  priorities: {}
-                  tags: []
-                  url_path: rpms/python-requre
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                remote_git: null
-                repo_from:
-                  access_groups:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    ticket: []
-                  access_users:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    owner:
-                    - jscotka
-                    ticket: []
-                  close_status: []
-                  custom_keys: []
-                  date_created: '1600700802'
-                  date_modified: '1600700802'
-                  description: The python-requre package
-                  fullname: forks/jscotka/rpms/python-requre
-                  id: 45827
-                  milestones: {}
-                  name: python-requre
-                  namespace: rpms
-                  parent:
-                    access_groups:
-                      admin: []
-                      collaborator: []
-                      commit: []
-                      ticket: []
-                    access_users:
-                      admin: []
-                      collaborator: []
-                      commit: []
-                      owner:
-                      - jscotka
-                      ticket: []
-                    close_status: []
-                    custom_keys: []
-                    date_created: '1586178839'
-                    date_modified: '1586178846'
-                    description: The python-requre package
-                    fullname: rpms/python-requre
-                    id: 41574
-                    milestones: {}
-                    name: python-requre
-                    namespace: rpms
-                    parent: null
-                    priorities: {}
-                    tags: []
-                    url_path: rpms/python-requre
-                    user:
-                      fullname: "Jan \u0160\u010Dotka"
-                      name: jscotka
-                      url_path: user/jscotka
-                  priorities: {}
-                  tags: []
-                  url_path: fork/jscotka/rpms/python-requre
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                status: Open
-                tags: []
-                threshold_reached: null
-                title: Update to upstream release 0.4.0
-                uid: f356d3cbcec4442194ef330cc05f1832
-                updated_on: '1602159568'
-                user:
-                  fullname: "Jan \u0160\u010Dotka"
-                  name: jscotka
-                  url_path: user/jscotka
-              total_requests: 28
+              total_requests: 32
             _next: null
-            elapsed: 0.857398
+            elapsed: 1.072264
             encoding: null
             headers:
               Connection: Keep-Alive
-              Date: Tue, 20 Oct 2020 10:47:58 GMT
+              Date: Thu, 22 Oct 2020 12:16:49 GMT
               Keep-Alive: timeout=15, max=500
               Referrer-Policy: same-origin
               Server: Apache
               Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
               X-Content-Type-Options: nosniff
-              X-Fedora-ProxyServer: proxy01.iad2.fedoraproject.org
-              X-Fedora-RequestID: X47AXsPQdRj6M9GzC2ZqrQAAAdc
+              X-Fedora-ProxyServer: proxy10.iad2.fedoraproject.org
+              X-Fedora-RequestID: X5F4MS46eAMZowHWVIkt9AAAB4o
               X-Frame-Options: SAMEORIGIN
               X-Xss-Protection: 1; mode=block
-              apptime: D=414463
-              content-length: '142871'
-              content-security-policy: default-src 'self'; script-src 'self' 'nonce-tSl6xGe3GvoikqRtXoNVgGCza'
+              apptime: D=724014
+              content-length: '121977'
+              content-security-policy: default-src 'self'; script-src 'self' 'nonce-iXMXr75Lb0rkG1ntR1v0wNTWG'
                 https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
-                'self' 'nonce-tSl6xGe3GvoikqRtXoNVgGCza'; object-src 'none'; base-uri
+                'self' 'nonce-iXMXr75Lb0rkG1ntR1v0wNTWG'; object-src 'none'; base-uri
                 'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
                 https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
               content-type: application/json
-              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiNzc0Mzc2Mjk3ODAyMTA0NTIxZTUwZmJhMTlkNjhjZjgxN2M0YmJhMyJ9.EnBR3g.Lc_4bQvTx1DQSz_NX5S_wolWAvE;
-                Expires=Fri, 20-Nov-2020 10:47:58 GMT; Secure; HttpOnly; Path=/
+              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiNjRiZjk4NmZlMzhlM2Y2NzgxZTM5MjdlNGNjYjVhYTEyOGExM2Y5OSJ9.EnMJsQ.Oh895M9wlt6cQIV_5duLMRO4qzs;
+                Expires=Sun, 22-Nov-2020 12:16:49 GMT; Secure; HttpOnly; Path=/
               x-fedora-appserver: pkgs01.iad2.fedoraproject.org
             raw: !!binary ""
             reason: OK
@@ -5891,7 +4683,7 @@ requests.sessions:
       https://src.fedoraproject.org/lookaside/pkgs/python-requre/requre-0.4.0.tar.gz/:
         all:
           metadata:
-            latency: 0.3965451717376709
+            latency: 0.5078325271606445
             module_call_list:
             - unittest.case
             - requre.online_replacing
@@ -5908,277 +4700,23 @@ requests.sessions:
             __store_indicator: 1
             _content: ''
             _next: null
-            elapsed: 0.396161
+            elapsed: 0.50538
             encoding: ISO-8859-1
             headers:
               Connection: Keep-Alive
-              Date: Tue, 20 Oct 2020 10:47:57 GMT
+              Date: Thu, 22 Oct 2020 12:16:48 GMT
               Keep-Alive: timeout=15, max=500
               Referrer-Policy: same-origin
               Server: Apache
               Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
               X-Content-Type-Options: nosniff
-              X-Fedora-ProxyServer: proxy10.iad2.fedoraproject.org
-              X-Fedora-RequestID: X47AXV6HH9AwN5cexM-X3AAAAEA
+              X-Fedora-ProxyServer: proxy01.iad2.fedoraproject.org
+              X-Fedora-RequestID: X5F4MBTUCKKIhyw5MgKNFAAACEA
               X-Frame-Options: SAMEORIGIN
               X-Xss-Protection: 1; mode=block
-              apptime: D=8121
+              apptime: D=6246
               content-type: text/html;charset=ISO-8859-1
               x-fedora-appserver: pkgs01.iad2.fedoraproject.org
             raw: !!binary ""
             reason: OK
             status_code: 200
-    POST:
-      https://src.fedoraproject.org/api/0/-/whoami:
-        all:
-          metadata:
-            latency: 0.1994173526763916
-            module_call_list:
-            - unittest.case
-            - requre.online_replacing
-            - tests_recording.test_api
-            - packit.api
-            - packit.distgit
-            - ogr.services.pagure.project
-            - ogr.services.pagure.user
-            - ogr.services.pagure.service
-            - requests.sessions
-            - requre.objects
-            - requre.cassette
-            - requests.sessions
-            - send
-          output:
-            __store_indicator: 2
-            _content:
-              username: lbarczio
-            _next: null
-            elapsed: 0.198624
-            encoding: null
-            headers:
-              Connection: Keep-Alive
-              Date: Tue, 20 Oct 2020 10:48:00 GMT
-              Keep-Alive: timeout=15, max=497
-              Referrer-Policy: same-origin
-              Server: Apache
-              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-              X-Content-Type-Options: nosniff
-              X-Fedora-ProxyServer: proxy01.iad2.fedoraproject.org
-              X-Fedora-RequestID: X47AYMPQdRj6M9GzC2Zq1wAAAcw
-              X-Frame-Options: SAMEORIGIN
-              X-Xss-Protection: 1; mode=block
-              apptime: D=72447
-              content-length: '29'
-              content-security-policy: default-src 'self'; script-src 'self' 'nonce-ZEPNHRnhdBt955AMvcVD3qZau'
-                https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
-                'self' 'nonce-ZEPNHRnhdBt955AMvcVD3qZau'; object-src 'none'; base-uri
-                'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
-                https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
-              content-type: application/json
-              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiNzc0Mzc2Mjk3ODAyMTA0NTIxZTUwZmJhMTlkNjhjZjgxN2M0YmJhMyJ9.EnBR4A.7xo3ndcfNo--dr-7unpaPulchvU;
-                Expires=Fri, 20-Nov-2020 10:48:00 GMT; Secure; HttpOnly; Path=/
-              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
-            raw: !!binary ""
-            reason: OK
-            status_code: 200
-      https://src.fedoraproject.org/api/0/rpms/python-requre/pull-request/new:
-        all:
-          metadata:
-            latency: 1.2613635063171387
-            module_call_list:
-            - unittest.case
-            - requre.online_replacing
-            - tests_recording.test_api
-            - packit.api
-            - packit.distgit
-            - ogr.read_only
-            - ogr.services.pagure.project
-            - ogr.services.pagure.pull_request
-            - ogr.services.pagure.project
-            - ogr.services.pagure.service
-            - requests.sessions
-            - requre.objects
-            - requre.cassette
-            - requests.sessions
-            - send
-          output:
-            __store_indicator: 2
-            _content:
-              assignee: null
-              branch: master
-              branch_from: 0.4.0-master-update
-              cached_merge_status: unknown
-              closed_at: null
-              closed_by: null
-              comments: []
-              commit_start: 4f91816ecedb9fa3c323313725d2e782ac166bce
-              commit_stop: 4f91816ecedb9fa3c323313725d2e782ac166bce
-              date_created: '1603190892'
-              id: 41
-              initial_comment: 'Upstream tag: 0.4.0
-
-                Upstream commit: 6957453b'
-              last_updated: '1603190892'
-              project:
-                access_groups:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  ticket: []
-                access_users:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  owner:
-                  - jscotka
-                  ticket: []
-                close_status: []
-                custom_keys: []
-                date_created: '1586178839'
-                date_modified: '1586178846'
-                description: The python-requre package
-                fullname: rpms/python-requre
-                id: 41574
-                milestones: {}
-                name: python-requre
-                namespace: rpms
-                parent: null
-                priorities: {}
-                tags: []
-                url_path: rpms/python-requre
-                user:
-                  fullname: "Jan \u0160\u010Dotka"
-                  name: jscotka
-                  url_path: user/jscotka
-              remote_git: null
-              repo_from:
-                access_groups:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  ticket: []
-                access_users:
-                  admin: []
-                  collaborator: []
-                  commit: []
-                  owner:
-                  - lbarczio
-                  ticket: []
-                close_status: []
-                custom_keys: []
-                date_created: '1603187163'
-                date_modified: '1603187163'
-                description: The python-requre package
-                fullname: forks/lbarczio/rpms/python-requre
-                id: 46377
-                milestones: {}
-                name: python-requre
-                namespace: rpms
-                parent:
-                  access_groups:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    ticket: []
-                  access_users:
-                    admin: []
-                    collaborator: []
-                    commit: []
-                    owner:
-                    - jscotka
-                    ticket: []
-                  close_status: []
-                  custom_keys: []
-                  date_created: '1586178839'
-                  date_modified: '1586178846'
-                  description: The python-requre package
-                  fullname: rpms/python-requre
-                  id: 41574
-                  milestones: {}
-                  name: python-requre
-                  namespace: rpms
-                  parent: null
-                  priorities: {}
-                  tags: []
-                  url_path: rpms/python-requre
-                  user:
-                    fullname: "Jan \u0160\u010Dotka"
-                    name: jscotka
-                    url_path: user/jscotka
-                priorities: {}
-                tags: []
-                url_path: fork/lbarczio/rpms/python-requre
-                user:
-                  fullname: "Laura Barcziov\xE1"
-                  name: lbarczio
-                  url_path: user/lbarczio
-              status: Open
-              tags: []
-              threshold_reached: null
-              title: Update to upstream release 0.4.0
-              uid: f876e7aa4d7e4f549169e2f85c3e948c
-              updated_on: '1603190892'
-              user:
-                fullname: "Laura Barcziov\xE1"
-                name: lbarczio
-                url_path: user/lbarczio
-            _next: null
-            elapsed: 1.260689
-            encoding: null
-            headers:
-              Connection: Keep-Alive
-              Date: Tue, 20 Oct 2020 10:48:12 GMT
-              Keep-Alive: timeout=15, max=493
-              Referrer-Policy: same-origin
-              Server: Apache
-              Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
-              X-Content-Type-Options: nosniff
-              X-Fedora-ProxyServer: proxy10.iad2.fedoraproject.org
-              X-Fedora-RequestID: X47AbKsq79ncW0mHIY9ezQAAAkQ
-              X-Frame-Options: SAMEORIGIN
-              X-Xss-Protection: 1; mode=block
-              apptime: D=1132682
-              content-length: '3361'
-              content-security-policy: default-src 'self'; script-src 'self' 'nonce-WNpTAJsTuVf9rBjosXCfUNpwN'
-                https://apps.fedoraproject.org https://mdapi.fedoraproject.org; style-src
-                'self' 'nonce-WNpTAJsTuVf9rBjosXCfUNpwN'; object-src 'none'; base-uri
-                'self'; img-src 'self' https:; connect-src 'self' https://pdc.fedoraproject.org
-                https://apps.fedoraproject.org https://mdapi.fedoraproject.org;
-              content-type: application/json
-              set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiNzc0Mzc2Mjk3ODAyMTA0NTIxZTUwZmJhMTlkNjhjZjgxN2M0YmJhMyJ9.EnBR7Q.Ro8XfvjIfu7au1XSf13DWwcFheA;
-                Expires=Fri, 20-Nov-2020 10:48:13 GMT; Secure; HttpOnly; Path=/
-              x-fedora-appserver: pkgs01.iad2.fedoraproject.org
-            raw: !!binary ""
-            reason: OK
-            status_code: 200
-unittest.case:
-  requre.online_replacing:
-    tests_recording.test_api:
-      tests_recording.testbase:
-        packit.local_project:
-          packit.utils.repo:
-            requre.helpers.files:
-              requre.objects:
-                requre.cassette:
-                  git.repo.base:
-                    clone_from:
-                      all:
-                        metadata:
-                          latency: 1.5857632160186768
-                          module_call_list:
-                          - unittest.case
-                          - requre.online_replacing
-                          - tests_recording.test_api
-                          - tests_recording.testbase
-                          - packit.local_project
-                          - packit.utils.repo
-                          - requre.helpers.files
-                          - requre.objects
-                          - requre.cassette
-                          - git.repo.base
-                          - clone_from
-                        output:
-                          _bare: false
-                          _common_dir: null
-                          _working_tree_dir: /tmp/packit_tmp/tests_recording.test_api.ProposeUpdate.test_comment_in_spec.yaml/static_tmp_1
-                          git_dir: /tmp/packit_tmp/tests_recording.test_api.ProposeUpdate.test_comment_in_spec.yaml/static_tmp_1/.git
-                          working_dir: /tmp/packit_tmp/tests_recording.test_api.ProposeUpdate.test_comment_in_spec.yaml/static_tmp_1


### PR DESCRIPTION
- Fixes #883
- Add `sync_changelog` option to the config, defaults to `False` (old behaviour).
- Sync specfile as a full file if `sync_changelog` is True.
- Downstream spec-file is located in the root not like in upstream.

TODO:

- [x] tests