### PR TITLE
[JobType] Remove values not used by users

### DIFF
--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -35,20 +35,14 @@ logger = getLogger(__name__)
 
 
 class JobType(Enum):
-    """ Type of the job to execute: pick the correct handler """
+    """ Type of the job used by users in the config """
 
     propose_downstream = "propose_downstream"
     build = "build"
     sync_from_downstream = "sync_from_downstream"
     copr_build = "copr_build"
     production_build = "production_build"  # koji build
-    add_to_whitelist = "add_to_whitelist"
     tests = "tests"
-    report_test_results = "report_test_results"
-    pull_request_action = "pull_request_action"
-    copr_build_finished = "copr_build_finished"
-    copr_build_started = "copr_build_started"
-    create_bugzilla = "create_bugzilla"
 
 
 class JobConfigTriggerType(Enum):


### PR DESCRIPTION
`JobType` enum should be used just for the values defined by users in the config.

TODO:

- [x] double check whether the removed values are not used anymore in the packit-service handlers and remove the usages

Fixes packit/packit-service#879