### PR TITLE
Allow only signed commits to be proposed downstream

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -14,6 +14,9 @@ actions:
   get-current-version:
     - "python3 setup.py --version"
 
+allowed_gpg_keys:
+  - 5DE3E0509C47EA3CF04A42D34AEE18F83AFDEB23
+
 jobs:
   - job: propose_downstream
     trigger: release


### PR DESCRIPTION
Merge commits created by Zuul are signed with the GitHub key. Allow only
such commits to be proposed downstream by configuring
`allowed_gpg_keys`. The list can be extended with other keys if needed.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>