### PR TITLE
Switch default for :champagne: comment to False

### DIFF
--- a/packit/config/notifications.py
+++ b/packit/config/notifications.py
@@ -24,7 +24,7 @@
 class PullRequestNotificationsConfig:
     """ Configuration of commenting on pull requests. """
 
-    def __init__(self, successful_build: bool = True):
+    def __init__(self, successful_build: bool = False):
         self.successful_build = successful_build
 
 

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -174,7 +174,7 @@ class MM23Schema(Schema):
 class PullRequestNotificationsSchema(MM23Schema):
     """ Configuration of commenting on pull requests. """
 
-    successful_build = fields.Bool(default=True)
+    successful_build = fields.Bool(default=False)
 
     @post_load
     def make_instance(self, data, **kwargs):

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -1057,7 +1057,7 @@ def test_get_all_files_to_sync(package_config, all_synced_files):
 
 def test_notifications_section():
     pc = PackageConfig.get_from_dict({"specfile_path": "package.spec"})
-    assert pc.notifications.pull_request.successful_build
+    assert not pc.notifications.pull_request.successful_build
 
 
 def test_get_local_specfile_path():


### PR DESCRIPTION
Disables congratulations comment by default, if not specified in config

Signed-off-by: Matej Focko <mfocko@redhat.com>