### PR TITLE
make sandcastle-related tests pass

### DIFF
--- a/files/packit-testing-farm-prepare.yaml
+++ b/files/packit-testing-farm-prepare.yaml
@@ -6,3 +6,4 @@
     - include_tasks: tasks/python-compile-deps.yaml
     - include_tasks: tasks/rpm-test-deps.yaml
     - include_tasks: tasks/configure-git.yaml
+    - include_tasks: tasks/sandcastle.yaml

--- a/tests/unit/test_base_git.py
+++ b/tests/unit/test_base_git.py
@@ -251,6 +251,9 @@ def test_run_action_in_sandcastle(
         assert " 1.2.3\n" in caplog.text
 
 
+@pytest.mark.skipif(
+    not can_a_module_be_imported("sandcastle"), reason="sandcastle is not installed"
+)
 def test_command_handler_is_set(packit_repository_base_with_sandcastle_object):
     from sandcastle import Sandcastle
 


### PR DESCRIPTION
* install sandcastle
* wrap sandcastle tests with the decorator to run them only when the
  module is available