### PR TITLE
Update tests_recording/test_data/ regeneration howto docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     rev: v3.4.0
     hooks:
       - id: check-added-large-files
-        exclude: tests_requre/test_data/test_api*
+        exclude: tests_recording/test_data/test_api/*
       - id: check-ast
       - id: check-merge-conflict
       - id: check-yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,25 +33,23 @@ Tests are stored in [tests](/tests) directory:
 
 Running tests locally:
 
-```
-make check_in_container
-```
+    make check_in_container
 
-To select a subset of the whole test suite, set `TESTS_TARGET`. For example to
-run only the unit tests use:
+To select a subset of the whole test suite, set `TESTS_TARGET`.
+For example to run only the unit tests use:
 
-```
-TESTS_TARGET=tests/unit make check_in_container
-```
+    TESTS_TARGET=tests/unit make check_in_container
 
-As a CI we use [Zuul](https://softwarefactory-project.io/zuul/t/local/builds?project=packit-service/packit) with a configuration in [.zuul.yaml](.zuul.yaml).
-If you want to re-run CI/tests in a pull request, just include `recheck` in a comment.
+Tests use pre-generated responses stored in [tests_recording/test_data/](tests_recording/test_data).
+To (re-)generate response file(s):
 
-When running the tests we are using the pregenerated responses that are saved in the ./tests/integration/test_data.
-If you need to generate a new file, just run the tests and provide environment variables for the service.
-The missing file will be automatically generated from the real response. Do not forget to commit the file as well.
+- [add requre to test image](files/local-tests-requirements.yaml)
+- remove files from [tests_recording/test_data/](tests_recording/test_data) you want to re-generate
+- set tokens in your [~/.config/.packit.yaml](https://packit.dev/docs/configuration/#user-configuration-file)
+- `make check_in_container_regenerate_data`
+- commit changed/new files
 
-If you need to regenerate a response file, just remove it and rerun the tests.
+See also [tests_recording/README.md](tests_recording/README.md)
 
 The saving of the responses is turned on by the `RECORD_REQUESTS` environment variable.
 The file, that will be used for storing, can be set by `RESPONSE_FILE` variable
@@ -63,6 +61,9 @@ response_file = self.get_datafile_filename() # name generated from the test name
 PersistentObjectStorage().storage_file = response_file
 ```
 
+As a CI we use [Zuul](https://softwarefactory-project.io/zuul/t/local/builds?project=packit-service/packit) with a configuration in [.zuul.yaml](.zuul.yaml).
+If you want to re-run CI/tests in a pull request, just include `recheck` in a PR comment.
+
 ### Additional configuration for development purposes
 
 #### Copr build
@@ -70,17 +71,17 @@ PersistentObjectStorage().storage_file = response_file
 For cases you'd like to trigger copr build in your copr project, you can configure it in
 packit configuration of your chosen package:
 
-```
+```yaml
 jobs:
-- job: copr_build
-  trigger: pull_request
-  metadata:
-    targets:
-      - some_targets
-    # (Optional) Defaults to 'packit'
-    owner: <your_fedora_username>
-    # (Optional) Defaults to <github_namespace>-<github_repo>
-    project: some_project_name
+  - job: copr_build
+    trigger: pull_request
+    metadata:
+      targets:
+        - some_targets
+      # (Optional) Defaults to 'packit'
+      owner: <your_fedora_username>
+      # (Optional) Defaults to <github_namespace>-<github_repo>
+      project: some_project_name
 ```
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ IMAGE=docker.io/usercont/packit
 TESTS_IMAGE=packit-tests
 
 CONTAINER_ENGINE ?= $(shell command -v podman 2> /dev/null || echo docker)
-TESTS_CONTAINER_RUN=$(CONTAINER_ENGINE) run --rm -ti -v $(CURDIR):/src --env TESTS_TARGET --security-opt label=disable $(TESTS_IMAGE)
 TESTS_RECORDING_PATH=tests_recording
 TESTS_TARGET ?= ./tests/unit ./tests/integration ./tests/functional
 
@@ -25,9 +24,21 @@ check:
 	find . -name "*.pyc" -exec rm {} \;
 	PYTHONPATH=$(CURDIR) PYTHONDONTWRITEBYTECODE=1 python3 -m pytest --verbose --showlocals $(TESTS_TARGET)
 
+# example: TESTS_TARGET=tests/unit/test_api.py make check_in_container
 check_in_container: tests_image
-	$(TESTS_CONTAINER_RUN) bash -c "pip3 install .; make check"
+	$(CONTAINER_ENGINE) run --rm -ti \
+		--env TESTS_TARGET \
+		-v $(CURDIR):/src \
+		--security-opt label=disable \
+		$(TESTS_IMAGE) \
+		bash -c "pip3 install .; make check"
 
-
+# Mounts your ~/.config/ where .packit.yaml with your github/gitlab tokens is expected
 check_in_container_regenerate_data: tests_image
-	$(TESTS_CONTAINER_RUN) bash -c "pip3 install .;make check TESTS_TARGET=$(TESTS_RECORDING_PATH) GITHUB_TOKEN=${GITHUB_TOKEN} PAGURE_TOKEN=${PAGURE_TOKEN}"
+	$(CONTAINER_ENGINE) run --rm -ti \
+		--env TESTS_TARGET=$(TESTS_RECORDING_PATH) \
+		-v $(CURDIR):/src \
+		-v $(HOME)/.config:/root/.config \
+		--security-opt label=disable \
+		$(TESTS_IMAGE) \
+		bash -c "pip3 install .; make check"

--- a/files/local-tests-requirements.yaml
+++ b/files/local-tests-requirements.yaml
@@ -8,6 +8,8 @@
     - include_tasks: tasks/configure-git.yaml
     - include_tasks: tasks/ogr-master.yaml
     - include_tasks: tasks/sandcastle-master.yaml
+    # In case you need to (re-)generate tests_recording/test_data/
+    #- include_tasks: tasks/requre-master.yaml
     - name: Install pre-commit
       dnf:
         name: pre-commit

--- a/tests_recording/README.md
+++ b/tests_recording/README.md
@@ -1,7 +1,7 @@
 # Recording testsuite
 
 This testsuite uses [Requre project](https://github.com/packit/requre)
-to store data from test using real credenials and communication with real
+to store data from test using real credentials and communication with real
 servers, etc.
 
 ## Add new substitutions if missing
@@ -15,13 +15,12 @@ There were troubles that different version of `ogr` or `rebasehelper`
 contained different behaviour, so that we had to generate these response
 files with various versions of these tools.
 
-The `unshare` command below will show tests which require network connectivity, because those will fail:
+The `unshare` command below will show tests which require network connectivity,
+because those will fail:
 
-```
-sudo unshare -n sudo -u $(whoami) pytest-3 -v -x tests/integration/test_status.py
-```
+    sudo unshare -n sudo -u $(whoami) pytest-3 -v -x tests_recording/test_status.py
 
-You can do it on your computer as the easiest way, becauase you have
+You can do it on your computer as the easiest way, because you have
 all credentials there eg:
 
 - github token
@@ -42,7 +41,9 @@ pytest-3 -v tests_recording
 
 ### Postprocessing
 
-- Remove secrets from stored files - Some parts are not covered by generic requre pre-commit hook for removing secrests, e.g. token and login for copr. Remove them manually or via requre-patch tools:
+- Remove secrets from stored files as some parts are not covered by generic
+  requre pre-commit hook for removing secrets, e.g. token and login for copr.
+  Remove them manually or with:
   ```
   requre-patch purge --replaces "copr.v3.helpers:login:str:somelogin" --replaces "copr.v3.helpers:token:str:sometoken" tests_recording/test_data/*/*yaml
   ```
@@ -55,5 +56,10 @@ pytest-3 -v tests_recording
 
 Install `requre` from git master branch
 
-- Inside Current version of packit there are no issues with various versions libraries. In case it happens, regenerate data with proper versions of libraries and add there keys for these versions.
-  -Define method `cassette_setup(cassette)` of your test class if not already defined. You can use there something like `cassette.data_miner.key = rebasehelper.VERSION`. It appends key with version of rebasehelper. You can add as many keys as necessarry.
+- Current version of packit has no issues with various libraries versions.
+  In case it happens, regenerate data with proper versions of libraries and
+  add there keys for these versions.
+- Define method `cassette_setup(cassette)` of your test class if not already defined.
+  You can use something like `cassette.data_miner.key = rebasehelper.VERSION`.
+  It appends a key with rebasehelper version.
+  You can add as many keys as necessary.

--- a/tests_recording/test_api.py
+++ b/tests_recording/test_api.py
@@ -108,7 +108,10 @@ class ProposeUpdate(PackitTest):
         return self._api
 
     def check_version_increase(self):
-        # change specfile little bit to have there some change
+        """Bump version in specfile and tag it with the new version.
+        Might fail if such tag already exists in requre repo.
+        In that case you probably need to bump Version in fedora/python-requre.spec
+        """
         filedata = self.project_specfile_location.read_text()
         # Patch the specfile with new version
         version_increase = "0.0.0"

--- a/tests_recording/testbase.py
+++ b/tests_recording/testbase.py
@@ -48,7 +48,7 @@ class PackitTest(unittest.TestCase):
         self._config = None
         self._project = None
         self._project_url = "https://github.com/packit/requre"
-        self._project_specfile_path = Path("fedora") / "python-requre.spec"
+        self._project_specfile_path = Path("fedora", "python-requre.spec")
         self._pc = None
         self._dg = None
         self._lp = None


### PR DESCRIPTION
I've been trying to make `make check_in_container_regenerate_data` work for me (because of #1074), but with no luck.

When I try `make check_in_container_regenerate_data` locally I see some problems with tokens so I checked the code and AFAICT we don't use `GITHUB_TOKEN` and `PAGURE_TOKEN` anymore so I changed the Makefile to mount my `~/.config/` into the test container. 

I also see
```
E   subprocess.CalledProcessError: Command 'cd /tmp/packit_tmp/tests_recording.test_api.ProposeUpdate.test_version_change_mocked.yaml/static_tmp_1;git commit -m 'test change' python-requre.spec;git tag -a 0.5.0 -m 'my version 0.5.0'' returned non-zero exit status 128.
------- Captured stderr call -------------
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/packit_tmp/tests_recording.test_api.ProposeUpdate.test_version_change_exception.yaml/static_tmp_1'
error: pathspec 'python-requre.spec' did not match any file(s) known to git
fatal: tag '0.5.0' already exists
```
which I failed to debug.
@jscotka ideas?