### PR TITLE
patches: run linearization commands in the repo

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -133,27 +133,10 @@ class PackitRepositoryBase:
                (exc will be raised if the branch is not in the remote)
         :return the branch which was just created
         """
-        # it's not an error if the branch already exists
-        if branch_name in self.local_project.git_repo.branches:
-            logger.debug(
-                f"It seems that branch {branch_name!r} already exists, checking it out."
-            )
-            head = self.local_project.git_repo.branches[branch_name]
-        else:
-            head = self.local_project.git_repo.create_head(branch_name, commit=base)
-
-        if setup_tracking:
-            origin = self.local_project.git_repo.remote("origin")
-            if branch_name in origin.refs:
-                remote_ref = origin.refs[branch_name]
-            else:
-                raise PackitException(
-                    f"Remote origin doesn't have ref {branch_name!r}."
-                )
-            # this is important to fedpkg: build can't find the tracking branch otherwise
-            head.set_tracking_branch(remote_ref)
-
-        return head
+        # keeping the method in this class to preserve compatibility
+        return self.local_project.create_branch(
+            branch_name=branch_name, base=base, setup_tracking=setup_tracking
+        )
 
     def checkout_branch(self, git_ref: str = None):
         """

--- a/packit/patches.py
+++ b/packit/patches.py
@@ -252,7 +252,7 @@ class PatchGenerator:
         current_time = datetime.datetime.now().strftime(DATETIME_FORMAT)
         target_branch = f"packit-patches-{current_time}"
         logger.info(f"Switch branch to {target_branch!r}.")
-        run_command(["git", "checkout", "-B", target_branch])
+        self.lp.create_branch(target_branch)
         target = f"{git_ref}..HEAD"
         logger.debug(f"Linearize history {target}.")
         # https://stackoverflow.com/a/17994534/909579
@@ -276,6 +276,7 @@ class PatchGenerator:
             # this env var prevents it from prints
             env={"FILTER_BRANCH_SQUELCH_WARNING": "1"},
             print_live=True,
+            cwd=self.lp.working_dir,
         )
 
     def run_git_format_patch(
@@ -509,7 +510,7 @@ class PatchGenerator:
         finally:
             if not contained:
                 # check out the previous branch
-                run_command(["git", "checkout", "-", "--"])
+                run_command(["git", "checkout", "-", "--"], cwd=self.lp.working_dir)
                 # we could also delete the newly created branch,
                 # but let's not do that so that user can inspect it
 


### PR DESCRIPTION
This is the error we got from oscap-anaconda-addon source-git:

    fatal: Unable to create '/src/.git/index.lock': Permission denied

It's clear that the linearization commands were run in a wrong path -
this commit fixes that by explicitly setting cwd to the project dir.

Should address problems in https://github.com/OpenSCAP/oscap-anaconda-addon/pull/139
Will verify that in https://github.com/TomasTomecek/oscap-anaconda-addon/pull/1 via stg