### PR TITLE
Install requre from PyPI & rpm instead of git

### DIFF
--- a/files/zuul-install-requirements-git.yaml
+++ b/files/zuul-install-requirements-git.yaml
@@ -1,9 +1,9 @@
 ---
-- name: pip install packit deps with ogr & requre
+- name: Install ogr & sandcastle & requre from git
   hosts: all
   tasks:
     - include_tasks: tasks/generic-dnf-requirements.yaml
     - include_tasks: tasks/python-compile-deps.yaml
     - include_tasks: tasks/ogr.yaml
-    - include_tasks: tasks/requre.yaml
     - include_tasks: tasks/sandcastle.yaml
+    - include_tasks: tasks/requre.yaml

--- a/files/zuul-install-requirements-pip.yaml
+++ b/files/zuul-install-requirements-pip.yaml
@@ -4,7 +4,6 @@
   tasks:
     - include_tasks: tasks/generic-dnf-requirements.yaml
     - include_tasks: tasks/python-compile-deps.yaml
-    - include_tasks: tasks/requre.yaml
     - name: Install deps from PyPI
       pip:
         name: "{{ item }}"
@@ -12,4 +11,5 @@
         - ogr
         - rebasehelper
         - sandcastle
+        - requre
       become: true

--- a/files/zuul-install-requirements-rpms.yaml
+++ b/files/zuul-install-requirements-rpms.yaml
@@ -1,7 +1,10 @@
 ---
-- name: Install RPM dependencies for packit.
+- name: Install RPM dependencies for packit
   hosts: all
   tasks:
     - include_tasks: tasks/generic-dnf-requirements.yaml
     - include_tasks: tasks/build-rpm-deps.yaml
-    - include_tasks: tasks/requre.yaml
+    - name: Install python3-requre rpm
+      dnf:
+        name: python3-requre
+      become: true


### PR DESCRIPTION
[tasks/requre.yaml installs requre from git](https://github.com/packit/packit/blob/main/files/tasks/requre.yaml) which is IMO not what we want in [zuul-install-requirements-rpms.yaml](https://github.com/packit/packit/blob/main/files/zuul-install-requirements-rpms.yaml) & [zuul-install-requirements-pip.yaml](https://github.com/packit/packit/blob/main/files/zuul-install-requirements-pip.yaml)