### PR TITLE
prepare upstream for srpm: better error message

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -524,7 +524,7 @@ class PackitAPI:
             self.up.prepare_upstream_for_srpm_creation(upstream_ref=upstream_ref)
         except Exception as ex:
             raise PackitSRPMException(
-                f"Preparing of the upstream to the SRPM build failed: {ex}"
+                f"Preparation of the repository for creation of an SRPM failed: {ex}"
             ) from ex
         try:
             srpm_path = self.up.create_srpm(srpm_path=output_file, srpm_dir=srpm_dir)


### PR DESCRIPTION
The old one is a bit unclear to me while the new one is more generic and
should tell users what went wrong. If create-archive failed, it will be
in the logs above this one.