### PR TITLE
source-git: support regular patches on top git-am patches

### DIFF
--- a/tests/integration/test_source_git.py
+++ b/tests/integration/test_source_git.py
@@ -36,6 +36,7 @@ from tests.spellbook import (
     create_git_am_style_history,
     create_patch_mixed_history,
     create_history_with_empty_commit,
+    run_prep_for_srpm,
 )
 
 
@@ -503,6 +504,10 @@ def test_srpm_git_am(mock_remote_functionality_sourcegit, api_instance_source_gi
         "0001-m04r-malt.patch",
         "malt.patch",
     }
+    run_prep_for_srpm(srpm_path)
+    prep_root = sg_path.joinpath("beerware-0.1.0")
+    assert prep_root.joinpath("malt").read_text() == "Munich\n"
+    assert prep_root.joinpath("hops").read_text() == "Saaz\n"
 
 
 @pytest.mark.parametrize("ref", ["0.1.0", "0.1*", "0.*"])

--- a/tests/spellbook.py
+++ b/tests/spellbook.py
@@ -226,6 +226,12 @@ def create_git_am_style_history(sg: Path):
     )
     git_add_and_commit(directory=sg, message=meta.commit_message)
 
+    malt.write_text("Munich\n")
+    git_add_and_commit(directory=sg, message="I like Munich malt!")
+
+    hops.write_text("Saaz\n")
+    git_add_and_commit(directory=sg, message="Saaz is interesting")
+
 
 def create_patch_mixed_history(sg: Path):
     """
@@ -292,6 +298,32 @@ def call_packit(fnc=None, parameters=None, envs=None, working_dir=None):
 
 def build_srpm(path: Path):
     run_command(["rpmbuild", "--rebuild", str(path)], output=True)
+
+
+def run_prep_for_srpm(srpm_path: Path):
+    cmd = [
+        "rpmbuild",
+        "-rp",
+        "--define",
+        f"_sourcedir {srpm_path.parent}",
+        "--define",
+        f"_srcdir {srpm_path.parent}",
+        "--define",
+        f"_specdir {srpm_path.parent}",
+        "--define",
+        f"_srcrpmdir {srpm_path.parent}",
+        "--define",
+        f"_topdir {srpm_path.parent}",
+        # we also need these 3 so that rpmbuild won't create them
+        "--define",
+        f"_builddir {srpm_path.parent}",
+        "--define",
+        f"_rpmdir {srpm_path.parent}",
+        "--define",
+        f"_buildrootdir {srpm_path.parent}",
+        str(srpm_path),
+    ]
+    run_command(cmd)
 
 
 def can_a_module_be_imported(module_name):


### PR DESCRIPTION
    source-git: git-am patches: enable regular patches on top

    the use case here is that a contributor can propose a PR and not follow
    the git-am patches style and packit would still create a correct SRPM
    and the patches would correctly be applied in %prep

    this is achieved by:
    1) checking that any of the patch commits has squash_commits=True
    2) then picking starting commits which don't have squash_commits
       and prepending them to the one which has

    I was also thinking about supporting an arbitrary patch commit in the
    middle, but realized:
    1) it's an unrealistic scenario since those commits are covered by d2s
    2) would be insanely touch to implement it and make it work reliable
    3) not worth the time

Fixes #943
