### PR TITLE
Respect requested dist-git branches when propose-update

### DIFF
--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -23,7 +23,7 @@
 import json
 import logging
 from pathlib import Path
-from typing import Optional, List, Dict, Union
+from typing import Optional, List, Dict, Union, Set
 
 from ogr.abstract import GitProject
 from yaml import safe_load
@@ -181,6 +181,12 @@ class PackageConfig(CommonPackageConfig):
                 f" if this is not the one you want."
             )
         return projects_list[0]
+
+    def get_propose_downstream_dg_branches_value(self) -> Optional[Set]:
+        for job in self.jobs:
+            if job.type == JobType.propose_downstream:
+                return job.metadata.dist_git_branches
+        return set()
 
     def __eq__(self, other: object):
         if not isinstance(other, self.__class__):

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -126,6 +126,65 @@ def test_project_from_copr_build_job(package_config, project):
     assert config_project_value == project
 
 
+@pytest.mark.parametrize(
+    "package_config, expected",
+    [
+        (
+            PackageConfig(
+                specfile_path="xxx",
+                jobs=[
+                    JobConfig(
+                        type=JobType.propose_downstream,
+                        trigger=JobConfigTriggerType.pull_request,
+                        metadata=JobMetadataConfig(
+                            dist_git_branches=[
+                                "example",
+                            ]
+                        ),
+                    )
+                ],
+            ),
+            {
+                "example",
+            },
+        ),
+        (
+            PackageConfig(
+                specfile_path="xxx",
+                jobs=[
+                    JobConfig(
+                        type=JobType.propose_downstream,
+                        trigger=JobConfigTriggerType.pull_request,
+                        metadata=JobMetadataConfig(
+                            dist_git_branches=[
+                                "example1",
+                                "example2",
+                            ]
+                        ),
+                    )
+                ],
+            ),
+            {"example1", "example2"},
+        ),
+        (
+            PackageConfig(
+                specfile_path="xxx",
+                jobs=[
+                    JobConfig(
+                        type=JobType.propose_downstream,
+                        trigger=JobConfigTriggerType.pull_request,
+                    )
+                ],
+            ),
+            set(),
+        ),
+    ],
+)
+def test_dg_branches_from_propose_downstream_job(package_config, expected):
+    branches = package_config.get_propose_downstream_dg_branches_value()
+    assert branches == expected
+
+
 def test_package_config_equal(job_config_simple):
     assert PackageConfig(
         specfile_path="fedora/package.spec",

--- a/tests/unit/test_propose_downstream.py
+++ b/tests/unit/test_propose_downstream.py
@@ -1,0 +1,214 @@
+# MIT License
+#
+# Copyright (c) 2020 Red Hat, Inc.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+from flexmock import flexmock
+
+from packit.api import PackitAPI
+from packit.config import PackageConfig
+from packit.cli.propose_downstream import get_dg_branches
+
+from packit.config import (
+    JobType,
+    JobConfigTriggerType,
+    JobConfig,
+)
+from packit.config.job_config import JobMetadataConfig
+
+
+@pytest.mark.parametrize(
+    "package_config,cmdline,expected",
+    [
+        (
+            PackageConfig(
+                specfile_path="xxx",
+                jobs=[
+                    JobConfig(
+                        type=JobType.propose_downstream,
+                        trigger=JobConfigTriggerType.pull_request,
+                    )
+                ],
+            ),
+            None,
+            {
+                "default_br",
+            },
+        ),
+        (
+            PackageConfig(
+                specfile_path="xxx",
+                jobs=[
+                    JobConfig(
+                        type=JobType.propose_downstream,
+                        trigger=JobConfigTriggerType.pull_request,
+                        metadata=JobMetadataConfig(dist_git_branches=["file"]),
+                    )
+                ],
+            ),
+            None,
+            {
+                "file",
+            },
+        ),
+        (
+            PackageConfig(
+                specfile_path="xxx",
+                jobs=[
+                    JobConfig(
+                        type=JobType.propose_downstream,
+                        trigger=JobConfigTriggerType.pull_request,
+                    )
+                ],
+            ),
+            "cmdline",
+            {
+                "cmdline",
+            },
+        ),
+        (
+            PackageConfig(
+                specfile_path="xxx",
+                jobs=[
+                    JobConfig(
+                        type=JobType.propose_downstream,
+                        trigger=JobConfigTriggerType.pull_request,
+                        metadata=JobMetadataConfig(dist_git_branches=["file"]),
+                    )
+                ],
+            ),
+            "cmdline",
+            {
+                "cmdline",
+            },
+        ),
+        (
+            PackageConfig(
+                specfile_path="xxx",
+                jobs=[
+                    JobConfig(
+                        type=JobType.propose_downstream,
+                        trigger=JobConfigTriggerType.pull_request,
+                        metadata=JobMetadataConfig(
+                            dist_git_branches=["file1", "file2"]
+                        ),
+                    )
+                ],
+            ),
+            None,
+            {
+                "file1",
+                "file2",
+            },
+        ),
+        (
+            PackageConfig(
+                specfile_path="xxx",
+                jobs=[
+                    JobConfig(
+                        type=JobType.propose_downstream,
+                        trigger=JobConfigTriggerType.pull_request,
+                    )
+                ],
+            ),
+            "cmdline1,cmdline2",
+            {
+                "cmdline1",
+                "cmdline2",
+            },
+        ),
+        (
+            PackageConfig(
+                specfile_path="xxx",
+                jobs=[
+                    JobConfig(
+                        type=JobType.propose_downstream,
+                        trigger=JobConfigTriggerType.pull_request,
+                    )
+                ],
+            ),
+            "rawhide",
+            {
+                "default_br",
+            },
+        ),
+        (
+            PackageConfig(
+                specfile_path="xxx",
+                jobs=[
+                    JobConfig(
+                        type=JobType.propose_downstream,
+                        trigger=JobConfigTriggerType.pull_request,
+                        metadata=JobMetadataConfig(dist_git_branches=["rawhide"]),
+                    )
+                ],
+            ),
+            None,
+            {
+                "default_br",
+            },
+        ),
+        (
+            PackageConfig(
+                specfile_path="xxx",
+                jobs=[
+                    JobConfig(
+                        type=JobType.propose_downstream,
+                        trigger=JobConfigTriggerType.pull_request,
+                        metadata=JobMetadataConfig(
+                            dist_git_branches=["file1", "rawhide"]
+                        ),
+                    )
+                ],
+            ),
+            None,
+            {
+                "file1",
+                "default_br",
+            },
+        ),
+        (
+            PackageConfig(
+                specfile_path="xxx",
+                jobs=[
+                    JobConfig(
+                        type=JobType.propose_downstream,
+                        trigger=JobConfigTriggerType.pull_request,
+                    )
+                ],
+            ),
+            "cmdline1,rawhide",
+            {
+                "cmdline1",
+                "default_br",
+            },
+        ),
+    ],
+)
+def test_get_dist_git_branches(package_config, cmdline, expected):
+
+    api = flexmock(PackitAPI)
+    api.package_config = package_config
+    git_project = flexmock(default_branch="default_br")
+    local_project = flexmock(git_project=git_project)
+    api.dg = flexmock(local_project=local_project)
+
+    assert get_dg_branches(api, cmdline) == expected


### PR DESCRIPTION
Previously, `propose-update` command didn't take `dist_git_branches`
option (set in `.packit.yaml`) into account. Now both command-line and
config-file options are respected. Command-line option has priority.