### PR TITLE
Be consistent in the naming of "propose-downstream"

### DIFF
--- a/packit/cli/packit_base.py
+++ b/packit/cli/packit_base.py
@@ -15,7 +15,7 @@ from packit.cli.push_updates import push_updates
 from packit.cli.srpm import srpm
 from packit.cli.status import status
 from packit.cli.sync_from_downstream import sync_from_downstream
-from packit.cli.propose_downstream import downstream
+from packit.cli.propose_downstream import propose_downstream
 from packit.cli.validate_config import validate_config
 from packit.config import Config, get_context_settings
 from packit.utils.logging import set_logging
@@ -92,7 +92,7 @@ def packit_base(ctx, debug, fas_user, keytab, dry_run, remote):
     logger.debug(f"Packit {packit_version} is being used.")
 
 
-packit_base.add_command(downstream)
+packit_base.add_command(propose_downstream)
 packit_base.add_command(sync_from_downstream)
 packit_base.add_command(build)
 packit_base.add_command(copr_build)

--- a/packit/cli/packit_base.py
+++ b/packit/cli/packit_base.py
@@ -1,24 +1,5 @@
-# MIT License
-#
-# Copyright (c) 2019 Red Hat, Inc.
-
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
 
 import logging
 

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -89,7 +89,7 @@ logger = logging.getLogger(__name__)
 @click.argument("version", required=False)
 @pass_config
 @cover_packit_exception
-def downstream(
+def propose_downstream(
     config,
     dist_git_path,
     dist_git_branch,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -26,7 +26,7 @@ from pkg_resources import get_distribution
 from packit.cli.build import build
 from packit.cli.create_update import create_update
 from packit.cli.packit_base import packit_base
-from packit.cli.propose_downstream import downstream
+from packit.cli.propose_downstream import propose_downstream
 from tests.spellbook import call_packit
 
 
@@ -43,7 +43,7 @@ def test_base_version():
     assert result.output.strip() == get_distribution("packitos").version
 
 
-@pytest.mark.parametrize("cmd_function", [downstream, build, create_update])
+@pytest.mark.parametrize("cmd_function", [propose_downstream, build, create_update])
 def test_base_subcommand_direct(cmd_function):
     result = call_packit(cmd_function, parameters=["--help"])
     assert result.exit_code == 0


### PR DESCRIPTION
The function implementing the "propose-downstream" command was called
"downstream", which doesn't match expectations, making navigating the
code more difficult. Fix this by making naming consistent.