### PR TITLE
Don't behave as if 'ref' would be always a branch

### DIFF
--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -393,12 +393,10 @@ class LocalProject:
             return self.git_repo.active_branch.name
 
     def checkout_ref(self, ref: str):
-        """ Check out selected ref in the git repo; equiv of git checkout -B ref """
-        logger.info(f"Checking out ref {ref}.")
-        if ref not in self.git_repo.branches:
-            self.git_repo.create_head(self._ref)
-
-        self.git_repo.branches[self._ref].checkout()
+        """ Check out selected ref in the git repo"""
+        logger.info(f"Checking out ref {ref!r}.")
+        self.git_repo.git.checkout(ref)
+        logger.debug(f"Current commit is '{self.git_repo.commit()}'")
 
     def checkout_pr(self, pr_id: Union[str, int]):
         """

--- a/tests/unit/test_local_project.py
+++ b/tests/unit/test_local_project.py
@@ -219,42 +219,10 @@ def test_clone_project_checkout_branch():
     """Checkout existing branch"""
     project = LocalProject(
         git_repo=flexmock(
-            active_branch="branch",
             working_dir=Path("something"),
-            branches={
-                "other": flexmock(checkout=lambda: None)
-                .should_receive("checkout")
-                .once()
-                .mock()
-            },
+            git=flexmock().should_receive("checkout").with_args("other").once().mock(),
+            commit=lambda: "9e131ba261d8d07fd1c55d8aff6ade085f5cd354",
         ),
-        ref="other",
-        git_url="git@github.com:org/name",
-    )
-    assert project.git_repo
-    assert project.working_dir == Path("something")
-    assert project._ref == "other"
-
-
-def test_clone_project_checkout_new_branch():
-    """Checkout newly created branch"""
-    branches = {}
-    project = LocalProject(
-        git_repo=flexmock(
-            active_branch="branch",
-            working_dir="something",
-            branches=branches,
-            head=flexmock(is_detached=False),
-        )
-        .should_receive("create_head")
-        .with_args("other")
-        .replace_with(
-            lambda x: branches.setdefault(
-                x, flexmock().should_receive("checkout").once().mock()
-            )
-        )
-        .once()
-        .mock(),
         ref="other",
         git_url="git@github.com:org/name",
     )


### PR DESCRIPTION
LocalProject.checkout_ref() considered ref to be a branch, and created
such a branch if it didn't exist.

This meant though that in a newly cloned repo instead of checking out a
remote branch, it created a local one, usually from the last commit on
the main branch.

In Packit Service this lead to the wrong commit being used for SRPM
builds.

Add a debug log to print the hash of the commit after checkout in order
to make future debugging easier.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>