### PR TITLE
Fix url for configurations when owner is COPR group

### DIFF
--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -76,6 +76,11 @@ class CoprHelper:
     ):
         copr_url = self.copr_client.config.get("copr_url")
         section = section or "edit"
+
+        # COPR groups starts with '@' but url have '/g/owner'
+        if owner.startswith("@"):
+            owner = f"g/{owner[1:]}"
+
         return f"{copr_url}/coprs/{owner}/{project}/{section}/"
 
     def create_copr_project_if_not_exists(


### PR DESCRIPTION
When owner of the project is group it starts with '@', however, this does not
work when generating URL to this group.

When owner is not group:

``https://copr.fedorainfracloud.org/coprs/{owner}/{project}/``

When owner is group:

``https://copr.fedorainfracloud.org/coprs/g/{owner[1:]}/{project}/``

Example of the broken solution:
https://github.com/jkonecny12/anaconda/commit/f60173824a44bcb6979798eab28ec22fa994ac80

-----------------------------
The code should be fine, however, it's **not tested** because I don't know how to do that when user of this method is service.