### PR TITLE
Add test repo reference to package-config

### DIFF
--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -66,6 +66,8 @@ class JobMetadataConfig:
         preserve_project: bool = False,
         additional_packages: List[str] = None,
         additional_repos: List[str] = None,
+        fmf_url: str = None,
+        fmf_ref: str = None,
     ):
         """
         :param targets: copr_build job, mock chroots where to build
@@ -93,6 +95,8 @@ class JobMetadataConfig:
         self.preserve_project: bool = preserve_project
         self.additional_packages: List[str] = additional_packages or []
         self.additional_repos: List[str] = additional_repos or []
+        self.fmf_url = fmf_url
+        self.fmf_ref = fmf_ref
 
     def __repr__(self):
         return (
@@ -107,7 +111,9 @@ class JobMetadataConfig:
             f"list_on_homepage={self.list_on_homepage}, "
             f"preserve_project={self.preserve_project}, "
             f"additional_packages={self.additional_packages}, "
-            f"additional_repos={self.additional_repos})"
+            f"additional_repos={self.additional_repos}, "
+            f"fmf_url={self.fmf_url}, "
+            f"fmf_ref={self.fmf_ref})"
         )
 
     def __eq__(self, other: object):
@@ -127,6 +133,8 @@ class JobMetadataConfig:
             and self.preserve_project == other.preserve_project
             and self.additional_packages == other.additional_packages
             and self.additional_repos == other.additional_repos
+            and self.fmf_url == other.fmf_url
+            and self.fmf_ref == other.fmf_ref
         )
 
 

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -208,6 +208,8 @@ class JobMetadataSchema(Schema):
     preserve_project = fields.Boolean()
     additional_packages = fields.List(fields.String(), missing=None)
     additional_repos = fields.List(fields.String(), missing=None)
+    fmf_url = fields.String(missing=None)
+    fmf_ref = fields.String(missing=None)
 
     @pre_load
     def ordered_preprocess(self, data, **_):

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -830,6 +830,36 @@ def test_package_config_parse_error(raw):
             ),
             id="sources",
         ),
+        pytest.param(
+            {
+                "specfile_path": "fedora/package.spec",
+                "jobs": [
+                    {
+                        "job": "copr_build",
+                        "trigger": "release",
+                        "metadata": {
+                            "fmf_url": "https://example.com",
+                            "fmf_ref": "test_ref",
+                        },
+                    },
+                ],
+            },
+            PackageConfig(
+                specfile_path="fedora/package.spec",
+                sync_changelog=False,
+                jobs=[
+                    JobConfig(
+                        type=JobType.copr_build,
+                        specfile_path="fedora/package.spec",
+                        trigger=JobConfigTriggerType.release,
+                        metadata=JobMetadataConfig(
+                            fmf_url="https://example.com", fmf_ref="test_ref"
+                        ),
+                    ),
+                ],
+            ),
+            id="sync_changelog_false_by_default",
+        ),
     ],
 )
 def test_package_config_parse(raw, expected):


### PR DESCRIPTION
This commit adds 'fmf_url' and 'fmf_ref' to JobMetadataConfig. This can
be later used to store tests in different repository.

Related To: packit/packit-service#968 