### PR TITLE
Generate proper %changelog in sync_release

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -232,6 +232,7 @@ class PackitAPI:
                 raw_files_to_sync = self._prepare_files_to_sync(
                     raw_sync_files=raw_sync_files,
                     full_version=full_version,
+                    upstream_tag=upstream_tag,
                 )
                 sync_files(raw_files_to_sync)
                 if upstream_ref:
@@ -272,14 +273,16 @@ class PackitAPI:
         return new_pr
 
     def _prepare_files_to_sync(
-        self, raw_sync_files, full_version
+        self, raw_sync_files, full_version, upstream_tag
     ) -> List[RawSyncFilesItem]:
         if self.package_config.sync_changelog:
             return raw_sync_files
         comment = (
             self.up.local_project.git_project.get_release(name=full_version).body
             if self.package_config.copy_upstream_release_description
-            else f"- new upstream release: {full_version}"
+            else self.up.get_commit_messages(
+                after=self.up.get_last_tag(upstream_tag), before=upstream_tag
+            )
         )
         try:
             self.dg.set_specfile_content(self.up.specfile, full_version, comment)

--- a/packit/api.py
+++ b/packit/api.py
@@ -230,7 +230,8 @@ class PackitAPI:
 
             if self.up.with_action(action=ActionName.prepare_files):
                 raw_files_to_sync = self._prepare_files_to_sync(
-                    raw_sync_files=raw_sync_files, full_version=full_version
+                    raw_sync_files=raw_sync_files,
+                    full_version=full_version,
                 )
                 sync_files(raw_files_to_sync)
                 if upstream_ref:
@@ -275,8 +276,11 @@ class PackitAPI:
     ) -> List[RawSyncFilesItem]:
         if self.package_config.sync_changelog:
             return raw_sync_files
-
-        comment = f"- new upstream release: {full_version}"
+        comment = (
+            self.up.local_project.git_project.get_release(name=full_version).body
+            if self.package_config.copy_upstream_release_description
+            else f"- new upstream release: {full_version}"
+        )
         try:
             self.dg.set_specfile_content(self.up.specfile, full_version, comment)
         except FileNotFoundError as ex:

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -73,6 +73,7 @@ class CommonPackageConfig:
         archive_root_dir_template: str = "{upstream_pkg_name}-{version}",
         patch_generation_ignore_paths: List[str] = None,
         notifications: Optional[NotificationsConfig] = None,
+        copy_upstream_release_description: bool = False,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -109,6 +110,7 @@ class CommonPackageConfig:
         # template to create an upstream tag name (upstream may use different tagging scheme)
         self.upstream_tag_template = upstream_tag_template
         self.archive_root_dir_template = archive_root_dir_template
+        self.copy_upstream_release_description = copy_upstream_release_description
 
     def __repr__(self):
         return (
@@ -130,7 +132,8 @@ class CommonPackageConfig:
             f"synced_files='{self.synced_files}', "
             f"spec_source_id='{self.spec_source_id}', "
             f"upstream_tag_template='{self.upstream_tag_template}', "
-            f"patch_generation_ignore_paths='{self.patch_generation_ignore_paths}')"
+            f"patch_generation_ignore_paths='{self.patch_generation_ignore_paths}',"
+            f"copy_upstream_release_description='{self.copy_upstream_release_description}')"
         )
 
     @property

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -169,6 +169,7 @@ class JobConfig(CommonPackageConfig):
         archive_root_dir_template: str = "{upstream_pkg_name}-{version}",
         patch_generation_ignore_paths: List[str] = None,
         notifications: Optional[NotificationsConfig] = None,
+        copy_upstream_release_description: bool = False,
     ):
         super().__init__(
             config_file_path=config_file_path,
@@ -192,6 +193,7 @@ class JobConfig(CommonPackageConfig):
             archive_root_dir_template=archive_root_dir_template,
             patch_generation_ignore_paths=patch_generation_ignore_paths,
             notifications=notifications,
+            copy_upstream_release_description=copy_upstream_release_description,
         )
         self.type: JobType = type
         self.trigger: JobConfigTriggerType = trigger
@@ -218,7 +220,8 @@ class JobConfig(CommonPackageConfig):
             f"sync_changelog='{self.sync_changelog}', "
             f"spec_source_id='{self.spec_source_id}', "
             f"upstream_tag_template='{self.upstream_tag_template}', "
-            f"patch_generation_ignore_paths='{self.patch_generation_ignore_paths}')"
+            f"patch_generation_ignore_paths='{self.patch_generation_ignore_paths}',"
+            f"copy_upstream_release_description='{self.copy_upstream_release_description}')"
         )
 
     @classmethod
@@ -254,6 +257,8 @@ class JobConfig(CommonPackageConfig):
             and self.sync_changelog == other.sync_changelog
             and self.spec_source_id == other.spec_source_id
             and self.upstream_tag_template == other.upstream_tag_template
+            and self.copy_upstream_release_description
+            == other.copy_upstream_release_description
         )
 
 

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -69,6 +69,7 @@ class PackageConfig(CommonPackageConfig):
         archive_root_dir_template: str = "{upstream_pkg_name}-{version}",
         patch_generation_ignore_paths: List[str] = None,
         notifications: Optional[NotificationsConfig] = None,
+        copy_upstream_release_description: bool = False,
     ):
         super().__init__(
             config_file_path=config_file_path,
@@ -92,6 +93,7 @@ class PackageConfig(CommonPackageConfig):
             archive_root_dir_template=archive_root_dir_template,
             patch_generation_ignore_paths=patch_generation_ignore_paths,
             notifications=notifications,
+            copy_upstream_release_description=copy_upstream_release_description,
         )
         self.jobs: List[JobConfig] = jobs or []
 
@@ -118,7 +120,8 @@ class PackageConfig(CommonPackageConfig):
             f"spec_source_id='{self.spec_source_id}', "
             f"upstream_tag_template='{self.upstream_tag_template}', "
             f"archive_root_dir_template={self.archive_root_dir_template}', "
-            f"patch_generation_ignore_paths='{self.patch_generation_ignore_paths}')"
+            f"patch_generation_ignore_paths='{self.patch_generation_ignore_paths}', "
+            f"copy_upstream_release_description='{self.copy_upstream_release_description}')"
         )
 
     @classmethod
@@ -202,6 +205,8 @@ class PackageConfig(CommonPackageConfig):
             and self.sync_changelog == other.sync_changelog
             and self.spec_source_id == other.spec_source_id
             and self.upstream_tag_template == other.upstream_tag_template
+            and self.copy_upstream_release_description
+            == other.copy_upstream_release_description
         )
 
 

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -284,6 +284,7 @@ class CommonConfigSchema(MM23Schema):
     sync_changelog = fields.Bool(default=False)
     patch_generation_ignore_paths = fields.List(fields.String())
     notifications = fields.Nested(NotificationsSchema)
+    copy_upstream_release_description = fields.Bool(default=False)
 
     @staticmethod
     def spec_source_id_serialize(value: PackageConfig):

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -427,7 +427,8 @@ class Upstream(PackitRepositoryBase):
         return None
 
     def get_last_tag(self, before: str = None) -> Optional[str]:
-        """get last git-tag from the repo
+        """
+        Get last git-tag from the repo.
         :param before: get last tag before the given tag
         """
         try:
@@ -460,6 +461,7 @@ class Upstream(PackitRepositoryBase):
         cmd = [
             "git",
             "log",
+            "--no-merges",
             "--pretty=format:- %s (%an)",
             commits_range,
             "--",

--- a/tests/integration/test_source_git.py
+++ b/tests/integration/test_source_git.py
@@ -128,6 +128,7 @@ def test_basic_local_update_patch_content(
     git_diff = subprocess.check_output(
         ["git", "diff", "HEAD~", "HEAD"], cwd=distgit
     ).decode()
+
     assert (
         """
 -Version:        0.0.0
@@ -159,7 +160,10 @@ def test_basic_local_update_patch_content(
 
     assert (
         """ - 0.1.0-1
-+- new upstream release: 0.1.0
++- commit with data (Packit Test Suite)
++- empty commit #2 (Packit Test Suite)
++- empty commit #1 (Packit Test Suite)
++- empty commit #0 (Packit Test Suite)
 +
  * Sun Feb 24 2019 Tomas Tomecek <ttomecek@redhat.com> - 0.0.0-1
  - No brewing, yet."""


### PR DESCRIPTION
Create config option `copy_upstream_release_description` which enables to copy the description of the release seen in Github to `%changelog` in `sync_release`, copy all commit messages between the last and previous upstream tags by default.

Fixes #427 

TODO:

- [x] tests