### PR TITLE
Treat the highest pending version in Bodhi as "rawhide"

### DIFF
--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -234,7 +234,6 @@ def get_aliases() -> Dict[str, List[str]]:
 
         if release.id_prefix == "FEDORA" and release.name != "ELN":
             name = release.long_name.lower().replace(" ", "-")
-            aliases["fedora-all"].append(name)
             if release.state == "current":
                 aliases["fedora-stable"].append(name)
             elif release.state == "pending":
@@ -244,7 +243,12 @@ def get_aliases() -> Dict[str, List[str]]:
             name = release.name.lower()
             aliases["epel-all"].append(name)
 
-    aliases["fedora-all"].append("fedora-rawhide")
-    aliases["fedora-development"].append("fedora-rawhide")
+    if aliases.get("fedora-development"):
+        aliases["fedora-development"].sort(key=lambda x: int(x.rsplit("-")[-1]))
+        # The Fedora with the highest version is "rawhide", but
+        # Bodhi always uses release names, and has no concept of "rawhide".
+        aliases["fedora-development"][-1] = "fedora-rawhide"
+
+    aliases["fedora-all"] = aliases["fedora-development"] + aliases["fedora-stable"]
 
     return aliases

--- a/tests/unit/test_config_aliases.py
+++ b/tests/unit/test_config_aliases.py
@@ -247,14 +247,23 @@ class TestGetAliases:
         [
             pytest.param(
                 [
-                    ("F31", "Fedora 31", "FEDORA", "current"),
+                    ("F30", "Fedora 30", "FEDORA", "archived"),
+                    ("F31", "Fedora 31", "FEDORA", "archived"),
+                    ("F32", "Fedora 32", "FEDORA", "current"),
+                    ("F33", "Fedora 33", "FEDORA", "current"),
                     ("F34", "Fedora 34", "FEDORA", "pending"),
+                    ("F35", "Fedora 35", "FEDORA", "pending"),
                     ("F31F", "Fedora 31 Flatpaks", "FEDORA-FLATPAK", "current"),
                     ("EPEL-8", "Fedora EPEL 8", "FEDORA-EPEL", "current"),
                 ],
                 {
-                    "fedora-all": ["fedora-31", "fedora-34", "fedora-rawhide"],
-                    "fedora-stable": ["fedora-31"],
+                    "fedora-all": [
+                        "fedora-32",
+                        "fedora-33",
+                        "fedora-34",
+                        "fedora-rawhide",
+                    ],
+                    "fedora-stable": ["fedora-32", "fedora-33"],
                     "fedora-development": ["fedora-34", "fedora-rawhide"],
                     "epel-all": ["epel-8"],
                 },


### PR DESCRIPTION
It turns out Bodhi has no concept of "rawhide". Which kinda makes sense,
as "rawhide" is a stream not a release. So Bodhi always display the
Fedora version "rawhide" is going to become in the `/releases` API
endpoint.

For example: before Fedora 34 was branched in dist-git, Bodhi showed
rawhide as Fedora 34 in "Pending releases". After the branching was
done, "Pending releases" had Fedora 34 and Fedora 35 listed.

Tweak the `get_aliases()` code to take this into the consideration.

Fixes packit/packit-service#900.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>