### PR TITLE
Changes for EPEL 8

### DIFF
--- a/packit/git_utils.py
+++ b/packit/git_utils.py
@@ -39,7 +39,9 @@ def get_message_from_metadata(metadata: dict, header: Optional[str] = None) -> s
             f"We can save only dictionaries to metadata. Not {metadata}"
         )
 
-    content = yaml.dump(metadata, indent=4) if metadata else ""
+    content = (
+        yaml.dump(metadata, indent=4, default_flow_style=False) if metadata else ""
+    )
     if not header:
         return content
 

--- a/packit/patches.py
+++ b/packit/patches.py
@@ -141,7 +141,7 @@ class PatchMetadata:
         if metadata:
             logger.debug(
                 f"Commit {commit.hexsha:.8} metadata:\n"
-                f"{yaml.dump(metadata, indent=4)}"
+                f"{yaml.dump(metadata, indent=4, default_flow_style=False)}"
             )
             metadata_defined = True
         else:

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from contextlib import nullcontext as does_not_raise
+from contextlib import suppress as does_not_raise
 
 from munch import Munch
 import pytest

--- a/tests/unit/test_upstream.py
+++ b/tests/unit/test_upstream.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from contextlib import nullcontext as does_not_raise
+from contextlib import suppress as does_not_raise
 
 import pytest
 from flexmock import flexmock


### PR DESCRIPTION
Related to issue #278.

* Make packit work with pyyaml < 5.1
* Use `contextlib.suppress` instead of `contextlib.nullcontext`