### PR TITLE
make `init` command work with CentOS packages

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -65,6 +65,10 @@ class DistGit(PackitRepositoryBase):
     # we store downstream content in source-git in this subdir
     source_git_downstream_suffix = "fedora"
 
+    # spec files are stored in this dir in dist-git
+    # this applies to Fedora and CentOS Stream 9
+    spec_dir_name = ""
+
     def __init__(
         self,
         config: Config,
@@ -163,6 +167,7 @@ class DistGit(PackitRepositoryBase):
         """ provide the path, don't check it """
         return (
             self.local_project.working_dir
+            / self.spec_dir_name
             / f"{self.package_config.downstream_package_name}.spec"
         )
 

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -69,6 +69,10 @@ class DistGit(PackitRepositoryBase):
     # this applies to Fedora and CentOS Stream 9
     spec_dir_name = ""
 
+    # sources are stored in this dir in dist-git
+    # this applies to Fedora and CentOS Stream 9
+    source_dir_name = ""
+
     def __init__(
         self,
         config: Config,
@@ -170,6 +174,11 @@ class DistGit(PackitRepositoryBase):
             / self.spec_dir_name
             / f"{self.package_config.downstream_package_name}.spec"
         )
+
+    @property
+    def absolute_source_dir(self) -> Path:
+        """ absoulute path to directory with spec-file sources """
+        return self.local_project.working_dir / self.source_dir_name
 
     @property
     def absolute_specfile_path(self) -> Path:
@@ -294,7 +303,7 @@ class DistGit(PackitRepositoryBase):
         """
         with cwd(self.local_project.working_dir):
             self.specfile.download_remote_sources()
-        archive = self.absolute_specfile_dir / self.upstream_archive_name
+        archive = self.absolute_source_dir / self.upstream_archive_name
         if not archive.exists():
             raise PackitException(
                 "Upstream archive was not downloaded, something is wrong."

--- a/packit/source_git.py
+++ b/packit/source_git.py
@@ -27,10 +27,10 @@ logger = logging.getLogger(__name__)
 
 
 class CentOSDistGit(DistGit):
-    """ Fedora and CentOS dist-git differ """
+    """ CentOS dist-git layout implementation """
 
-    # we store downstream content in source-git in this subdir
-    source_git_downstream_suffix = "SPECS"
+    # spec files are stored in this dir in dist-git
+    spec_dir_name = "SPECS"
 
     @classmethod
     def clone(

--- a/packit/source_git.py
+++ b/packit/source_git.py
@@ -26,11 +26,16 @@ from packit.utils.repo import clone_centos_package
 logger = logging.getLogger(__name__)
 
 
+# TODO: we'll need to distinct b/w 8 and 9 - 9 will follow Fedora
 class CentOSDistGit(DistGit):
     """ CentOS dist-git layout implementation """
 
     # spec files are stored in this dir in dist-git
     spec_dir_name = "SPECS"
+
+    # sources are stored in this dir in dist-git
+    # this applies to CentOS Stream 8 and CentOS Linux 7 and 8
+    source_dir_name = "SOURCES"
 
     @classmethod
     def clone(
@@ -45,10 +50,6 @@ class CentOSDistGit(DistGit):
         )
         lp = LocalProject(working_dir=path)
         return cls(config, package_config, local_project=lp)
-
-    @property
-    def absolute_source_dir(self):
-        return self.local_project.working_dir / "SOURCES"
 
 
 def get_distgit_kls_from_repo(
@@ -311,6 +312,7 @@ class SourceGitGenerator:
         """
         if self.dist_git_branch:
             self.dist_git.checkout_branch(self.dist_git_branch)
+        self.dist_git.download_upstream_archive()
         root_downstream_dir = self.dist_git.get_root_downstream_dir_for_source_git(
             self.local_project.working_dir
         )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 filterwarnings = ignore::DeprecationWarning
+addopts = -m "not slow"
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/tests/data/cronie/.cronie.metadata
+++ b/tests/data/cronie/.cronie.metadata
@@ -1,0 +1,1 @@
+03e53a07f2a5b8724e8d7cf7124539b4e82414d3 SOURCES/cronie-1.5.2.tar.gz

--- a/tests/data/cronie/.gitignore
+++ b/tests/data/cronie/.gitignore
@@ -1,0 +1,1 @@
+SOURCES/cronie-1.5.2.tar.gz

--- a/tests/data/cronie/SOURCES/cronie-1.5.2-context-role.patch
+++ b/tests/data/cronie/SOURCES/cronie-1.5.2-context-role.patch
@@ -1,0 +1,40 @@
+From 1f866530f5b3c49012c61b299f3c4e1dceff2a71 Mon Sep 17 00:00:00 2001
+From: Tomas Mraz <tmraz@fedoraproject.org>
+Date: Thu, 18 Oct 2018 14:25:58 +0200
+Subject: [PATCH] Use the role from the crond context for system job contexts.
+
+New SELinux policy added multiple roles for the system_u user on crond_t.
+The default context returned from get_default_context_with_level() is now
+unconfined_t instead of system_cronjob_t which is incorrect for system cron
+jobs.
+We use the role to limit the default context to system_cronjob_t.
+---
+ src/security.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/src/security.c b/src/security.c
+index d1bdc7f..5213cf3 100644
+--- a/src/security.c
++++ b/src/security.c
+@@ -505,6 +505,7 @@ get_security_context(const char *name, int crontab_fd,
+ 		retval = get_default_context_with_level(seuser, level, NULL, &scontext);
+ 	}
+ 	else {
++		const char *current_user, *current_role;
+ 		if (getcon(&current_context_str) < 0) {
+ 			log_it(name, getpid(), "getcon FAILED", "", 0);
+ 			return (security_getenforce() > 0);
+@@ -517,8 +518,9 @@ get_security_context(const char *name, int crontab_fd,
+ 			return (security_getenforce() > 0);
+ 		}
+
+-		const char *current_user = context_user_get(current_context);
+-		retval = get_default_context_with_level(current_user, level, NULL, &scontext);
++		current_user = context_user_get(current_context);
++		current_role = context_role_get(current_context);
++		retval = get_default_context_with_rolelevel(current_user, current_role, level, NULL, &scontext);
+
+ 		freecon(current_context_str);
+ 		context_free(current_context);
+--
+2.14.5

--- a/tests/data/cronie/SOURCES/cronie-1.5.2-restart-on-failure.patch
+++ b/tests/data/cronie/SOURCES/cronie-1.5.2-restart-on-failure.patch
@@ -1,0 +1,12 @@
+diff -ru cronie-1.5.2/contrib/cronie.systemd cronie-1.5.2_patched/contrib/cronie.systemd
+--- cronie-1.5.2/contrib/cronie.systemd	2018-11-27 15:26:46.797288342 +0100
++++ cronie-1.5.2_patched/contrib/cronie.systemd	2018-11-27 15:26:19.479159225 +0100
+@@ -7,6 +7,8 @@
+ ExecStart=/usr/sbin/crond -n $CRONDARGS
+ ExecReload=/bin/kill -HUP $MAINPID
+ KillMode=process
++Restart=on-failure
++RestartSec=30s
+
+ [Install]
+ WantedBy=multi-user.target

--- a/tests/data/cronie/SOURCES/fix-memory-leaks.patch
+++ b/tests/data/cronie/SOURCES/fix-memory-leaks.patch
@@ -1,0 +1,140 @@
+diff -ru cronie-1.5.2/anacron/readtab.c cronie-1.5.2_patched/anacron/readtab.c
+--- cronie-1.5.2/anacron/readtab.c	2017-09-14 13:53:21.000000000 +0200
++++ cronie-1.5.2_patched/anacron/readtab.c	2018-09-07 15:13:17.752498050 +0200
+@@ -134,8 +134,19 @@
+
+     var_len = (int)strlen(env_var);
+     val_len = (int)strlen(value);
++    if (!var_len) {
++        return;
++    }
++
+     er = obstack_alloc(&tab_o, sizeof(env_rec));
++    if (er == NULL) {
++        die_e("Cannot allocate memory.");
++    }
++
+     er->assign = obstack_alloc(&tab_o, var_len + 1 + val_len + 1);
++    if (er->assign == NULL) {
++        die_e("Cannot allocate memory.");
++    }
+     strcpy(er->assign, env_var);
+     er->assign[var_len] = '=';
+     strcpy(er->assign + var_len + 1, value);
+@@ -167,15 +178,24 @@
+ 	return;
+     }
+     jr = obstack_alloc(&tab_o, sizeof(job_rec));
++    if (jr == NULL) {
++        die_e("Cannot allocate memory.");
++    }
+     jr->period = period;
+     jr->named_period = 0;
+     delay += random_number;
+     jr->delay = delay;
+     jr->tab_line = line_num;
+     jr->ident = obstack_alloc(&tab_o, ident_len + 1);
++    if (jr->ident == NULL) {
++        die_e("Cannot allocate memory.");
++    }
+     strcpy(jr->ident, ident);
+     jr->arg_num = job_arg_num(ident);
+     jr->command = obstack_alloc(&tab_o, command_len + 1);
++    if (jr->command == NULL) {
++        die_e("Cannot allocate memory.");
++    }
+     strcpy(jr->command, command);
+     jr->job_pid = jr->mailer_pid = 0;
+     if (last_job_rec != NULL) last_job_rec->next = jr;
+@@ -208,6 +228,9 @@
+     }
+
+     jr = obstack_alloc(&tab_o, sizeof(job_rec));
++    if (jr == NULL) {
++        die_e("Cannot allocate memory.");
++    }
+     if (!strncmp ("@monthly", periods, 8)) {
+ 		jr->named_period = 1;
+     } else if (!strncmp("@yearly", periods, 7) || !strncmp("@annually", periods, 9) || !strncmp(/* backwards compat misspelling */"@annualy", periods, 8)) {
+@@ -225,9 +248,15 @@
+     jr->delay = delay;
+     jr->tab_line = line_num;
+     jr->ident = obstack_alloc(&tab_o, ident_len + 1);
++    if (jr->ident == NULL) {
++        die_e("Cannot allocate memory.");
++    }
+     strcpy(jr->ident, ident);
+     jr->arg_num = job_arg_num(ident);
+     jr->command = obstack_alloc(&tab_o, command_len + 1);
++    if (jr->command == NULL) {
++        die_e("Cannot allocate memory.");
++    }
+     strcpy(jr->command, command);
+     jr->job_pid = jr->mailer_pid = 0;
+     if (last_job_rec != NULL) last_job_rec->next = jr;
+diff -ru cronie-1.5.2/anacron/runjob.c cronie-1.5.2_patched/anacron/runjob.c
+--- cronie-1.5.2/anacron/runjob.c	2018-01-24 17:02:33.000000000 +0100
++++ cronie-1.5.2_patched/anacron/runjob.c	2018-09-07 15:13:17.752498050 +0200
+@@ -104,9 +104,44 @@
+ static void
+ xputenv(const char *s)
+ {
+-    char *copy = strdup (s);
+-    if (!copy) die_e("Not enough memory to set the environment");
+-    if (putenv(copy)) die_e("Can't set the environment");
++    char *name = NULL, *val = NULL;
++    char *eq_ptr;
++    const char *errmsg;
++    size_t eq_index;
++
++    if (s == NULL) {
++        die_e("Invalid environment string");
++    }
++
++    eq_ptr = strchr(s, '=');
++    if (eq_ptr == NULL) {
++        die_e("Invalid environment string");
++    }
++
++    eq_index = (size_t) (eq_ptr - s);
++
++    name = malloc((eq_index + 1) * sizeof(char));
++    if (name == NULL) {
++        die_e("Not enough memory to set the environment");
++    }
++
++    val = malloc((strlen(s) - eq_index) * sizeof(char));
++    if (val == NULL) {
++        die_e("Not enough memory to set the environment");
++    }
++
++    strncpy(name, s, eq_index);
++    name[eq_index] = '\0';
++    strcpy(val, s + eq_index + 1);
++
++    if (setenv(name, val, 1)) {
++        die_e("Can't set the environment");
++    }
++
++    free(name);
++    free(val);
++    return;
++
+ }
+
+ static void
+diff -ru cronie-1.5.2/src/entry.c cronie-1.5.2_patched/src/entry.c
+--- cronie-1.5.2/src/entry.c	2017-09-14 13:53:21.000000000 +0200
++++ cronie-1.5.2_patched/src/entry.c	2018-09-07 15:13:17.752498050 +0200
+@@ -131,8 +131,10 @@
+ 			goto eof;
+ 		}
+ 		ch = get_char(file);
+-		if (ch == EOF)
++		if (ch == EOF) {
++			free(e);
+ 			return NULL;
++		}
+ 	}
+
+ 	if (ch == '@') {

--- a/tests/data/cronie/SOURCES/fix-unsafe-code.patch
+++ b/tests/data/cronie/SOURCES/fix-unsafe-code.patch
@@ -1,0 +1,117 @@
+diff -ru cronie-1.5.2/src/cronnext.c cronie-1.5.2_patched/src/cronnext.c
+--- cronie-1.5.2/src/cronnext.c	2018-05-03 18:41:12.000000000 +0200
++++ cronie-1.5.2_patched/src/cronnext.c	2018-09-07 15:17:54.555924440 +0200
+@@ -71,13 +71,13 @@
+ /*
+  * print entry flags
+  */
+-char *flagname[]= {
+-	[MIN_STAR] =	"MIN_STAR",
+-	[HR_STAR] =	"HR_STAR",
+-	[DOM_STAR] =	"DOM_STAR",
+-	[DOW_STAR] =	"DOW_STAR",
+-	[WHEN_REBOOT] =	"WHEN_REBOOT",
+-	[DONT_LOG] =	"DONT_LOG"
++const char *flagname[]= {
++	"MIN_STAR",
++	"HR_STAR",
++	"DOM_STAR",
++	"DOW_STAR",
++	"WHEN_REBOOT",
++	"DONT_LOG"
+ };
+
+ void printflags(char *indent, int flags) {
+@@ -85,8 +85,8 @@
+ 	int first = 1;
+
+ 	printf("%s    flagnames:", indent);
+-	for (f = 1; f < sizeof(flagname);  f = f << 1)
+-		if (flags & f) {
++	for (f = 0; f < sizeof(flagname)/sizeof(char *);  f++)
++		if (flags & (int)1 << f) {
+ 			printf("%s%s", first ? " " : "|", flagname[f]);
+ 			first = 0;
+ 		}
+diff -ru cronie-1.5.2/src/do_command.c cronie-1.5.2_patched/src/do_command.c
+--- cronie-1.5.2/src/do_command.c	2017-09-14 13:53:21.000000000 +0200
++++ cronie-1.5.2_patched/src/do_command.c	2018-09-07 15:17:54.555924440 +0200
+@@ -418,7 +418,7 @@
+ 			if (mailto && safe_p(usernm, mailto)
+ 				&& strncmp(MailCmd,"off",3) && !SyslogOutput) {
+ 				char **env;
+-				char mailcmd[MAX_COMMAND];
++				char mailcmd[MAX_COMMAND+1]; /* +1 for terminator */
+ 				char hostname[MAXHOSTNAMELEN];
+ 				char *content_type = env_get("CONTENT_TYPE", jobenv),
+ 					*content_transfer_encoding =
+@@ -434,7 +434,7 @@
+ 					}
+ 				}
+ 				else {
+-					strncpy(mailcmd, MailCmd, MAX_COMMAND);
++					strncpy(mailcmd, MailCmd, MAX_COMMAND+1);
+ 				}
+ 				if (!(mail = cron_popen(mailcmd, "w", e->pwd, jobenv))) {
+ 					perror(mailcmd);
+diff -ru cronie-1.5.2/src/env.c cronie-1.5.2_patched/src/env.c
+--- cronie-1.5.2/src/env.c	2017-09-14 13:53:21.000000000 +0200
++++ cronie-1.5.2_patched/src/env.c	2018-09-07 15:17:54.554924435 +0200
+@@ -63,7 +63,7 @@
+ 		for (i = 0; i < count; i++)
+ 			if ((p[i] = strdup(envp[i])) == NULL) {
+ 				save_errno = errno;
+-				while (--i >= 0)
++				while (i-- > 0)
+ 					free(p[i]);
+ 				free(p);
+ 				errno = save_errno;
+@@ -263,7 +263,9 @@
+ 	}
+ 	if (state != FINI && state != EQ2 && !(state == VALUE && !quotechar)) {
+ 		Debug(DPARS, ("load_env, not an env var, state = %d\n", state));
+-			fseek(f, filepos, 0);
++			if (fseek(f, filepos, 0)) {
++                return ERR;
++           }
+ 		Set_LineNum(fileline);
+ 		return (FALSE);
+ 	}
+diff -ru cronie-1.5.2/src/globals.h cronie-1.5.2_patched/src/globals.h
+--- cronie-1.5.2/src/globals.h	2017-01-17 16:53:50.000000000 +0100
++++ cronie-1.5.2_patched/src/globals.h	2018-09-07 15:17:54.555924440 +0200
+@@ -77,7 +77,7 @@
+ XTRN time_t	StartTime;
+ XTRN int	NoFork;
+ XTRN int        PermitAnyCrontab;
+-XTRN char       MailCmd[MAX_COMMAND];
++XTRN char       MailCmd[MAX_COMMAND+1]; /* +1 for terminator */
+ XTRN char       cron_default_mail_charset[MAX_ENVSTR];
+ XTRN int        EnableClustering;
+ XTRN int	ChangePath;
+diff -ru cronie-1.5.2/src/security.c cronie-1.5.2_patched/src/security.c
+--- cronie-1.5.2/src/security.c	2017-09-14 13:29:47.000000000 +0200
++++ cronie-1.5.2_patched/src/security.c	2018-09-07 15:17:54.554924435 +0200
+@@ -417,7 +417,7 @@
+ 		}
+ 	}
+
+-	if (strcmp(u->scontext, ucontext)) {
++	if (!ucontext || strcmp(u->scontext, ucontext)) {
+ 		if (!cron_authorize_range(u->scontext, ucontext)) {
+ 			if (security_getenforce() > 0) {
+ # ifdef WITH_AUDIT
+diff -ru cronie-1.5.2/src/user.c cronie-1.5.2_patched/src/user.c
+--- cronie-1.5.2/src/user.c	2017-01-17 16:53:50.000000000 +0100
++++ cronie-1.5.2_patched/src/user.c	2018-09-07 15:17:54.555924440 +0200
+@@ -44,6 +44,10 @@
+ free_user (user * u) {
+ 	entry *e, *ne;
+
++	if (!u) {
++		return;
++	}
++
+ 	free(u->name);
+ 	free(u->tabname);
+ 	for (e = u->crontab; e != NULL; e = ne)	{

--- a/tests/data/cronie/SPECS/cronie.spec
+++ b/tests/data/cronie/SPECS/cronie.spec
@@ -1,0 +1,536 @@
+%bcond_without selinux
+%bcond_without pam
+%bcond_without audit
+%bcond_without inotify
+
+Summary:   Cron daemon for executing programs at set times
+Name:      cronie
+Version:   1.5.2
+Release:   4%{?dist}
+License:   MIT and BSD and ISC and GPLv2+
+Group:     System Environment/Base
+URL:       https://github.com/cronie-crond/cronie
+Source0:   https://github.com/cronie-crond/cronie/releases/download/cronie-%{version}/cronie-%{version}.tar.gz
+
+Requires:  dailyjobs
+
+%if %{with selinux}
+Requires:      libselinux >= 2.0.64
+Buildrequires: libselinux-devel >= 2.0.64
+%endif
+%if %{with pam}
+Requires:      pam >= 1.0.1
+Buildrequires: pam-devel >= 1.0.1
+%endif
+%if %{with audit}
+Buildrequires: audit-libs-devel >= 1.4.1
+%endif
+
+BuildRequires:    gcc
+BuildRequires:    systemd
+Obsoletes:        %{name}-sysvinit
+
+Requires(post):   coreutils sed
+Requires(post):   systemd
+Requires(preun):  systemd
+Requires(postun): systemd
+Requires(post):   systemd
+
+# Some parts of code could result in a memory leak.
+Patch0:     fix-memory-leaks.patch
+# Some parts of code could result in undefined behavior.
+Patch1:     fix-unsafe-code.patch
+# Use correct selinux role
+Patch2:     cronie-1.5.2-context-role.patch
+# Make systemd restart crond when it fails.
+Patch3:     cronie-1.5.2-restart-on-failure.patch
+
+%description
+Cronie contains the standard UNIX daemon crond that runs specified programs at
+scheduled times and related tools. It is a fork of the original vixie-cron and
+has security and configuration enhancements like the ability to use pam and
+SELinux.
+
+%package anacron
+Summary:   Utility for running regular jobs
+Requires:  crontabs
+Group:     System Environment/Base
+Provides:  dailyjobs
+Provides:  anacron = 2.4
+Obsoletes: anacron <= 2.3
+Requires(post): coreutils
+Requires:  %{name} = %{version}-%{release}
+
+%description anacron
+Anacron is part of cronie that is used for running jobs with regular
+periodicity which do not have exact time of day of execution.
+
+The default settings of anacron execute the daily, weekly, and monthly
+jobs, but anacron allows setting arbitrary periodicity of jobs.
+
+Using anacron allows running the periodic jobs even if the system is often
+powered off and it also allows randomizing the time of the job execution
+for better utilization of resources shared among multiple systems.
+
+%package noanacron
+Summary:   Utility for running simple regular jobs in old cron style
+Group:     System Environment/Base
+Provides:  dailyjobs
+Requires:  crontabs
+Requires:  %{name} = %{version}-%{release}
+
+%description noanacron
+Old style of running {hourly,daily,weekly,monthly}.jobs without anacron. No
+extra features.
+
+%prep
+%setup -q
+
+%patch0 -p1
+%patch1 -p1
+%patch2 -p1
+%patch3 -p1
+
+%build
+%configure \
+%if %{with pam}
+--with-pam \
+%endif
+%if %{with selinux}
+--with-selinux \
+%endif
+%if %{with audit}
+--with-audit \
+%endif
+%if %{with inotify}
+--with-inotify \
+%endif
+--enable-anacron \
+--enable-pie \
+--enable-relro
+
+make %{?_smp_mflags} V=2
+
+%install
+make install DESTDIR=$RPM_BUILD_ROOT DESTMAN=$RPM_BUILD_ROOT%{_mandir}
+mkdir -pm700 $RPM_BUILD_ROOT%{_localstatedir}/spool/cron
+mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig/
+mkdir -pm755 $RPM_BUILD_ROOT%{_sysconfdir}/cron.d/
+%if ! %{with pam}
+    rm -f $RPM_BUILD_ROOT%{_sysconfdir}/pam.d/crond
+%endif
+install -m 644 crond.sysconfig $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig/crond
+touch $RPM_BUILD_ROOT%{_sysconfdir}/cron.deny
+install -m 644 contrib/anacrontab $RPM_BUILD_ROOT%{_sysconfdir}/anacrontab
+install -c -m755 contrib/0hourly $RPM_BUILD_ROOT%{_sysconfdir}/cron.d/0hourly
+mkdir -pm 755 $RPM_BUILD_ROOT%{_sysconfdir}/cron.hourly
+install -c -m755 contrib/0anacron $RPM_BUILD_ROOT%{_sysconfdir}/cron.hourly/0anacron
+mkdir -p $RPM_BUILD_ROOT/var/spool/anacron
+touch $RPM_BUILD_ROOT/var/spool/anacron/cron.daily
+touch $RPM_BUILD_ROOT/var/spool/anacron/cron.weekly
+touch $RPM_BUILD_ROOT/var/spool/anacron/cron.monthly
+
+# noanacron package
+install -m 644 contrib/dailyjobs $RPM_BUILD_ROOT/%{_sysconfdir}/cron.d/dailyjobs
+
+# install systemd initscript
+mkdir -p $RPM_BUILD_ROOT/lib/systemd/system/
+install -m 644 contrib/cronie.systemd $RPM_BUILD_ROOT/lib/systemd/system/crond.service
+
+%post
+# run after an installation
+%systemd_post crond.service
+
+%post anacron
+[ -e /var/spool/anacron/cron.daily ] || touch /var/spool/anacron/cron.daily 2>/dev/null || :
+[ -e /var/spool/anacron/cron.weekly ] || touch /var/spool/anacron/cron.weekly 2>/dev/null || :
+[ -e /var/spool/anacron/cron.monthly ] || touch /var/spool/anacron/cron.monthly 2>/dev/null || :
+
+%preun
+# run before a package is removed
+%systemd_preun crond.service
+
+%postun
+# run after a package is removed
+%systemd_postun_with_restart crond.service
+
+%triggerun -- cronie-anacron < 1.4.1
+# empty /etc/crontab in case there are only old regular jobs
+cp -a /etc/crontab /etc/crontab.rpmsave
+sed -e '/^01 \* \* \* \* root run-parts \/etc\/cron\.hourly/d'\
+  -e '/^02 4 \* \* \* root run-parts \/etc\/cron\.daily/d'\
+  -e '/^22 4 \* \* 0 root run-parts \/etc\/cron\.weekly/d'\
+  -e '/^42 4 1 \* \* root run-parts \/etc\/cron\.monthly/d' /etc/crontab.rpmsave > /etc/crontab
+exit 0
+
+%triggerun -- cronie < 1.4.7-2
+# Save the current service runlevel info
+# User must manually run systemd-sysv-convert --apply crond
+# to migrate them to systemd targets
+/usr/bin/systemd-sysv-convert --save crond
+
+# The package is allowed to autostart:
+/bin/systemctl enable crond.service >/dev/null 2>&1
+
+/sbin/chkconfig --del crond >/dev/null 2>&1 || :
+/bin/systemctl try-restart crond.service >/dev/null 2>&1 || :
+/bin/systemctl daemon-reload >/dev/null 2>&1 || :
+
+%triggerin -- pam, glibc, libselinux
+# changes in pam, glibc or libselinux can make crond crash
+# when it calls pam
+/bin/systemctl try-restart crond.service >/dev/null 2>&1 || :
+
+%files
+%doc AUTHORS README ChangeLog
+%{!?_licensedir:%global license %%doc}
+%license COPYING
+%attr(755,root,root) %{_sbindir}/crond
+%attr(4755,root,root) %{_bindir}/crontab
+%attr(755,root,root) %{_bindir}/cronnext
+%{_mandir}/man8/crond.*
+%{_mandir}/man8/cron.*
+%{_mandir}/man5/crontab.*
+%{_mandir}/man1/crontab.*
+%{_mandir}/man1/cronnext.*
+%dir %{_localstatedir}/spool/cron
+%dir %{_sysconfdir}/cron.d
+%if %{with pam}
+%attr(0644,root,root) %config(noreplace) %{_sysconfdir}/pam.d/crond
+%endif
+%config(noreplace) %{_sysconfdir}/sysconfig/crond
+%config(noreplace) %{_sysconfdir}/cron.deny
+%attr(0644,root,root) %config(noreplace) %{_sysconfdir}/cron.d/0hourly
+%attr(0644,root,root) /lib/systemd/system/crond.service
+
+%files anacron
+%{_sbindir}/anacron
+%attr(0755,root,root) %{_sysconfdir}/cron.hourly/0anacron
+%config(noreplace) %{_sysconfdir}/anacrontab
+%dir /var/spool/anacron
+%ghost %attr(0600,root,root) %verify(not md5 size mtime) /var/spool/anacron/cron.daily
+%ghost %attr(0600,root,root) %verify(not md5 size mtime) /var/spool/anacron/cron.weekly
+%ghost %attr(0600,root,root) %verify(not md5 size mtime) /var/spool/anacron/cron.monthly
+%{_mandir}/man5/anacrontab.*
+%{_mandir}/man8/anacron.*
+
+%files noanacron
+%attr(0644,root,root) %config(noreplace) %{_sysconfdir}/cron.d/dailyjobs
+
+%changelog
+* Wed Jun 12 2019 Marcel Plch <mplch@redhat.com> - 1.5.2-4
+- Make crond restart on failure
+- Resolves: rhbz#1715137
+
+* Mon May 20 2019 Marcel Plch <mplch@redhat.com> - 1.5.2-3
+- use role from the current context for system crontabs
+- Resolves: rhbz#1708557
+
+* Fri Sep 07 2018 Marcel Plch <mplch@redhat.com> - 1.5.2-2
+- Covscan issues review
+- Fix potential memory leaks
+- Fix unsafe code
+- Resolves: rhbz#1602467
+
+* Thu May  3 2018 Tomáš Mráz <tmraz@redhat.com> - 1.5.2-1
+- new upstream release 1.5.2
+
+* Wed Feb 07 2018 Fedora Release Engineering <releng@fedoraproject.org> - 1.5.1-9
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_28_Mass_Rebuild
+
+* Wed Aug 02 2017 Fedora Release Engineering <releng@fedoraproject.org> - 1.5.1-8
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Binutils_Mass_Rebuild
+
+* Wed Jul 26 2017 Fedora Release Engineering <releng@fedoraproject.org> - 1.5.1-7
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Mass_Rebuild
+
+* Thu May  4 2017 Tomáš Mráz <tmraz@redhat.com> - 1.5.1-6
+- fix Y2038 problems in cron and anacron (#1445136)
+
+* Fri Feb 10 2017 Fedora Release Engineering <releng@fedoraproject.org> - 1.5.1-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_26_Mass_Rebuild
+
+* Tue Jan  3 2017 Tomáš Mráz <tmraz@redhat.com> - 1.5.1-4
+- make failure of creation of the ghost files in /var non-fatal
+
+* Mon Sep  5 2016 Tomáš Mráz <tmraz@redhat.com> - 1.5.1-3
+- on some machines the power supply is named ADP0
+
+* Tue Aug 23 2016 Tomáš Mráz <tmraz@redhat.com> - 1.5.1-2
+- query power status directly from kernel
+
+* Thu Jun 23 2016 Tomáš Mráz <tmraz@redhat.com> - 1.5.1-1
+- new upstream release
+
+* Wed Feb 03 2016 Fedora Release Engineering <releng@fedoraproject.org> - 1.5.0-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_24_Mass_Rebuild
+
+* Mon Jul 13 2015 Tomáš Mráz <tmraz@redhat.com> - 1.5.0-3
+- the temp file name used by crontab needs to be ignored by crond
+
+* Wed Jun 17 2015 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.5.0-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_23_Mass_Rebuild
+
+* Thu May 28 2015 Tomáš Mráz <tmraz@redhat.com> - 1.5.0-1
+- new upstream release
+
+* Tue Apr 21 2015 Tomáš Mráz <tmraz@redhat.com> - 1.4.12-6
+- mark the 0hourly and dailyjobs crontabs as config
+- do not add already existing orphan on reload
+
+* Tue Feb  3 2015 Tomáš Mráz <tmraz@redhat.com> - 1.4.12-5
+- correct the permissions of the anacron timestamp files
+
+* Fri Jan  2 2015 Tomáš Mráz <tmraz@redhat.com> - 1.4.12-4
+- check for NULL pamh on two more places (#1176215)
+
+* Tue Dec  2 2014 Tomáš Mráz <tmraz@redhat.com> - 1.4.12-3
+- call PAM only for non-root user or non-system crontabs (#956157)
+- bypass the PAM check in crontab for root (#1169175)
+
+* Tue Nov  4 2014 Tomáš Mráz <tmraz@redhat.com> - 1.4.12-2
+- refresh user entries when jobs are run
+
+* Wed Sep 17 2014 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.12-1
+- new release 1.4.12
+- remove gpl2 license, because it's part of upstream COPYING now
+
+* Sat Aug 16 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.4.11-9
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_21_22_Mass_Rebuild
+
+* Fri Jul 11 2014 Tom Callaway <spot@fedoraproject.org> - 1.4.11-8
+- fix license handling
+
+* Sat Jun 07 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.4.11-7
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_21_Mass_Rebuild
+
+* Wed Apr 30 2014 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.11-6
+- unwanted fd could make trouble to SElinux 1075106
+
+* Thu Jan 16 2014 Ville Skyttä <ville.skytta@iki.fi> - 1.4.11-5
+- Drop INSTALL from docs, fix rpmlint tabs vs spaces warning.
+
+* Wed Sep 25 2013 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.11-4
+- some jobs are not executed because not all environment variables are set 995590
+- cronie's systemd script use "KillMode=process" 919290
+
+* Sat Aug 03 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.4.11-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_20_Mass_Rebuild
+
+* Mon Jul 22 2013 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.11-2
+- scriptlets are not created correctly if systemd is not in BR 986698
+- remove sub-package sysvinit, which is not needed anymore
+- update license, anacron is under GPLv2+
+
+* Thu Jul 18 2013 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.11-1
+- new release 1.4.11 (contains previous bug fixes from 1.4.10-5)
+
+* Tue Jun 11 2013 Tomáš Mráz <tmraz@redhat.com> - 1.4.10-5
+- add support for RANDOM_DELAY - delaying job startups
+- pass some environment variables to processes (LANG, etc.) (#969761)
+- do not use putenv() with string literals (#971516)
+
+* Wed Feb 13 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.4.10-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_19_Mass_Rebuild
+
+* Wed Jan  2 2013 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.10-3
+- change configuration files to 644
+- change 6755 to 4755 for crontab binary
+
+* Tue Nov 27 2012 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.10-1
+- New release 1.4.10
+
+* Thu Nov 22 2012 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.9-1
+- New release 1.4.9
+
+* Wed Sep 05 2012 Václav Pavlín <vpavlin@redhat.com> - 1.4.8-13
+- Scriptlets replaced with new systemd macros (#850070)
+
+* Fri Jul 27 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.4.8-12
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_18_Mass_Rebuild
+
+* Fri Jan 13 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.4.8-11
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_17_Mass_Rebuild
+
+* Wed Oct 26 2011 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.4.8-10
+- Rebuilt for glibc bug#747377
+
+* Tue Oct 25 2011 Tomáš Mráz <tmraz@redhat.com> - 1.4.8-9
+- make crond run a little bit later in the boot process (#747759)
+
+* Mon Oct 17 2011 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.8-8
+- change triggerun to fix 735802 during upgrade
+
+* Wed Jul 27 2011 Karsten Hopp <karsten@redhat.com> 1.4.8-7
+- rebuild again, ppc still had the broken rpm in the buildroots
+
+* Thu Jul 21 2011 Rex Dieter <rdieter@fedoraproject.org> 1.4.8-6
+- rebuild (broken rpm in buildroot)
+
+* Thu Jul 21 2011 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.8-5
+- fix permission of init.d/crond
+
+* Thu Jun 30 2011 Tomáš Mráz <tmraz@redhat.com> - 1.4.8-4
+- drop the without systemd build condition
+- add the chkconfig readding trigger to the sysvinit subpackage
+
+* Wed Jun 29 2011 Tomáš Mráz <tmraz@redhat.com> - 1.4.8-3
+- start crond after auditd
+
+* Wed Jun 29 2011 Tomáš Mráz <tmraz@redhat.com> - 1.4.8-2
+- fix inotify support to not leak fds (#717505)
+
+* Tue Jun 28 2011 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.8-1
+- update to 1.4.8
+- create sub-package sysvinit for initscript
+
+* Mon May  9 2011 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.7-3
+- missing requirement on systemd-sysv for scriptlets
+
+* Thu May 05 2011 Tomáš Mráz <tmraz@redhat.com> - 1.4.7-2
+- use only systemd units with systemd
+- add trigger for restart on glibc, libselinux or pam upgrades (#699189)
+
+* Tue Mar 15 2011 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.7-1
+- new release 1.4.7
+
+* Tue Feb 08 2011 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.4.6-9
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_15_Mass_Rebuild
+
+* Mon Jan 17 2011 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.6-8
+- enable crond even with systemctl
+
+* Thu Dec 16 2010 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.6-7
+- 663193 rewritten selinux support
+
+* Wed Dec 15 2010 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.6-6
+- apply selinux patch from dwalsh
+
+* Fri Dec 10 2010 Tomas Mraz <tmraz@redhat.com> - 1.4.6-5
+- do not lock jobs that fall out of allowed range - 661966
+
+* Thu Dec 02 2010 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.6-4
+- fix post (thanks plautrba for review)
+
+* Tue Nov 30 2010 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.6-3
+- systemd init script 617320
+
+* Tue Nov 30 2010 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.6-2
+- fix typos in man pages
+
+* Fri Oct 22 2010 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.6-1
+- update to 1.4.6
+
+* Fri Aug 13 2010 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.5-4
+- 623908 fix fd leak in anacron, which caused denail of prelink
+  and others
+
+* Mon Aug  9 2010 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.5-2
+- remove sendmail from requirements. If it's not installed, it will
+ log into (r)syslog.
+
+* Mon Aug  2 2010 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.5-1
+- update to new release
+
+* Fri Feb 19 2010 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.4-1
+- update to new release
+
+* Mon Feb 15 2010 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.3-3
+- 564894 FTBFS DSOLinking
+
+* Thu Nov  5 2009 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.3-2
+- 533189 pam needs add a line and selinux needs defined one function
+
+* Fri Oct 30 2009 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.3-1
+- 531963 and 532482 creating noanacron package
+
+* Mon Oct 19 2009 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.2-2
+- 529632 service crond stop returns appropriate value
+
+* Mon Oct 12 2009 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.2-1
+- new release
+
+* Fri Aug 21 2009 Tomas Mraz <tmraz@redhat.com> - 1.4.1-3
+- rebuilt with new audit
+
+* Fri Aug 14 2009 Tomas Mraz <tmraz@redhat.com> - 1.4.1-2
+- create the anacron timestamps in correct post script
+
+* Fri Aug 14 2009 Marcela Mašláňová <mmaslano@redhat.com> - 1.4.1-1
+- update to 1.4.1
+- create and own /var/spool/anacron/cron.{daily,weekly,monthly} to
+ remove false warning about non existent files
+- Resolves: 517398
+
+* Wed Aug  5 2009 Tomas Mraz <tmraz@redhat.com> - 1.4-4
+- 515762 move anacron provides and obsoletes to the anacron subpackage
+
+* Fri Jul 24 2009 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.4-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_12_Mass_Rebuild
+
+* Mon Jul 20 2009 Marcela Mašláňová <mmaslano@redhat.com> - 1.4-2
+- merge cronie and anacron in new release of cronie
+- obsolete/provide anacron in spec
+
+* Thu Jun 18 2009 Marcela Mašláňová <mmaslano@redhat.com> - 1.3-2
+- 506560 check return value of access
+
+* Mon Apr 27 2009 Marcela Mašláňová <mmaslano@redhat.com> - 1.3-1
+- new release
+
+* Fri Apr 24 2009 Marcela Mašláňová <mmaslano@redhat.com> - 1.2-8
+- 496973 close file descriptors after exec
+
+* Mon Mar  9 2009 Tomas Mraz <tmraz@redhat.com> - 1.2-7
+- rebuild
+
+* Tue Feb 24 2009 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 1.2-6
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_11_Mass_Rebuild
+
+* Tue Dec 23 2008 Marcela Mašláňová <mmaslano@redhat.com> - 1.2-5
+- 477100 NO_FOLLOW was removed, reload after change in symlinked
+  crontab is needed, man updated.
+
+* Fri Oct 24 2008 Marcela Mašláňová <mmaslano@redhat.com> - 1.2-4
+- update init script
+
+* Thu Sep 25 2008 Marcela Maslanova <mmaslano@redhat.com> - 1.2-3
+- add sendmail file into requirement, cause it's needed some MTA
+
+* Thu Sep 18 2008 Marcela Maslanova <mmaslano@redhat.com> - 1.2-2
+- 462252  /etc/sysconfig/crond does not need to be executable
+
+* Thu Jun 26 2008 Marcela Maslanova <mmaslano@redhat.com> - 1.2-1
+- update to 1.2
+
+* Tue Jun 17 2008 Tomas Mraz <tmraz@redhat.com> - 1.1-3
+- fix setting keycreate context
+- unify logging a bit
+- cleanup some warnings and fix a typo in TZ code
+- 450993 improve and fix inotify support
+
+* Wed Jun  4 2008 Marcela Maslanova <mmaslano@redhat.com> - 1.1-2
+- 49864 upgrade/update problem. Syntax error in spec.
+
+* Wed May 28 2008 Marcela Maslanova <mmaslano@redhat.com> - 1.1-1
+- release 1.1
+
+* Tue May 20 2008 Marcela Maslanova <mmaslano@redhat.com> - 1.0-6
+- 446360 check for lock didn't call chkconfig
+
+* Tue Feb 12 2008 Marcela Maslanova <mmaslano@redhat.com> - 1.0-5
+- upgrade from less than cronie-1.0-4 didn't add chkconfig
+
+* Wed Feb  6 2008 Marcela Maslanova <mmaslano@redhat.com> - 1.0-4
+- 431366 after reboot wasn't cron in chkconfig
+
+* Tue Feb  5 2008 Marcela Maslanova <mmaslano@redhat.com> - 1.0-3
+- 431366 trigger part => after update from vixie-cron on cronie will
+  be daemon running.
+
+* Wed Jan 30 2008 Marcela Maslanova <mmaslano@redhat.com> - 1.0-2
+- change the provides on higher version than obsoletes
+
+* Tue Jan  8 2008 Marcela Maslanova <mmaslano@redhat.com> - 1.0-1
+- packaging cronie
+- thank's for help with packaging to my reviewers

--- a/tests/integration/test_source_git_generator.py
+++ b/tests/integration/test_source_git_generator.py
@@ -196,3 +196,24 @@ def test_create_srcgit_requre_populated(api_instance_source_git, tmp_path: Path)
     srpm_path = list(source_git_path.glob("python-requre-0.4.0-2.*.src.rpm"))[0]
     assert srpm_path.is_file()
     # requre needs sphinx, so SRPM is fine
+
+
+@pytest.mark.slow
+def test_centos_cronie(api_instance_source_git, tmp_path: Path):
+    source_git_path = tmp_path.joinpath("cronie-sg")
+    # create src-git
+    source_git_path.mkdir()
+    create_new_repo(source_git_path, [])
+    sgg = SourceGitGenerator(
+        LocalProject(working_dir=source_git_path),
+        api_instance_source_git.config,
+        "https://github.com/cronie-crond/cronie",
+        upstream_ref="cronie-1.5.2",
+        centos_package="cronie",
+    )
+    sgg.create_from_upstream()
+
+    # verify it
+    subprocess.check_call(["packit", "srpm"], cwd=source_git_path)
+    srpm_path = list(source_git_path.glob("cronie-1.5.2-*.src.rpm"))[0]
+    assert srpm_path.is_file()

--- a/tests/spellbook.py
+++ b/tests/spellbook.py
@@ -27,6 +27,7 @@ A book with our finest spells
 import shutil
 import subprocess
 from pathlib import Path
+from typing import Optional
 
 from click.testing import CliRunner
 from packit.patches import PatchMetadata
@@ -57,6 +58,7 @@ DG_OGR = DATA_DIR / "dg-ogr"
 SPECFILE = DATA_DIR / "upstream_git/beer.spec"
 UPSTREAM_SPEC_NOT_IN_ROOT = DATA_DIR / "spec_not_in_root/upstream"
 SYNC_FILES = DATA_DIR / "sync_files"
+CRONIE = DATA_DIR / "cronie"
 
 
 def git_set_user_email(directory):
@@ -87,8 +89,10 @@ def initiate_git_repo(
     tag=None,
     upstream_remote="https://lol.wat",
     push=False,
-    copy_from: str = None,
+    copy_from: Optional[Path] = None,
     remotes=None,
+    empty_commits_count: int = 3,
+    add_initial_content: bool = True,
 ):
     """
     Initiate a git repo for testing.
@@ -107,15 +111,16 @@ def initiate_git_repo(
         shutil.copytree(copy_from, directory)
     create_new_repo(directory, [])
     git_set_user_email(directory)
-    for i in range(3):
+    for i in range(empty_commits_count):
         subprocess.check_call(
             ["git", "commit", "--allow-empty", "-m", f"empty commit #{i}"],
             cwd=directory,
         )
-    directory_path = Path(directory)
-    directory_path.joinpath("README").write_text("Best upstream project ever!")
-    # this file is in the tarball
-    directory_path.joinpath("hops").write_text("Cascade\n")
+    if add_initial_content:
+        directory_path = Path(directory)
+        directory_path.joinpath("README").write_text("Best upstream project ever!")
+        # this file is in the tarball
+        directory_path.joinpath("hops").write_text("Cascade\n")
     subprocess.check_call(["git", "add", "."], cwd=directory)
     subprocess.check_call(["git", "commit", "-m", "commit with data"], cwd=directory)
     if tag:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,7 +9,7 @@ from packit.config import Config
 from packit.distgit import DistGit
 from packit.local_project import LocalProject
 from packit.upstream import Upstream
-from tests.spellbook import get_test_config
+from tests.spellbook import get_test_config, CRONIE, initiate_git_repo
 
 
 @pytest.fixture
@@ -135,3 +135,21 @@ def distgit_mock(local_project_mock, config_mock, package_config_mock):
     distgit.should_receive("push")
     distgit.should_receive("absolute_specfile_dir").and_return(Path("/mock_path"))
     return distgit
+
+
+@pytest.fixture
+def cronie(tmp_path: Path):
+    """ c8s dist-git repo with cronie """
+    remote_url = "https://git.centos.org/rpms/cronie"
+    d = tmp_path / "cronie"
+    initiate_git_repo(
+        d,
+        copy_from=CRONIE,
+        push=False,
+        remotes=[
+            ("origin", remote_url),
+        ],
+        empty_commits_count=0,
+        add_initial_content=False,
+    )
+    return d

--- a/tests/unit/test_source_git_generator.py
+++ b/tests/unit/test_source_git_generator.py
@@ -1,0 +1,39 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+from pathlib import Path
+
+from flexmock import flexmock
+
+from packit.config import Config
+from packit.distgit import DistGit
+from packit.local_project import LocalProject
+from packit.source_git import SourceGitGenerator, CentOSDistGit
+from packit.utils.repo import create_new_repo
+
+
+def test_centos_conf(cronie, tmp_path: Path):
+    """ make sure the centos-specific configuration is correct """
+    source_git_path = tmp_path.joinpath("cronie-sg")
+    # create src-git
+    source_git_path.mkdir()
+    create_new_repo(source_git_path, [])
+    sgg = SourceGitGenerator(
+        LocalProject(working_dir=source_git_path),
+        Config(),
+        dist_git_path=cronie,
+        upstream_ref="cronie-1.5.2",
+        centos_package="cronie",
+    )
+
+    dg = sgg.dist_git
+    assert isinstance(dg, CentOSDistGit)
+
+    flexmock(
+        DistGit,
+        download_upstream_archive=lambda: cronie / "SOURCES" / "cronie-1.5.2.tar.gz",
+    )
+    assert sgg.primary_archive == cronie / "SOURCES" / "cronie-1.5.2.tar.gz"
+
+    assert dg.absolute_source_dir == cronie / "SOURCES"
+    assert dg.absolute_specfile_dir == cronie / "SPECS"
+    assert dg.absolute_specfile_path == cronie / "SPECS" / "cronie.spec"


### PR DESCRIPTION
```
init: correctly pick up sources from CentOS

though we are not using the official get_sources.sh script (to not add
such a weird dependency to the functionality), instead we download the
archive from the internet - Source0

same drill as the previous commit, except this is for sources
```

```
init: correctly fetch spec from centos dist-git

the former code was a mess, this commit makes it clear:

 * there is a spec_dir_name class variable which says in which dir the
   spec is stored: fedora = "", centos = "SPECS"

 * the variable is now used in dist_git.absolute_spec_path
```

Fixes #1104 