### PR TITLE
Fix SpecFile.get_source()

### DIFF
--- a/packit/constants.py
+++ b/packit/constants.py
@@ -91,5 +91,3 @@ SYNCING_NOTE = (
     "This repository is maintained by packit.\nhttps://packit.dev/\n"
     "The file was generated using packit {packit_version}.\n"
 )
-
-SPEC_PACKAGE_SECTION = "%package"

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -36,7 +36,7 @@ from packit.actions import ActionName
 from packit.base_git import PackitRepositoryBase
 from packit.config import Config, SyncFilesConfig
 from packit.config.common_package_config import CommonPackageConfig
-from packit.constants import SPEC_PACKAGE_SECTION, DEFAULT_ARCHIVE_EXT, DATETIME_FORMAT
+from packit.constants import DEFAULT_ARCHIVE_EXT, DATETIME_FORMAT
 from packit.exceptions import (
     PackitException,
     PackitSRPMNotFoundException,
@@ -567,10 +567,9 @@ class Upstream(PackitRepositoryBase):
     def _fix_spec_source(self, archive):
         response = self.specfile.get_source(self.package_config.spec_source_id)
         if response:
-            idx, source_name, _ = response
-            self.specfile.spec_content.section(SPEC_PACKAGE_SECTION)[
-                idx
-            ] = f"{source_name}: {archive}"
+            self.specfile.set_raw_tag_value(
+                response.name, archive, section=response.section_index
+            )
         else:
             raise PackitException(
                 "The spec file doesn't have sources set "

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -221,6 +221,41 @@ def test_fix_spec(upstream_instance):
     assert re.match(r"\d\.\d{20}\.\w+\.\d+\.g\w{7}", release)
 
 
+@pytest.mark.parametrize(
+    "spec_source_id, expected_line",
+    [
+        pytest.param(
+            "Source",
+            r"Source:\s*fixed-source-archive.tar.gz",
+            id="Source",
+        ),
+        pytest.param(
+            "Source0",
+            r"Source:\s*fixed-source-archive.tar.gz",
+            id="Source0",
+        ),
+        pytest.param(
+            "Source100",
+            r"Source100:\s*fixed-source-archive.tar.gz",
+            id="Source100",
+        ),
+    ],
+)
+def test__fix_spec_source(upstream_instance, spec_source_id, expected_line):
+    u, ups = upstream_instance
+
+    data = u.joinpath("beer.spec").read_text()
+    data = re.sub(r"(Source:.*)", "\\1\nSource100: extra-sources.tar.gz", data)
+    with open(u.joinpath("beer.spec"), "w") as f:
+        f.write(data)
+
+    ups.package_config.spec_source_id = spec_source_id
+    ups._fix_spec_source("fixed-source-archive.tar.gz")
+    ups.specfile.write_spec_content()
+
+    assert re.search(expected_line, u.joinpath("beer.spec").read_text())
+
+
 def test_create_srpm(upstream_instance, tmp_path):
     u, ups = upstream_instance
 


### PR DESCRIPTION
If the first *Source* tag in a spec file is not indexed, it is always returned, no matter the value of `source_name`.
Fix that by taking advantage of `SpecFile.tags`.

Fixes #1011.