### PR TITLE
Improve logic in get_current_version

### DIFF
--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -34,7 +34,6 @@ from packit.config.notifications import (
 from packit.config.sync_files_config import SyncFilesConfig
 from packit.constants import PROD_DISTGIT_URL
 from packit.sync import SyncFilesItem
-from packit.utils.repo import get_current_version_command
 
 
 class CommonPackageConfig:
@@ -104,9 +103,7 @@ class CommonPackageConfig:
         # uncommitted changes will not be present in the archive
         self.create_tarball_command: List[str] = create_tarball_command
         # command to get current version of the project
-        self.current_version_command: List[
-            str
-        ] = current_version_command or get_current_version_command(glob_pattern="*")
+        self.current_version_command: List[str] = current_version_command
         # template to create an upstream tag name (upstream may use different tagging scheme)
         self.upstream_tag_template = upstream_tag_template
         self.archive_root_dir_template = archive_root_dir_template

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -54,27 +54,43 @@ def test_get_spec_version(upstream_instance):
 
 
 @pytest.mark.parametrize(
-    "tag, tag_template, expected_output",
+    "tag, tag_template, current_version_command_out, expected_output",
     [
         pytest.param(
             "1.0.0",
             "{version}",
+            None,
             "1.0.0",
-            id="pure_version-valid_template",
+            id="no_command-pure_version-valid_template",
         ),
         pytest.param(
             "test-1.0.0",
             "test-{version}",
+            None,
             "1.0.0",
-            id="valid_string-valid_template",
+            id="no_command-valid_tag-valid_template",
+        ),
+        pytest.param(
+            "_",
+            "_",
+            "2.0",
+            "2.0",
+            id="with_command_output",
         ),
     ],
 )
-def test_get_current_version(tag, tag_template, expected_output, upstream_instance):
+def test_get_current_version(
+    tag, tag_template, current_version_command_out, expected_output, upstream_instance
+):
     u, ups = upstream_instance
     flexmock(ups)
     ups.package_config.upstream_tag_template = tag_template
-    ups.should_receive("command_handler.run_command").and_return(tag)
+    # just to simulate current_vesrsion_command set/notset
+    ups.package_config.current_version_command = current_version_command_out
+    ups.should_receive("command_handler.run_command").and_return(
+        current_version_command_out
+    )
+    ups.should_receive("get_last_tag").and_return(tag)
 
     assert ups.get_current_version() == expected_output
 

--- a/tests/unit/test_upstream.py
+++ b/tests/unit/test_upstream.py
@@ -202,19 +202,28 @@ def test_fix_spec__setup_line(
 
 
 @pytest.mark.parametrize(
-    "action_output, version, expected_result",
+    "action_output, current_version_command, version, expected_result",
     [
         pytest.param(
-            ("some_action_output", "1.0.1"), "_", "1.0.1", id="with_action_output"
+            ("some_action_output", "1.0.1"), None, "_", "1.0.1", id="with_action_output"
         ),
-        pytest.param(None, "1.0.2", "1.0.2", id="valid_version"),
-        pytest.param(None, "1.0-3", "1.0.3", id="version_with_dash"),
+        pytest.param(None, "1.0.2", "_", "1.0.2", id="command_valid_version"),
+        pytest.param(None, "1.0-3", "_", "1.0.3", id="command_version_with_dash"),
+        pytest.param(None, None, "1.0.2", "1.0.2", id="tag_valid_version"),
+        pytest.param(None, None, "1.0-3", "1.0.3", id="tag_version_with_dash"),
     ],
 )
-def test_get_current_version(action_output, version, expected_result, upstream_mock):
+def test_get_current_version(
+    action_output, current_version_command, version, expected_result, upstream_mock
+):
     flexmock(packit.upstream.os).should_receive("listdir").and_return("mocked")
     upstream_mock.should_receive("get_output_from_action").and_return(action_output)
-    upstream_mock.should_receive("command_handler.run_command").and_return("_mocked")
+    # just to simulate if is configured or not
+    upstream_mock.package_config.current_version_command = current_version_command
+    upstream_mock.should_receive("command_handler.run_command").and_return(
+        current_version_command
+    )
+    upstream_mock.should_receive("get_last_tag").and_return("_mocked")
     upstream_mock.should_receive("get_version_from_tag").and_return(version)
     assert upstream_mock.get_current_version() == expected_result
 


### PR DESCRIPTION
Method `Upstream.get_current_version()` is trying following to get
version:
1. get output from actions
2. use configured `current_version_command (.packit.yaml)
3. extract version from `self.get_last_tag()` using `self.get_version_from_tag()`

fixes #1012