### PR TITLE
Support sources in configuration

### DIFF
--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -31,6 +31,7 @@ from packit.config.notifications import (
     NotificationsConfig,
     PullRequestNotificationsConfig,
 )
+from packit.config.sources import SourcesItem
 from packit.config.sync_files_config import SyncFilesConfig
 from packit.constants import PROD_DISTGIT_URL
 from packit.sync import SyncFilesItem
@@ -73,6 +74,7 @@ class CommonPackageConfig:
         patch_generation_ignore_paths: List[str] = None,
         notifications: Optional[NotificationsConfig] = None,
         copy_upstream_release_description: bool = False,
+        sources: Optional[List[SourcesItem]] = None,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -108,6 +110,7 @@ class CommonPackageConfig:
         self.upstream_tag_template = upstream_tag_template
         self.archive_root_dir_template = archive_root_dir_template
         self.copy_upstream_release_description = copy_upstream_release_description
+        self.sources = sources or []
 
     def __repr__(self):
         return (
@@ -130,7 +133,8 @@ class CommonPackageConfig:
             f"spec_source_id='{self.spec_source_id}', "
             f"upstream_tag_template='{self.upstream_tag_template}', "
             f"patch_generation_ignore_paths='{self.patch_generation_ignore_paths}',"
-            f"copy_upstream_release_description='{self.copy_upstream_release_description}')"
+            f"copy_upstream_release_description='{self.copy_upstream_release_description}',"
+            f"sources='{self.sources}')"
         )
 
     @property

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -28,6 +28,7 @@ from typing import List, Set, Dict, Optional, Union
 from packit.actions import ActionName
 from packit.config.common_package_config import CommonPackageConfig
 from packit.config.notifications import NotificationsConfig
+from packit.config.sources import SourcesItem
 from packit.config.sync_files_config import SyncFilesConfig
 from packit.exceptions import PackitConfigException
 
@@ -164,6 +165,7 @@ class JobConfig(CommonPackageConfig):
         patch_generation_ignore_paths: List[str] = None,
         notifications: Optional[NotificationsConfig] = None,
         copy_upstream_release_description: bool = False,
+        sources: Optional[List[SourcesItem]] = None,
     ):
         super().__init__(
             config_file_path=config_file_path,
@@ -188,6 +190,7 @@ class JobConfig(CommonPackageConfig):
             patch_generation_ignore_paths=patch_generation_ignore_paths,
             notifications=notifications,
             copy_upstream_release_description=copy_upstream_release_description,
+            sources=sources,
         )
         self.type: JobType = type
         self.trigger: JobConfigTriggerType = trigger
@@ -215,7 +218,8 @@ class JobConfig(CommonPackageConfig):
             f"spec_source_id='{self.spec_source_id}', "
             f"upstream_tag_template='{self.upstream_tag_template}', "
             f"patch_generation_ignore_paths='{self.patch_generation_ignore_paths}',"
-            f"copy_upstream_release_description='{self.copy_upstream_release_description}')"
+            f"copy_upstream_release_description='{self.copy_upstream_release_description}',"
+            f"sources='{self.sources}')"
         )
 
     @classmethod
@@ -253,6 +257,7 @@ class JobConfig(CommonPackageConfig):
             and self.upstream_tag_template == other.upstream_tag_template
             and self.copy_upstream_release_description
             == other.copy_upstream_release_description
+            and self.sources == other.sources
         )
 
 

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -32,6 +32,7 @@ from packit.actions import ActionName
 from packit.config.common_package_config import CommonPackageConfig
 from packit.config.job_config import JobConfig, get_default_jobs, JobType
 from packit.config.notifications import NotificationsConfig
+from packit.config.sources import SourcesItem
 from packit.config.sync_files_config import SyncFilesConfig
 from packit.constants import CONFIG_FILE_NAMES
 from packit.exceptions import PackitConfigException
@@ -70,6 +71,7 @@ class PackageConfig(CommonPackageConfig):
         patch_generation_ignore_paths: List[str] = None,
         notifications: Optional[NotificationsConfig] = None,
         copy_upstream_release_description: bool = False,
+        sources: Optional[List[SourcesItem]] = None,
     ):
         super().__init__(
             config_file_path=config_file_path,
@@ -94,6 +96,7 @@ class PackageConfig(CommonPackageConfig):
             patch_generation_ignore_paths=patch_generation_ignore_paths,
             notifications=notifications,
             copy_upstream_release_description=copy_upstream_release_description,
+            sources=sources,
         )
         self.jobs: List[JobConfig] = jobs or []
 
@@ -121,7 +124,8 @@ class PackageConfig(CommonPackageConfig):
             f"upstream_tag_template='{self.upstream_tag_template}', "
             f"archive_root_dir_template={self.archive_root_dir_template}', "
             f"patch_generation_ignore_paths='{self.patch_generation_ignore_paths}', "
-            f"copy_upstream_release_description='{self.copy_upstream_release_description}')"
+            f"copy_upstream_release_description='{self.copy_upstream_release_description}',"
+            f"sources='{self.sources}')"
         )
 
     @classmethod
@@ -210,6 +214,7 @@ class PackageConfig(CommonPackageConfig):
             and self.upstream_tag_template == other.upstream_tag_template
             and self.copy_upstream_release_description
             == other.copy_upstream_release_description
+            and self.sources == other.sources
         )
 
 

--- a/packit/config/sources.py
+++ b/packit/config/sources.py
@@ -1,0 +1,18 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+from typing import NamedTuple
+
+
+class SourcesItem(NamedTuple):
+    path: str
+    url: str
+
+    def __repr__(self):
+        return f"SourcesItem(path={self.path}, url={self.url})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SourcesItem):
+            raise NotImplementedError()
+
+        return self.path == other.path and self.url == other.url

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -302,7 +302,7 @@ class DistGit(PackitRepositoryBase):
         :return: str, path to the archive
         """
         with cwd(self.local_project.working_dir):
-            self.specfile.download_remote_sources()
+            self.download_remote_sources()
         archive = self.absolute_source_dir / self.upstream_archive_name
         if not archive.exists():
             raise PackitException(

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -36,6 +36,7 @@ from packit.config.job_config import (
 )
 from packit.config.package_config import NotificationsConfig
 from packit.config.notifications import PullRequestNotificationsConfig
+from packit.config.sources import SourcesItem
 from packit.sync import SyncFilesItem
 
 logger = getLogger(__name__)
@@ -131,6 +132,19 @@ class NotProcessedField(fields.Field):
         additional_message = self.metadata.get("additional_message")
         if additional_message:
             logger.warning(f"{additional_message}")
+
+
+class SourceSchema(Schema):
+    """
+    Schema for sources.
+    """
+
+    path = fields.String(required=True)
+    url = fields.String(required=True)
+
+    @post_load
+    def make_instance(self, data, **_):
+        return SourcesItem(**data)
 
 
 class PullRequestNotificationsSchema(Schema):
@@ -247,6 +261,7 @@ class CommonConfigSchema(Schema):
     patch_generation_ignore_paths = fields.List(fields.String(), missing=None)
     notifications = fields.Nested(NotificationsSchema)
     copy_upstream_release_description = fields.Bool(default=False)
+    sources = fields.List(fields.Nested(SourceSchema), missing=None)
 
     # For backwards compatibility with packit-service. Should be removed once
     # packit-service uses dump method.

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -704,9 +704,7 @@ class Upstream(PackitRepositoryBase):
             )
             logger.warning("Therefore skipping downloading of remote sources.")
         else:
-            # > Method that iterates over all sources and downloads ones,
-            # > which contain URL instead of just a file.
-            self.specfile.download_remote_sources()
+            self.download_remote_sources()
 
     def fix_specfile_to_use_local_archive(self, archive, archive_version) -> None:
         """

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,12 +36,12 @@ from ogr.services.github import GithubService, GithubProject
 from ogr.services.pagure import PagureProject, PagureService, PagureUser
 
 from packit.api import PackitAPI
+from packit.base_git import PackitRepositoryBase
 from packit.cli.utils import get_packit_api
 from packit.config import get_local_package_config
 from packit.distgit import DistGit
 from packit.fedpkg import FedPKG
 from packit.local_project import LocalProject
-from packit.specfile import Specfile
 from packit.upstream import Upstream
 from packit.utils.commands import cwd
 from packit.utils.repo import create_new_repo
@@ -116,7 +116,7 @@ def mock_spec_download_remote_s(
         ]
         subprocess.check_call(archive_cmd, cwd=repo_path)
 
-    flexmock(Specfile, download_remote_sources=mock_download_remote_sources)
+    flexmock(PackitRepositoryBase, download_remote_sources=mock_download_remote_sources)
 
 
 def mock_remote_functionality(distgit: Path, upstream: Path):

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -42,6 +42,7 @@ from packit.config.package_config import (
     PackageConfig,
     get_local_specfile_path,
 )
+from packit.config.sources import SourcesItem
 from packit.schema import PackageConfigSchema
 from packit.sync import SyncFilesItem
 from tests.spellbook import UP_OSBUILD, SYNC_FILES
@@ -408,6 +409,27 @@ def test_package_config_not_equal(not_equal_package_config):
             {
                 "specfile_path": "fedora/package.spec",
                 "notifications": {"pull_request": False},
+            },
+            False,
+        ),
+        (
+            {
+                "specfile_path": "fedora/package.spec",
+                "sources": [{"path": "example_path"}],
+            },
+            False,
+        ),
+        (
+            {
+                "specfile_path": "fedora/package.spec",
+                "sources": [{"url": "example_url"}],
+            },
+            False,
+        ),
+        (
+            {
+                "specfile_path": "fedora/package.spec",
+                "sources": {"path": "example_path", "url": "example_url"},
             },
             False,
         ),
@@ -784,6 +806,29 @@ def test_package_config_parse_error(raw):
                 ],
             ),
             id="sync_changelog_false_by_default",
+        ),
+        pytest.param(
+            {
+                "specfile_path": "fedora/package.spec",
+                "sources": [
+                    {
+                        "path": "rsync-3.1.3.tar.gz",
+                        "url": "https://git.centos.org/sources/rsync/c8s/82e7829",
+                    }
+                ],
+                "jobs": [],
+            },
+            PackageConfig(
+                specfile_path="fedora/package.spec",
+                sources=[
+                    SourcesItem(
+                        path="rsync-3.1.3.tar.gz",
+                        url="https://git.centos.org/sources/rsync/c8s/82e7829",
+                    ),
+                ],
+                jobs=[],
+            ),
+            id="sources",
         ),
     ],
 )
@@ -1170,6 +1215,25 @@ def test_get_local_specfile_path():
             dist_git_base_url="https://something.wicked",
             downstream_package_name="package",
             spec_source_id="Source1",
+        ),
+        PackageConfig(
+            specfile_path="fedora/package.spec",
+            actions={
+                ActionName.pre_sync: "some/pre-sync/command --option",
+                ActionName.get_current_version: "get-me-version",
+            },
+            jobs=[],
+            upstream_project_url="https://github.com/asd/qwe",
+            upstream_package_name="qwe",
+            dist_git_base_url="https://something.wicked",
+            downstream_package_name="package",
+            spec_source_id="Source1",
+            sources=[
+                SourcesItem(
+                    path="rsync-3.1.3.tar.gz",
+                    url="https://git.centos.org/sources/rsync/c8s/82e7829",
+                ),
+            ],
         ),
     ],
 )


### PR DESCRIPTION
Closes #1105 

For `download_remote_sources` I extended [the code](https://github.com/rebase-helper/rebase-helper/blob/0be4d04b195d46f3880107e7f6b7e888733f59c5/rebasehelper/specfile.py#L144) from rebase-helper with getting the URL from config and using it if present.

The issue says that the `path` for sources in config should be relative to the config, but wouldn't be better to have there the path in the sources dir, since we have the `absolute_source_dir` property and also rebase-helper works with it?
