### PR TITLE
Unify log format for all log levels

### DIFF
--- a/packit/utils/logging.py
+++ b/packit/utils/logging.py
@@ -49,7 +49,7 @@ def set_logging(
     level=logging.INFO,
     handler_class=logging.StreamHandler,
     handler_kwargs=None,
-    date_format="%H:%M:%S",
+    date_format=None,
 ):
     """
     Set personal logger for this library.

--- a/packit/utils/logging.py
+++ b/packit/utils/logging.py
@@ -30,16 +30,18 @@ class StreamLogger(threading.Thread):
 
 
 class PackitFormatter(logging.Formatter):
-    def format(self, record):
-        if record.levelno == logging.INFO:
-            self._style._fmt = "%(message)s"
-        elif record.levelno > logging.INFO:
-            self._style._fmt = "%(levelname)-8s %(message)s"
-        else:  # debug
-            self._style._fmt = (
-                "%(asctime)s.%(msecs).03d %(filename)-17s %(levelname)-6s %(message)s"
-            )
-        return logging.Formatter.format(self, record)
+    def __init__(
+        self,
+        fmt=None,
+        datefmt=None,
+        *args,
+    ):
+        fmt = (
+            fmt
+            or "%(asctime)s.%(msecs).03d %(filename)-17s %(levelname)-6s %(message)s"
+        )
+        datefmt = datefmt or "%Y-%m-%d %H:%M:%S"
+        super().__init__(fmt, datefmt, *args)
 
 
 def set_logging(

--- a/tests/functional/test_srpm.py
+++ b/tests/functional/test_srpm.py
@@ -71,7 +71,8 @@ def test_action_output(upstream_and_remote):
     out = call_real_packit(
         parameters=["srpm"], cwd=upstream_repo_path, return_output=True
     )
-    assert f"\n{the_line_we_want}\n" in out.decode()
+
+    assert f"INFO   {the_line_we_want}\n" in out.decode()
     srpm_path = list(upstream_repo_path.glob("*.src.rpm"))[0]
     assert srpm_path.exists()
     build_srpm(srpm_path)
@@ -150,7 +151,7 @@ def _test_srpm_symlinking(upstream_repo_path, path_prefix):
     out = call_real_packit(
         parameters=["srpm"], cwd=upstream_repo_path, return_output=True
     )
-    assert f"\n{desired_path}\n" in out.decode()
+    assert f"INFO   {desired_path}\n" in out.decode()
 
     srpm_path = list(upstream_repo_path.glob("*.src.rpm"))[0]
     assert srpm_path.exists()


### PR DESCRIPTION
Previously several formats of log messages were used - format of certain log record was determined by its log-level.
To make logs more consistent, only one log format is used now.

In order to improve informative value of logs, date part was added to default log timestamp format. 