### PR TITLE
Treat centos-stream as centos-stream-8

### DIFF
--- a/packit/cli/copr_build.py
+++ b/packit/cli/copr_build.py
@@ -28,7 +28,7 @@ import click
 from packit.cli.types import LocalProjectParameter
 from packit.cli.utils import cover_packit_exception, get_packit_api
 from packit.config import pass_config, get_context_settings, PackageConfig
-from packit.config.aliases import get_valid_build_targets
+from packit.config.aliases import get_valid_build_targets, DEPRECATED_TARGET_MAP
 from packit.utils import sanitize_branch_name
 
 logger = logging.getLogger(__name__)
@@ -137,8 +137,15 @@ def copr_build(
 
     logger.info(f"Using COPR project name = {project}")
 
+    targets_list = targets.split(",")
+    for target in targets_list:
+        if target in DEPRECATED_TARGET_MAP:
+            logger.warning(
+                f"Target '{target}' is deprecated. "
+                f"Please use '{DEPRECATED_TARGET_MAP[target]}' instead."
+            )
     targets_to_build = get_valid_build_targets(
-        *targets.split(","), default="fedora-rawhide-x86_64"
+        *targets_list, default="fedora-rawhide-x86_64"
     )
 
     logger.info(f"Targets to build: {targets_to_build}.")

--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -46,6 +46,14 @@ ARCHITECTURE_LIST: List[str] = [
     "s390x",
     "x86_64",
 ]
+
+DEPRECATED_TARGET_MAP = {"centos-stream": "centos-stream-8"}
+DEPRECATED_TARGET_MAP = {
+    f"{k}-{x}": f"{v}-{x}"
+    for k, v in DEPRECATED_TARGET_MAP.items()
+    for x in ARCHITECTURE_LIST
+}
+
 DEFAULT_VERSION = "fedora-stable"
 
 logger = logging.getLogger(__name__)
@@ -91,6 +99,7 @@ def get_build_targets(*name: str, default: str = DEFAULT_VERSION) -> Set[str]:
             # => cannot guess anything other than rawhide
             if "rawhide" in one_name:
                 sys_name, version, architecture = "fedora", "rawhide", "x86_64"
+
             else:
                 err_msg = (
                     "Cannot get build target from '{one_name}'"
@@ -119,6 +128,11 @@ def get_build_targets(*name: str, default: str = DEFAULT_VERSION) -> Set[str]:
                 for sys_and_version in get_versions(f"{sys_name}-{version}")
             }
         )
+    possible_sys_and_versions = {
+        DEPRECATED_TARGET_MAP.get(target, target)
+        for target in possible_sys_and_versions
+    }
+
     return possible_sys_and_versions
 
 

--- a/tests/unit/test_config_aliases.py
+++ b/tests/unit/test_config_aliases.py
@@ -52,7 +52,7 @@ class TestGetVersions:
             ("fedora-stable", {"fedora-31", "fedora-32"}),
             ("fedora-development", {"fedora-33", "fedora-rawhide"}),
             ("fedora-all", {"fedora-31", "fedora-32", "fedora-33", "fedora-rawhide"}),
-            ("centos-stream", {"centos-stream"}),
+            ("centos-stream-8", {"centos-stream-8"}),
         ],
     )
     def test_get_versions(self, name, versions, mock_get_aliases):
@@ -87,8 +87,10 @@ class TestGetBuildTargets:
             ("fedora-rawhide", {"fedora-rawhide-x86_64"}),
             ("openmandriva-rolling", {"openmandriva-rolling-x86_64"}),
             ("opensuse-leap-15.0", {"opensuse-leap-15.0-x86_64"}),
-            ("centos-stream", {"centos-stream-x86_64"}),
-            ("centos-stream-x86_64", {"centos-stream-x86_64"}),
+            ("centos-stream", {"centos-stream-8-x86_64"}),
+            ("centos-stream-x86_64", {"centos-stream-8-x86_64"}),
+            ("centos-stream-8", {"centos-stream-8-x86_64"}),
+            ("centos-stream-8-x86_64", {"centos-stream-8-x86_64"}),
             ("fedora-stable", {"fedora-31-x86_64", "fedora-32-x86_64"}),
             ("fedora-development", {"fedora-33-x86_64", "fedora-rawhide-x86_64"}),
             ("fedora-29-x86_64", {"fedora-29-x86_64"}),


### PR DESCRIPTION
Acording to [1], centos-stream target in Copr will be changed to
centos-stream-8. This change reflects it.

centos-stream target is temporarily resolved to centos-stream-8 and
warnings saying that users should update their configuration are
printed.

[1] https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/PJT7PK2TLW7T2Z2WLXUGHUYBWR244SBB/

Related To: packit/packit-service#961