### PR TITLE
command_handler: run all actions in a single sandbox

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -874,8 +874,11 @@ class PackitAPI:
 
     def clean(self):
         """ clean up stuff once all the work is done """
-        # command handlers have nothing to clean
-        logger.debug("PackitAPI.cleanup (there are no objects to clean)")
+        # this is called in p-s: Handler.clean
+        if self.up.is_command_handler_set():
+            self.up.command_handler.clean()
+        if self.dg.is_command_handler_set():
+            self.dg.command_handler.clean()
 
     @staticmethod
     def validate_package_config(working_dir: Path) -> str:

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -81,6 +81,10 @@ class PackitRepositoryBase:
             )
         return self._command_handler
 
+    def is_command_handler_set(self) -> bool:
+        """ return True when command_handler is initialized """
+        return bool(self._command_handler)
+
     def running_in_service(self) -> bool:
         """ are we running in packit service? """
         return self.command_handler.name == RunCommandType.sandcastle


### PR DESCRIPTION
https://issues.redhat.com/browse/PACKIT-1133

needs: https://github.com/packit/sandcastle/pull/93

https://blog.tomecek.net/post/automake-in-openshift/

Running actions in separate sandboxes is wasting resources (time,
compute, storage, memory) for no benefit - actually, changes in files
can result into breakages in further actions since absolute paths would
stop working because the "unique" path within the sandbox would no
longer be valid.

This should also result in a speed-up of SRPM builds since we'll no
longer need to re-create the sandbox pods.

Another benefit: less "exceeded timebound quota" errors because we'll be
creating less sandbox pods.