### PR TITLE
copr, log CoprException.result when creating repo fails

### DIFF
--- a/packit/cli/copr_build.py
+++ b/packit/cli/copr_build.py
@@ -29,6 +29,7 @@ from packit.cli.types import LocalProjectParameter
 from packit.cli.utils import cover_packit_exception, get_packit_api
 from packit.config import pass_config, get_context_settings, PackageConfig
 from packit.config.aliases import get_valid_build_targets
+from packit.utils import sanitize_branch_name
 
 logger = logging.getLogger(__name__)
 
@@ -131,7 +132,8 @@ def copr_build(
                 "COPR project not found in the job configuration. "
                 "Using the default one."
             )
-            project = f"packit-cli-{path_or_url.repo_name}-{path_or_url.ref}"
+            sanitized_ref = sanitize_branch_name(path_or_url.ref)
+            project = f"packit-cli-{path_or_url.repo_name}-{sanitized_ref}"
 
     logger.info(f"Using COPR project name = {project}")
 

--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -292,6 +292,7 @@ class CoprHelper:
                 f"(owner={owner} project={project} chroots={chroots}): {ex}"
             )
             logger.error(error)
+            logger.error(ex.result)
             raise PackitCoprProjectException(error, ex)
 
     def watch_copr_build(

--- a/packit/utils/__init__.py
+++ b/packit/utils/__init__.py
@@ -34,3 +34,28 @@ __all__ = [
     is_a_git_ref.__name__,
     git_remote_url_to_https_url.__name__,
 ]
+
+
+def sanitize_branch_name(branch_name: str) -> str:
+    """
+    replace potentially problematic characters in provided string, a branch name
+
+    e.g. copr says:
+        Name must contain only letters, digits, underscores, dashes and dots.
+    """
+    # https://stackoverflow.com/questions/3411771/best-way-to-replace-multiple-characters-in-a-string
+    offenders = "!@#$%^&*()+={[}]|\\'\":;<,>/?~`"
+    for o in offenders:
+        branch_name = branch_name.replace(o, "-")
+    return branch_name
+
+
+def sanitize_branch_name_for_rpm(branch_name: str) -> str:
+    """
+    rpm is picky about release: hates "/" - it's an error
+    also prints a warning for "-"
+    """
+    offenders = "!@#$%^&*()+={[}]|\\'\":;<,>/?~`"
+    for o in offenders:
+        branch_name = branch_name.replace(o, "")
+    return branch_name.replace("-", ".")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -30,6 +30,7 @@ from pkg_resources import DistributionNotFound, Distribution
 
 from packit.api import get_packit_version
 from packit.exceptions import PackitException, ensure_str
+from packit.utils import sanitize_branch_name, sanitize_branch_name_for_rpm
 from packit.utils.decorators import fallback_return_value
 from packit.utils.repo import (
     get_namespace_and_repo_name,
@@ -168,3 +169,12 @@ class TestFallbackReturnValue:
 
         elif not raise_exception:
             assert simple_function() == 42
+
+
+@pytest.mark.parametrize(
+    "inp,exp,exp_rpm",
+    (("pr/123", "pr-123", "pr123"), ("🌈🌈🌈", "🌈🌈🌈", "🌈🌈🌈"), ("@#$#$%", "------", "")),
+)
+def test_sanitize_branch(inp, exp, exp_rpm):
+    assert sanitize_branch_name(inp) == exp
+    assert sanitize_branch_name_for_rpm(inp) == exp_rpm


### PR DESCRIPTION
we have sentry errors which only tell

    Cannot create a new Copr project (owner=packit
    project=rhinstaller-anaconda-2997
    chroots=['fedora-rawhide-x86_64']): Request wasn't successful, there
    is probably a bug in the API code.

not useful at all, this is an attempt to get more info from copr api

This should help us diagnose
https://github.com/packit/packit-service/issues/869

This also fixes a CLI issue:

    cli.copr-build: replace / with -

    copr doesn't allow / in project names