### PR TITLE
packit.yaml: create downstream %changelog from git-log

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -5,7 +5,7 @@ synced_files:
 # packit was already taken on PyPI
 upstream_package_name: packitos
 upstream_project_url: https://github.com/packit/packit
-copy_upstream_release_description: true
+copy_upstream_release_description: false
 
 actions:
   create-archive:


### PR DESCRIPTION
Hunor is correct, our upstream release description used as a %changelog
violates Fedora guidelines, so let packit assemble %changelog from
git-log.

https://docs.fedoraproject.org/en-US/packaging-guidelines/#changelogs

https://packit.dev/docs/configuration/#copy_upstream_release_description