### PR TITLE
Fix Koji tag in create-update for EPEL

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -398,7 +398,9 @@ class DistGit(PackitRepositoryBase):
                 f"{self.package_config.downstream_package_name!r}: \n{builds_str}"
             )
 
-            koji_tag = f"{dist_git_branch}-updates-candidate"
+            # EPEL uses "testing-candidate" instead of "updates-candidate"
+            prefix = "testing" if dist_git_branch.startswith("epel") else "updates"
+            koji_tag = f"{dist_git_branch}-{prefix}-candidate"
             try:
                 koji_builds = [builds_d[koji_tag]]
                 koji_builds_str = "\n".join(f" - {b}" for b in koji_builds)


### PR DESCRIPTION
When creating update against EPEL, Koji tag is epel*-testing-candidate
as opposed to the f*-updates-candidate for Fedora.

Signed-off-by: Matej Focko <mfocko@redhat.com>