### PR TITLE
Don't use dirs_exist_ok parameter of shutil.copytree

### DIFF
--- a/tests/integration/test_patches.py
+++ b/tests/integration/test_patches.py
@@ -17,18 +17,23 @@ def git_repo(tmpdir):
     source-git repo.
     """
     repo = git.Repo.init(tmpdir)
-    shutil.copytree(
-        src="tests/data/patches/previous/",
-        dst=repo.working_tree_dir,
-        dirs_exist_ok=True,
-    )
+    try:
+        # dirs_exist_ok parameter doesn't exist in python < 3.8
+        shutil.copytree(
+            src="tests/data/patches/previous/",
+            dst=repo.working_tree_dir,
+        )
+    except FileExistsError:
+        pass
     repo.git.add(repo.working_tree_dir)
     repo.git.commit("-mInitial patches")
-    shutil.copytree(
-        src="tests/data/patches/regenerated/",
-        dst=repo.working_tree_dir,
-        dirs_exist_ok=True,
-    )
+    try:
+        shutil.copytree(
+            src="tests/data/patches/regenerated/",
+            dst=repo.working_tree_dir,
+        )
+    except FileExistsError:
+        pass
     return repo
 
 


### PR DESCRIPTION
as [it needs python>=3.8](https://docs.python.org/3/library/shutil.html#shutil.copytree)

Fixes http://artifacts.dev.testing-farm.io/9b608786-9042-4bf5-bafd-b482d971779c/ (epel8)