### PR TITLE
Update pre-commit configuration for prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,8 @@ repos:
     rev: v2.7.2
     hooks:
       - id: pyupgrade
-  - repo: https://github.com/prettier/prettier
-    rev: 2.1.2
+  - repo: https://github.com/prettier/pre-commit
+    rev: v2.1.2
     hooks:
       - id: prettier
         exclude: tests_recording/test_data/*


### PR DESCRIPTION
In order to solve this installation issue:

https://github.com/prettier/prettier/issues/9459

It seems that prettier is moving the pre-commit parts in a separate
repository.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>