### PR TITLE
propose-downstream: Detect identical patches

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,9 @@ repos:
       - id: detect-private-key
         exclude: tests/integration/conftest.py
       - id: end-of-file-fixer
+        exclude: tests/data/patches
       - id: trailing-whitespace
+        exclude: tests/data/patches
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.8.4
     hooks:

--- a/packit/api.py
+++ b/packit/api.py
@@ -53,6 +53,7 @@ from packit.exceptions import (
     PackitCoprException,
 )
 from packit.local_project import LocalProject
+from packit.patches import PatchGenerator
 from packit.source_git import SourceGitGenerator
 from packit.status import Status
 from packit.sync import RawSyncFilesItem, sync_files
@@ -261,6 +262,9 @@ class PackitAPI:
                     patches = self.up.create_patches(
                         upstream=upstream_ref,
                         destination=str(self.dg.absolute_specfile_dir),
+                    )
+                    patches = PatchGenerator.undo_identical(
+                        patches, self.dg.local_project.git_repo
                     )
                     self.dg.specfile_add_patches(patches)
                 self._handle_sources(

--- a/tests/data/patches/previous/git-diff.patch
+++ b/tests/data/patches/previous/git-diff.patch
@@ -1,0 +1,93 @@
+Short description: fnmatch() fails with MBCS.
+Author(s): Fedora glibc team <glibc@lists.fedoraproject.org>
+Origin: PATCH
+Bug-RHEL: #819430, #826149, #826151
+Bug-Upstream: #14185
+Upstream status: not-submitted
+
+fnmatch() fails when '*' wildcard is applied on the file name
+containing multi-byte character(s)
+
+This needs to be reviewed thoroughly and go upstream with a
+new test case.
+
+
+diff --git a/posix/fnmatch.c b/posix/fnmatch.c
+index 5896812c966ac7c6..63df3dae0911030f 100644
+--- a/posix/fnmatch.c
++++ b/posix/fnmatch.c
+@@ -237,6 +237,7 @@ fnmatch (const char *pattern, const char *string, int flags)
+ {
+   if (__glibc_unlikely (MB_CUR_MAX != 1))
+     {
++      const char *orig_pattern = pattern;
+       mbstate_t ps;
+       size_t n;
+       const char *p;
+@@ -256,10 +257,8 @@ fnmatch (const char *pattern, const char *string, int flags)
+                                                  alloca_used);
+           n = mbsrtowcs (wpattern, &p, n + 1, &ps);
+           if (__glibc_unlikely (n == (size_t) -1))
+-            /* Something wrong.
+-               XXX Do we have to set 'errno' to something which mbsrtows hasn't
+-               already done?  */
+-            return -1;
++	    /* Something wrong: Fall back to single byte matching.  */
++	    goto try_singlebyte;
+           if (p)
+             {
+               memset (&ps, '\0', sizeof (ps));
+@@ -271,10 +270,8 @@ fnmatch (const char *pattern, const char *string, int flags)
+         prepare_wpattern:
+           n = mbsrtowcs (NULL, &pattern, 0, &ps);
+           if (__glibc_unlikely (n == (size_t) -1))
+-            /* Something wrong.
+-               XXX Do we have to set 'errno' to something which mbsrtows hasn't
+-               already done?  */
+-            return -1;
++	    /* Something wrong: Fall back to single byte matching.  */
++	    goto try_singlebyte;
+           if (__glibc_unlikely (n >= (size_t) -1 / sizeof (wchar_t)))
+             {
+               __set_errno (ENOMEM);
+@@ -297,14 +294,8 @@ fnmatch (const char *pattern, const char *string, int flags)
+                                                 alloca_used);
+           n = mbsrtowcs (wstring, &p, n + 1, &ps);
+           if (__glibc_unlikely (n == (size_t) -1))
+-            {
+-              /* Something wrong.
+-                 XXX Do we have to set 'errno' to something which
+-                 mbsrtows hasn't already done?  */
+-            free_return:
+-              free (wpattern_malloc);
+-              return -1;
+-            }
++	    /* Something wrong: Fall back to single byte matching.  */
++	    goto free_and_try_singlebyte;
+           if (p)
+             {
+               memset (&ps, '\0', sizeof (ps));
+@@ -316,10 +307,8 @@ fnmatch (const char *pattern, const char *string, int flags)
+         prepare_wstring:
+           n = mbsrtowcs (NULL, &string, 0, &ps);
+           if (__glibc_unlikely (n == (size_t) -1))
+-            /* Something wrong.
+-               XXX Do we have to set 'errno' to something which mbsrtows hasn't
+-               already done?  */
+-            goto free_return;
++	    /* Something wrong: Fall back to singlebyte matching. */
++	    goto free_and_try_singlebyte;
+           if (__glibc_unlikely (n >= (size_t) -1 / sizeof (wchar_t)))
+             {
+               free (wpattern_malloc);
+@@ -346,6 +335,10 @@ fnmatch (const char *pattern, const char *string, int flags)
+       free (wpattern_malloc);
+ 
+       return res;
++      free_and_try_singlebyte:
++	free(wpattern_malloc);
++      try_singlebyte:
++	pattern = orig_pattern;
+     }
+ 
+   return internal_fnmatch (pattern, string, string + strlen (string),

--- a/tests/data/patches/previous/missing-diff-line.patch
+++ b/tests/data/patches/previous/missing-diff-line.patch
@@ -1,0 +1,31 @@
+Short description: Place glibc info into "Libraries" category.
+Author(s): Fedora glibc team <glibc@lists.fedoraproject.org>
+Origin: PATCH
+Upstream status: not-needed
+
+The category names for libraries is completely random including
+"Libraries", "GNU Libraries", "GNU libraries", and "Software libraries."
+In the GNU info manual the "Software libraries" category is given as an
+example, but really we need to standardize on a category for upstream.
+I suggest we drop this change after some upstream discussion.
+
+From 4820b9175535e13df79ce816106016040014916e Mon Sep 17 00:00:00 2001
+From: Jakub Jelinek <jakub@redhat.com>
+Date: Fri, 3 Nov 2006 16:31:21 +0000
+Subject: [PATCH] Change @dircategory.
+
+---
+ manual/libc.texinfo |    2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+--- a/manual/libc.texinfo
++++ b/manual/libc.texinfo
+@@ -7,7 +7,7 @@
+ @include macros.texi
+ 
+ @comment Tell install-info what to do.
+-@dircategory Software libraries
++@dircategory Libraries
+ @direntry
+ * Libc: (libc).                 C library.
+ @end direntry

--- a/tests/data/patches/previous/unified-diff.patch
+++ b/tests/data/patches/previous/unified-diff.patch
@@ -1,0 +1,15 @@
+Short description: Adjust CS_PATH return value.
+Author(s): Fedora glibc team <glibc@lists.fedoraproject.org>
+Origin: PATCH
+Upstream status: not-needed
+
+In Fedora we should return only /usr/bin because /bin is just a symlink
+to /usr/bin after MoveToUsr transition (which glibc has not really
+completed).
+
+diff -pruN a/sysdeps/unix/confstr.h b/sysdeps/unix/confstr.h
+--- a/sysdeps/unix/confstr.h	2012-12-25 08:32:13.000000000 +0530
++++ b/sysdeps/unix/confstr.h	2014-09-05 20:02:55.698275219 +0530
+@@ -1 +1 @@
+-#define	CS_PATH	"/bin:/usr/bin"
++#define	CS_PATH	"/usr/bin"

--- a/tests/data/patches/previous/weird-identical.patch
+++ b/tests/data/patches/previous/weird-identical.patch
@@ -1,0 +1,38 @@
+Short description: Add syslog.target dependency.
+Author(s): Fedora glibc team <glibc@lists.fedoraproject.org>
+Origin: PATCH
+Bug-Fedora: #1070416
+Upstream status: not-needed
+
+Fedora-specific changes to the nscd.service file.
+See also: glibc-nscd-sysconfig.patch.
+
+--- a/nscd/nscd.service
++++ b/nscd/nscd.service
+@@ -2,6 +2,7 @@
+ 
+ [Unit]
+ Description=Name Service Cache Daemon
++After=syslog.target
+ 
+ [Service]
+ Type=forking
+@@ -17,3 +18,4 @@
+ 
+ [Install]
+ WantedBy=multi-user.target
++Also=nscd.socket
+diff --git a/nscd/nscd.socket b/nscd/nscd.socket
+new file mode 100644
+index 0000000..7e512d5
+--- /dev/null
++++ b/nscd/nscd.socket
+@@ -0,0 +1,8 @@
++[Unit]
++Description=Name Service Cache Daemon Socket
++
++[Socket]
++ListenDatagram=/var/run/nscd/socket
++
++[Install]
++WantedBy=sockets.target

--- a/tests/data/patches/regenerated/git-diff.patch
+++ b/tests/data/patches/regenerated/git-diff.patch
@@ -1,0 +1,94 @@
+From 355fb33889db98b0ce9af4184a92fbca2247955e Mon Sep 17 00:00:00 2001
+From: Tomas Tomecek <ttomecek@redhat.com>
+Date: Tue, 16 Feb 2021 09:51:20 +0100
+Subject: [PATCH 07/20] Apply patch glibc-rh819430.patch
+
+patch_name: glibc-rh819430.patch
+present_in_specfile: true
+location_in_specfile: 7
+---
+ posix/fnmatch.c | 33 +++++++++++++--------------------
+ 1 file changed, 13 insertions(+), 20 deletions(-)
+
+diff --git a/posix/fnmatch.c b/posix/fnmatch.c
+index b8a71f164d..e50a9b9064 100644
+--- a/posix/fnmatch.c
++++ b/posix/fnmatch.c
+@@ -237,6 +237,7 @@ fnmatch (const char *pattern, const char *string, int flags)
+ {
+   if (__glibc_unlikely (MB_CUR_MAX != 1))
+     {
++      const char *orig_pattern = pattern;
+       mbstate_t ps;
+       size_t n;
+       const char *p;
+@@ -256,10 +257,8 @@ fnmatch (const char *pattern, const char *string, int flags)
+                                                  alloca_used);
+           n = mbsrtowcs (wpattern, &p, n + 1, &ps);
+           if (__glibc_unlikely (n == (size_t) -1))
+-            /* Something wrong.
+-               XXX Do we have to set 'errno' to something which mbsrtows hasn't
+-               already done?  */
+-            return -1;
++	    /* Something wrong: Fall back to single byte matching.  */
++	    goto try_singlebyte;
+           if (p)
+             {
+               memset (&ps, '\0', sizeof (ps));
+@@ -271,10 +270,8 @@ fnmatch (const char *pattern, const char *string, int flags)
+         prepare_wpattern:
+           n = mbsrtowcs (NULL, &pattern, 0, &ps);
+           if (__glibc_unlikely (n == (size_t) -1))
+-            /* Something wrong.
+-               XXX Do we have to set 'errno' to something which mbsrtows hasn't
+-               already done?  */
+-            return -1;
++	    /* Something wrong: Fall back to single byte matching.  */
++	    goto try_singlebyte;
+           if (__glibc_unlikely (n >= (size_t) -1 / sizeof (wchar_t)))
+             {
+               __set_errno (ENOMEM);
+@@ -297,14 +294,8 @@ fnmatch (const char *pattern, const char *string, int flags)
+                                                 alloca_used);
+           n = mbsrtowcs (wstring, &p, n + 1, &ps);
+           if (__glibc_unlikely (n == (size_t) -1))
+-            {
+-              /* Something wrong.
+-                 XXX Do we have to set 'errno' to something which
+-                 mbsrtows hasn't already done?  */
+-            free_return:
+-              free (wpattern_malloc);
+-              return -1;
+-            }
++	    /* Something wrong: Fall back to single byte matching.  */
++	    goto free_and_try_singlebyte;
+           if (p)
+             {
+               memset (&ps, '\0', sizeof (ps));
+@@ -316,10 +307,8 @@ fnmatch (const char *pattern, const char *string, int flags)
+         prepare_wstring:
+           n = mbsrtowcs (NULL, &string, 0, &ps);
+           if (__glibc_unlikely (n == (size_t) -1))
+-            /* Something wrong.
+-               XXX Do we have to set 'errno' to something which mbsrtows hasn't
+-               already done?  */
+-            goto free_return;
++	    /* Something wrong: Fall back to singlebyte matching. */
++	    goto free_and_try_singlebyte;
+           if (__glibc_unlikely (n >= (size_t) -1 / sizeof (wchar_t)))
+             {
+               free (wpattern_malloc);
+@@ -346,6 +335,10 @@ fnmatch (const char *pattern, const char *string, int flags)
+       free (wpattern_malloc);
+ 
+       return res;
++      free_and_try_singlebyte:
++	free(wpattern_malloc);
++      try_singlebyte:
++	pattern = orig_pattern;
+     }
+ 
+   return internal_fnmatch (pattern, string, string + strlen (string),
+-- 
+2.29.2
+

--- a/tests/data/patches/regenerated/missing-diff-line.patch
+++ b/tests/data/patches/regenerated/missing-diff-line.patch
@@ -1,0 +1,28 @@
+From 12668fa2cd987d47af4018a772bcf9d2b04f0970 Mon Sep 17 00:00:00 2001
+From: Tomas Tomecek <ttomecek@redhat.com>
+Date: Tue, 16 Feb 2021 09:51:19 +0100
+Subject: [PATCH 05/20] Apply patch glibc-fedora-manual-dircategory.patch
+
+patch_name: glibc-fedora-manual-dircategory.patch
+present_in_specfile: true
+location_in_specfile: 5
+---
+ manual/libc.texinfo | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/manual/libc.texinfo b/manual/libc.texinfo
+index ad606cae63..d094809f02 100644
+--- a/manual/libc.texinfo
++++ b/manual/libc.texinfo
+@@ -14,7 +14,7 @@
+ @include macros.texi
+ 
+ @comment Tell install-info what to do.
+-@dircategory Software libraries
++@dircategory Libraries
+ @direntry
+ * Libc: (libc).                 C library.
+ @end direntry
+-- 
+2.29.2
+

--- a/tests/data/patches/regenerated/unified-diff.patch
+++ b/tests/data/patches/regenerated/unified-diff.patch
@@ -1,0 +1,22 @@
+From 6aceabb69fdef1c85d73c5e17b08b7dedcdcf05d Mon Sep 17 00:00:00 2001
+From: Tomas Tomecek <ttomecek@redhat.com>
+Date: Tue, 16 Feb 2021 09:51:20 +0100
+Subject: [PATCH 11/20] Apply patch glibc-cs-path.patch
+
+patch_name: glibc-cs-path.patch
+present_in_specfile: true
+location_in_specfile: 11
+---
+ sysdeps/unix/confstr.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sysdeps/unix/confstr.h b/sysdeps/unix/confstr.h
+index 15859c3b27..9b63b7f806 100644
+--- a/sysdeps/unix/confstr.h
++++ b/sysdeps/unix/confstr.h
+@@ -1 +1 @@
+-#define	CS_PATH	"/bin:/usr/bin"
++#define	CS_PATH	"/usr/bin"
+-- 
+2.29.2
+

--- a/tests/data/patches/regenerated/weird-identical.patch
+++ b/tests/data/patches/regenerated/weird-identical.patch
@@ -1,0 +1,48 @@
+From 9de5daa2fb3df914b367c0966fd0adc13298d096 Mon Sep 17 00:00:00 2001
+From: Tomas Tomecek <ttomecek@redhat.com>
+Date: Tue, 16 Feb 2021 09:51:20 +0100
+Subject: [PATCH 09/20] Apply patch glibc-rh1070416.patch
+
+patch_name: glibc-rh1070416.patch
+present_in_specfile: true
+location_in_specfile: 9
+---
+ nscd/nscd.service | 2 ++
+ nscd/nscd.socket  | 8 ++++++++
+ 2 files changed, 10 insertions(+)
+ create mode 100644 nscd/nscd.socket
+
+diff --git a/nscd/nscd.service b/nscd/nscd.service
+index ab38e8f982..a97018605c 100644
+--- a/nscd/nscd.service
++++ b/nscd/nscd.service
+@@ -2,6 +2,7 @@
+ 
+ [Unit]
+ Description=Name Service Cache Daemon
++After=syslog.target
+ 
+ [Service]
+ Type=forking
+@@ -17,3 +18,4 @@ PIDFile=/run/nscd/nscd.pid
+ 
+ [Install]
+ WantedBy=multi-user.target
++Also=nscd.socket
+diff --git a/nscd/nscd.socket b/nscd/nscd.socket
+new file mode 100644
+index 0000000000..7e512d5339
+--- /dev/null
++++ b/nscd/nscd.socket
+@@ -0,0 +1,8 @@
++[Unit]
++Description=Name Service Cache Daemon Socket
++
++[Socket]
++ListenDatagram=/var/run/nscd/socket
++
++[Install]
++WantedBy=sockets.target
+-- 
+2.29.2
+

--- a/tests/integration/test_patches.py
+++ b/tests/integration/test_patches.py
@@ -1,0 +1,57 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import git
+import pytest
+import shutil
+
+from pathlib import Path
+from packit.patches import PatchGenerator, PatchMetadata
+
+
+@pytest.fixture
+def git_repo(tmpdir):
+    """
+    Set up a git repo with some initial patch files in the history,
+    and the same patch files updated after re-generating them from a
+    source-git repo.
+    """
+    repo = git.Repo.init(tmpdir)
+    shutil.copytree(
+        src="tests/data/patches/previous/",
+        dst=repo.working_tree_dir,
+        dirs_exist_ok=True,
+    )
+    repo.git.add(repo.working_tree_dir)
+    repo.git.commit("-mInitial patches")
+    shutil.copytree(
+        src="tests/data/patches/regenerated/",
+        dst=repo.working_tree_dir,
+        dirs_exist_ok=True,
+    )
+    return repo
+
+
+def test_undo_identical(git_repo):
+    """
+    Check that identical patches are correctly detected and changes
+    undone in the target git repo.
+    """
+    input_patch_list = [
+        PatchMetadata(name=path.name, path=path)
+        for path in Path(git_repo.working_tree_dir).iterdir()
+        if path.suffix == ".patch"
+    ]
+    output_patch_list = [
+        x for x in input_patch_list if x.name == "weird-identical.patch"
+    ]
+    assert (
+        PatchGenerator.undo_identical(input_patch_list, git_repo) == output_patch_list
+    )
+    # 'weird-identical.patch' is identical, except the original patch file
+    # is missing a "function" name at one of the hunks, which causes the
+    # patch-ids to be different.
+    # Is there any safe way to handle this?
+    assert [item.a_path for item in git_repo.index.diff(None)] == [
+        "weird-identical.patch"
+    ]

--- a/tests/integration/test_source_git.py
+++ b/tests/integration/test_source_git.py
@@ -45,7 +45,6 @@ from tests.spellbook import (
 def test_basic_local_update_without_patching(
     sourcegit_and_remote,
     distgit_and_remote,
-    mock_patching,
     mock_remote_functionality_sourcegit,
     api_instance_source_git,
 ):

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -29,6 +29,7 @@ from flexmock import flexmock
 from packit.api import PackitAPI
 from packit.copr_helper import CoprHelper
 from packit.exceptions import PackitException
+from packit.patches import PatchGenerator
 
 
 def build_dict(copr_url, id):
@@ -136,6 +137,7 @@ def test_sync_release_version_tag_processing(
     api_mock.should_receive("_prepare_files_to_sync").with_args(
         raw_sync_files=[], full_version=version, upstream_tag=tag
     )
+    flexmock(PatchGenerator).should_receive("undo_identical")
     with expectation:
         api_mock.sync_release(
             version=version or get_version_return, tag=tag, dist_git_branch="_"


### PR DESCRIPTION
The 'propose-downstream' command is using 'git format-patch' to generate
and update the patch files in the dist-git repository. These new patch
files will always be 'git-formatted', while existing patches might use
some different format and this will result an unnecessary update of the
patch-file.

In order to avoid this, attempt to massage the previously present
patch-files in the dist-git repo to a format which can be used with 'git
patch-id --stable', and tell if updating a patch-file can be skipped by
comparing the current and previous patch-id.

The code was tested on the f34 branch of glibc.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>