### PR TITLE
Don't use setuptools option.data_files to install bash-completion

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -62,9 +62,8 @@ rm -rf %{pypi_name}.egg-info
 %py3_install
 python3 setup.py --command-packages=click_man.commands man_pages --target %{buildroot}%{_mandir}/man1
 
-# FIXME: workaround for setuptools installing it into bash_completion/ instead of bash-completion/
 install -d -m 755 %{buildroot}%{_datadir}/bash-completion/completions
-mv %{buildroot}%{_datadir}/bash_completion/completions/packit %{buildroot}%{_datadir}/bash-completion/completions/packit
+cp files/bash-completion/packit %{buildroot}%{_datadir}/bash-completion/completions/packit
 
 %files
 %license LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,5 +75,6 @@ testing =
 exclude =
     tests*
 
-[options.data_files]
-share/bash-completion/completions/ = files/bash-completion/packit
+# needs setuptools >= 40.6.0
+# [options.data_files]
+# share/bash-completion/completions/ = files/bash-completion/packit


### PR DESCRIPTION
- it [requires setuptools >= 40.6.0](https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html#options) (rhel/centos/epel-8 has 39.2.0)
- it installs it into bash_completion/ while we (epel/fedora) need bash-completion/