### PR TITLE
source-git & propose-downstream: always --local-content

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -201,8 +201,14 @@ class PackitAPI:
 
         current_up_branch = self.up.active_branch
         try:
-
-            if not use_local_content:
+            # we want to check out the tag only when local_content is not set
+            # and it's an actual upstream repo and not source-git
+            if upstream_ref:
+                logger.info(
+                    "We will not check out the upstream tag "
+                    "because this is a source-git repo."
+                )
+            elif not use_local_content:
                 self.up.local_project.checkout_release(upstream_tag)
 
             self.dg.check_last_commit()
@@ -281,7 +287,7 @@ class PackitAPI:
             else:
                 self.dg.push(refspec=f"HEAD:{dist_git_branch}")
         finally:
-            if not use_local_content:
+            if not use_local_content and not upstream_ref:
                 self.up.local_project.git_repo.git.checkout(current_up_branch)
             self.dg.refresh_specfile()
             self.dg.local_project.git_repo.git.reset("--hard", "HEAD")

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -52,7 +52,8 @@ logger = logging.getLogger(__name__)
     "--local-content",
     is_flag=True,
     default=False,
-    help="Do not checkout release tag. Use the current state of the repo.",
+    help="Do not checkout release tag. Use the current state of the repo. "
+    "This option is set by default for source-git repos",
 )
 @click.option(
     "--force-new-sources",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -59,6 +59,7 @@ from tests.spellbook import (
 
 DOWNSTREAM_PROJECT_URL = "https://src.fedoraproject.org/not/set.git"
 UPSTREAM_PROJECT_URL = "https://github.com/also-not/set.git"
+SOURCE_GIT_RELEASE_TAG = "0.1.0"
 
 
 @pytest.fixture()
@@ -198,7 +199,7 @@ def sourcegit_and_remote(tmp_path):
 
     sourcegit_dir = tmp_path / "source_git"
     shutil.copytree(SOURCEGIT_UPSTREAM, sourcegit_dir)
-    initiate_git_repo(sourcegit_dir, tag="0.1.0")
+    initiate_git_repo(sourcegit_dir, tag=SOURCE_GIT_RELEASE_TAG)
     subprocess.check_call(
         ["cp", "-R", SOURCEGIT_SOURCEGIT, tmp_path], cwd=sourcegit_remote
     )
@@ -282,6 +283,7 @@ def api_instance_source_git(sourcegit_and_remote, distgit_and_remote):
         pc = get_local_package_config(str(sourcegit))
         pc.upstream_project_url = str(sourcegit)
         pc.dist_git_clone_path = str(distgit)
+        pc.upstream_ref = SOURCE_GIT_RELEASE_TAG
         up_lp = LocalProject(working_dir=sourcegit)
         api = PackitAPI(c, pc, up_lp)
         return api

--- a/tests/integration/test_source_git.py
+++ b/tests/integration/test_source_git.py
@@ -56,7 +56,6 @@ def test_basic_local_update_without_patching(
     api_instance_source_git.sync_release(
         dist_git_branch="master",
         version="0.1.0",
-        use_local_content=True,
         upstream_ref="0.1.0",
     )
 
@@ -79,7 +78,6 @@ def test_basic_local_update_empty_patch(
     api_instance_source_git.sync_release(
         dist_git_branch="master",
         version="0.1.0",
-        use_local_content=True,
         upstream_ref=ref,
     )
 
@@ -121,7 +119,6 @@ def test_basic_local_update_patch_content(
     api_instance_source_git.sync_release(
         dist_git_branch="master",
         version="0.1.0",
-        use_local_content=True,
         upstream_ref="0.1.0",
     )
 
@@ -294,7 +291,6 @@ def test_basic_local_update_patch_content_with_metadata(
     api_instance_source_git.sync_release(
         dist_git_branch="master",
         version="0.1.0",
-        use_local_content=True,
         upstream_ref="0.1.0",
     )
 
@@ -352,7 +348,6 @@ def test_basic_local_update_patch_content_with_metadata_and_patch_ignored(
     api_instance_source_git.sync_release(
         dist_git_branch="master",
         version="0.1.0",
-        use_local_content=True,
         upstream_ref="0.1.0",
     )
 
@@ -398,7 +393,6 @@ def test_basic_local_update_patch_content_with_downstream_patch(
     api_instance_source_git.sync_release(
         dist_git_branch="master",
         version="0.1.0",
-        use_local_content=True,
         upstream_ref="0.1.0",
     )
 


### PR DESCRIPTION
Checking out release tag for source-git repos is a mistake since:
* we wouldn't be able to create patches
* and probably wouldn't even have a specfile and downstream packaging

Updates from source-git have to always be made from HEAD since recent
commits are directly related to downstream and that's exactly what
maintainers want to put to downstream. This the most significant
difference between source-git and upstream projects.

Fixes #975