### PR TITLE
patches: dont run linearization if the repo is dirty

### DIFF
--- a/packit/exceptions.py
+++ b/packit/exceptions.py
@@ -108,3 +108,7 @@ class PackitRPMNotFoundException(PackitRPMException):
 
 class PackitFailedToCreateRPMException(PackitRPMException):
     """ Failed to create RPM """
+
+
+class PackitGitException(PackitException):
+    """ Operation with a git repo failed """

--- a/packit/patches.py
+++ b/packit/patches.py
@@ -275,6 +275,7 @@ class PatchGenerator:
             # git prints nasty warning when filter-branch is used that it's dangerous
             # this env var prevents it from prints
             env={"FILTER_BRANCH_SQUELCH_WARNING": "1"},
+            print_live=True,
         )
 
     def run_git_format_patch(

--- a/tests/integration/test_source_git.py
+++ b/tests/integration/test_source_git.py
@@ -469,7 +469,7 @@ def test_srpm_merge_storm_dirty(api_instance_source_git):
     with pytest.raises(PackitException) as ex:
         with cwd(sg_path):
             api_instance_source_git.create_srpm(upstream_ref=ref)
-    assert "he source-git repo is dirty" in str(ex.value)
+    assert "The source-git repo is dirty" in str(ex.value)
 
 
 @pytest.mark.parametrize("ref", ["0.1.0", "0.1*", "0.*"])


### PR DESCRIPTION
The filter-branch command is indeed kind-of experimental since this is
the error from git when the repo is dirty:

    Proceeding with filter-branch...

    fatal: ambiguous argument '2,3': unknown revision or path not in the working tree.
    Use '--' to separate paths from revisions, like this:
    'git <command> [<revision>...] -- [<file>...]'

Example of the problem:
* https://github.com/OpenSCAP/oscap-anaconda-addon/pull/139
* https://prod.packit.dev/srpm-build/15607/logs