### PR TITLE
packit-service: log output of failures from actions

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -524,7 +524,7 @@ class PackitAPI:
             self.up.prepare_upstream_for_srpm_creation(upstream_ref=upstream_ref)
         except Exception as ex:
             raise PackitSRPMException(
-                f"Preparing of the upstream to the SRPM build failed: {ex}"
+                f"Preparation of the repository for creation of an SRPM failed: {ex}"
             ) from ex
         try:
             srpm_path = self.up.create_srpm(srpm_path=output_file, srpm_dir=srpm_dir)

--- a/packit/command_handler.py
+++ b/packit/command_handler.py
@@ -159,7 +159,17 @@ class SandcastleCommandHandler(CommandHandler):
         :param print_live: not used here
         """
         logger.info(f"Running command: {' '.join(command)}")
-        out: str = self.sandcastle.exec(command=command, env=env, cwd=cwd)
+
+        # we import here so that packit does not depend on sandcastle (and thus python-kube)
+        from sandcastle import SandcastleCommandFailed
+
+        try:
+            out: str = self.sandcastle.exec(command=command, env=env, cwd=cwd)
+        except SandcastleCommandFailed as ex:
+            # we need to log the output when the command fails
+            # ex.output is a multiline string usually
+            logger.info(f"The command failed, output:\n{ex.output}")
+            raise
 
         logger.info(f"Output of {command!r}:")
         # out = 'make po-pull\nmake[1]: Entering directory \'/sand


### PR DESCRIPTION
so users can see them in the SRPM logs

I wasn't able to find any place where they were logged before (so I'm
assuming they never were). The most fitting place I'd say is the
command_handler itself.