### PR TITLE
Rebase patches against HEAD branch, not `master`

### DIFF
--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -510,5 +510,9 @@ class LocalProject:
         """ git reset --hard $ref """
         self.git_repo.head.reset(ref, index=True, working_tree=True)
 
+    @property
+    def head_branch(self) -> str:
+        return self.git_repo.head.name
+
     def __del__(self):
         self.clean()

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -510,9 +510,5 @@ class LocalProject:
         """ git reset --hard $ref """
         self.git_repo.head.reset(ref, index=True, working_tree=True)
 
-    @property
-    def head_branch(self) -> str:
-        return self.git_repo.head.name
-
     def __del__(self):
         self.clean()

--- a/packit/source_git.py
+++ b/packit/source_git.py
@@ -445,5 +445,9 @@ class SourceGitGenerator:
         self._add_packit_config()
         if self.dist_git.specfile.get_applied_patches():
             self._run_prep()
-            self._rebase_patches(get_default_branch())
+            self._rebase_patches(
+                get_default_branch(
+                    LocalProject(working_dir=self.get_BUILD_dir()).git_repo
+                )
+            )
             # TODO: patches which are defined but not applied should be copied

--- a/packit/source_git.py
+++ b/packit/source_git.py
@@ -441,5 +441,5 @@ class SourceGitGenerator:
         self._add_packit_config()
         if self.dist_git.specfile.get_applied_patches():
             self._run_prep()
-            self._rebase_patches("master")
+            self._rebase_patches(self.local_project.head_branch)
             # TODO: patches which are defined but not applied should be copied

--- a/packit/source_git.py
+++ b/packit/source_git.py
@@ -26,7 +26,11 @@ from packit.distgit import DistGit
 from packit.exceptions import PackitException
 from packit.local_project import LocalProject
 from packit.utils.commands import run_command
-from packit.utils.repo import clone_centos_8_package, clone_centos_9_package
+from packit.utils.repo import (
+    clone_centos_8_package,
+    clone_centos_9_package,
+    get_default_branch,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -441,5 +445,5 @@ class SourceGitGenerator:
         self._add_packit_config()
         if self.dist_git.specfile.get_applied_patches():
             self._run_prep()
-            self._rebase_patches(self.local_project.head_branch)
+            self._rebase_patches(get_default_branch())
             # TODO: patches which are defined but not applied should be copied

--- a/packit/utils/repo.py
+++ b/packit/utils/repo.py
@@ -60,18 +60,22 @@ def is_a_git_ref(repo: git.Repo, ref: str) -> bool:
         return False
 
 
-def get_default_branch() -> str:
+def get_default_branch(repository: git.Repo) -> str:
     """
-    Returns default branch for newly created repos on the local system.
+    Returns default branch for newly created repos in the parent directory of
+    passed in repository. Accepts `repository` to ensure the closest override of
+    git configuration is used.
+
+    Args:
+        repository (git.Repo): Git repository closest to the directory where
+            the configuration is applied.
 
     Returns:
         Default branch for new repos, if not supported or not configured returns
         `master`.
     """
-    output = run_command(
-        ["git", "config", "init.defaultBranch"], output=True, fail=False
-    )
-    return output.strip() if output else "master"
+    config = repository.config_reader()
+    return config.get_value("init", "defaultBranch", "master")
 
 
 def git_remote_url_to_https_url(inp: str) -> str:

--- a/packit/utils/repo.py
+++ b/packit/utils/repo.py
@@ -60,6 +60,20 @@ def is_a_git_ref(repo: git.Repo, ref: str) -> bool:
         return False
 
 
+def get_default_branch() -> str:
+    """
+    Returns default branch for newly created repos on the local system.
+
+    Returns:
+        Default branch for new repos, if not supported or not configured returns
+        `master`.
+    """
+    output = run_command(
+        ["git", "config", "init.defaultBranch"], output=True, fail=False
+    )
+    return output.strip() if output else "master"
+
+
 def git_remote_url_to_https_url(inp: str) -> str:
     """
     turn provided git remote URL to https URL:


### PR DESCRIPTION
Branch was dependant on temporary locally created git repository, added function to get default branch for new repositories.

Signed-off-by: Matej Focko <mfocko@redhat.com>