### PR TITLE
Add tag parameter to `api.sync_release` method

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -138,6 +138,7 @@ class PackitAPI:
         self,
         dist_git_branch: str,
         version: str = None,
+        tag: str = None,
         use_local_content=False,
         force_new_sources=False,
         upstream_ref: str = None,
@@ -150,6 +151,7 @@ class PackitAPI:
         :param dist_git_branch: branch in dist-git
         :param use_local_content: don't check out anything
         :param version: upstream version to update in Fedora
+        :param tag: upstream git tag
         :param force_new_sources: don't check the lookaside cache and perform new-sources
         :param upstream_ref: for a source-git repo, use this ref as the latest upstream commit
         :param create_pr: create a pull request if set to True
@@ -157,6 +159,24 @@ class PackitAPI:
 
         :return created PullRequest if create_pr is True, else None
         """
+
+        # process version and tag parameters
+        if version and tag:
+            raise PackitException(
+                "Function parameters version and tag are mutually exclusive."
+            )
+        elif not tag:
+            if not version:
+                version = self.up.get_version()
+                if not version:
+                    raise PackitException(
+                        "Could not figure out version of latest upstream release."
+                    )
+            upstream_tag = self.up.convert_version_to_tag(version)
+        elif tag:
+            upstream_tag = tag
+            version = self.up.get_version_from_tag(tag)
+
         assert_existence(self.up.local_project, "Upstream local project")
         assert_existence(self.dg.local_project, "Dist-git local project")
         if self.dg.is_dirty():
@@ -177,15 +197,8 @@ class PackitAPI:
         create_pr = create_pr and self.package_config.create_pr
         self.up.run_action(actions=ActionName.post_upstream_clone)
 
-        version = version or self.up.get_version()
-
-        if not version:
-            raise PackitException(
-                "Could not figure out version of latest upstream release."
-            )
         current_up_branch = self.up.active_branch
         try:
-            upstream_tag = self.up.convert_version_to_tag(version)
 
             if not use_local_content:
                 self.up.local_project.checkout_release(upstream_tag)

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -417,10 +417,10 @@ class LocalProject:
         self.git_repo.create_head(local_branch, f"{remote_name}/{local_branch}")
         self.git_repo.branches[local_branch].checkout()
 
-    def checkout_release(self, version: str) -> None:
-        logger.info(f"Checking out upstream version {version}.")
+    def checkout_release(self, tag: str) -> None:
+        logger.info(f"Checking out upstream version {tag}.")
         try:
-            self.git_repo.git.checkout(version)
+            self.git_repo.git.checkout(tag)
         except Exception as ex:
             raise PackitException(f"Cannot checkout release tag: {ex!r}.")
 

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -924,6 +924,26 @@ class Upstream(PackitRepositoryBase):
             logger.error(msg)
             raise PackitException(msg)
 
+    def convert_version_to_tag(self, version_: str) -> str:
+        """
+        Converts version to tag using upstream_tag_tepmlate
+
+        :param version_: version to be converted
+        upstream_template_tag
+        :return: tag
+        """
+        try:
+            tag = self.package_config.upstream_tag_template.format(version=version_)
+        except KeyError:
+            msg = (
+                f"Invalid upstream_tag_template: {self.package_config.upstream_tag_template} - "
+                f'"version" placeholder is missing'
+            )
+            logger.error(msg)
+            raise PackitException(msg)
+
+        return tag
+
     def get_archive_root_dir(self, archive: str) -> Union[str, None]:
         """
         Returns archive root dir.

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,8 +1,15 @@
+from pathlib import Path
+
 import pytest
 from flexmock import flexmock
 from munch import munchify
 
 import packit
+from packit.config import Config
+from packit.distgit import DistGit
+from packit.local_project import LocalProject
+from packit.upstream import Upstream
+from tests.spellbook import get_test_config
 
 
 @pytest.fixture
@@ -34,3 +41,97 @@ def mock_get_aliases():
             "epel-all": ["epel-6", "epel-7", "epel-8"],
         }
     )
+
+
+@pytest.fixture
+def package_config_mock():
+    mock = flexmock(
+        synced_files=None,
+        upstream_package_name="test_package_name",
+        downstream_package_name="test_package_name",
+        upstream_tag_template="_",
+        upstream_project_url="_",
+        allowed_gpg_keys="_",
+        upstream_ref="_",
+        create_pr=False,
+        actions=[],
+        patch_generation_ignore_paths=[],
+    )
+    mock.should_receive("current_version_command")
+    mock.should_receive("get_all_files_to_sync.get_raw_files_to_sync").and_return([])
+    return mock
+
+
+@pytest.fixture
+def config_mock():
+    conf = Config()
+    conf._pagure_user_token = "test"
+    conf._github_token = "test"
+    return conf
+
+
+@pytest.fixture
+def git_project_mock():
+    mock = flexmock(upstream_project_url="dummy_url")
+    return mock
+
+
+@pytest.fixture
+def git_repo_mock():
+    git_repo = flexmock(
+        git=flexmock(checkout=lambda *_: None, reset=lambda *_: None),
+        remote=lambda *_: flexmock(refs={"_": "_"}),
+        branches=[],
+        create_head=lambda *_, **__: None,
+    )
+    return git_repo
+
+
+@pytest.fixture
+def local_project_mock(git_project_mock, git_repo_mock):
+    flexmock(Path).should_receive("write_text")
+    mock = flexmock(
+        git_project=git_project_mock,
+        working_dir=Path("/mock_dir"),
+        ref="mock_ref",
+        git_repo=git_repo_mock,
+        checkout_release=lambda *_: None,
+        commit_hexsha="_",
+    )
+    return mock
+
+
+@pytest.fixture
+def upstream_mock(local_project_mock, package_config_mock):
+    upstream = Upstream(
+        config=get_test_config(),
+        package_config=package_config_mock,
+        local_project=LocalProject(working_dir="test"),
+    )
+    flexmock(upstream)
+    upstream.should_receive("local_project").and_return(local_project_mock)
+    upstream.should_receive("absolute_specfile_path").and_return("_spec_file_path")
+    upstream.should_receive("absolute_specfile_dir").and_return("_spec_file_dir")
+    upstream.should_receive("is_dirty").and_return(False)
+    upstream.should_receive("create_patches")
+
+    return upstream
+
+
+@pytest.fixture
+def distgit_mock(local_project_mock, config_mock, package_config_mock):
+    distgit = DistGit(
+        config=config_mock,
+        package_config=package_config_mock,
+        local_project=local_project_mock,
+    )
+    flexmock(distgit)
+    distgit.should_receive("is_dirty").and_return(False)
+    distgit.should_receive("downstream_config").and_return(package_config_mock)
+    distgit.should_receive("create_branch")
+    distgit.should_receive("update_branch")
+    distgit.should_receive("checkout_branch")
+    distgit.should_receive("commit")
+    distgit.should_receive("push")
+    distgit.should_receive("absolute_specfile_dir").and_return(Path("/mock_path"))
+    return distgit

--- a/tests/unit/test_upstream.py
+++ b/tests/unit/test_upstream.py
@@ -28,44 +28,7 @@ from flexmock import flexmock
 import packit
 from packit.actions import ActionName
 from packit.exceptions import PackitException
-from packit.local_project import LocalProject
 from packit.upstream import Upstream
-from tests.spellbook import get_test_config
-
-
-@pytest.fixture
-def package_config_mock():
-    mock = flexmock(synced_files=None, upstream_package_name="test_package_name")
-    mock.should_receive("current_version_command")
-    return mock
-
-
-@pytest.fixture
-def git_project_mock():
-    mock = flexmock(upstream_project_url="dummy_url")
-    return mock
-
-
-@pytest.fixture
-def local_project_mock(git_project_mock):
-    mock = flexmock(
-        git_project=git_project_mock, working_dir="/mock_dir", ref="mock_ref"
-    )
-    return mock
-
-
-@pytest.fixture
-def upstream_mock(local_project_mock, package_config_mock):
-    upstream = Upstream(
-        config=get_test_config(),
-        package_config=package_config_mock,
-        local_project=LocalProject(working_dir="test"),
-    )
-    flexmock(upstream)
-    upstream.should_receive("local_project").and_return(local_project_mock)
-    upstream.should_receive("absolute_specfile_path").and_return("_spec_file_path")
-    upstream.should_receive("absolute_specfile_dir").and_return("_spec_file_dir")
-    return upstream
 
 
 @pytest.fixture

--- a/tests/unit/test_upstream.py
+++ b/tests/unit/test_upstream.py
@@ -341,3 +341,26 @@ def test_get_archive_root_dir_from_template(
     upstream_mock.should_receive("get_version").and_return("1.0")
     upstream_mock.package_config.archive_root_dir_template = template
     assert upstream_mock.get_archive_root_dir_from_template() == expected_return_value
+
+
+@pytest.mark.parametrize(
+    "version, tag_template, expected_output, expectation",
+    [
+        pytest.param(
+            "1.0.0", "{version}", "1.0.0", does_not_raise(), id="valid_template"
+        ),
+        pytest.param(
+            "1.0.0",
+            "{rsion}",
+            "1.0.0",
+            pytest.raises(PackitException),
+            id="invalid_template",
+        ),
+    ],
+)
+def test_convert_version_to_tag(
+    version, tag_template, expected_output, expectation, upstream_mock
+):
+    with expectation:
+        upstream_mock.package_config.upstream_tag_template = tag_template
+        assert upstream_mock.convert_version_to_tag(version) == expected_output


### PR DESCRIPTION
Fixed `api.sync_release` bug, cuased by using version number instead of
git tag name for git checkout.

Added method `upstream.convert_version_to_tag`.