### PR TITLE
download_remote_sources: dont download a source twice

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -410,9 +410,11 @@ class PackitRepositoryBase:
         """
         # Fetch all sources defined in packit.yaml -> sources
         for source in self.package_config.sources:
-            logger.info(f"Downloading source {source.path!r}.")
-            DownloadHelper.download_file(
-                source.url,
-                str(Path(self.specfile.sources_location).joinpath(source.path)),
-            )
+            source_path = Path(self.specfile.sources_location).joinpath(source.path)
+            if not source_path.is_file():
+                logger.info(f"Downloading source {source.path!r}.")
+                DownloadHelper.download_file(
+                    source.url,
+                    str(source_path),
+                )
         self.specfile.download_remote_sources()

--- a/tests/unit/test_base_git.py
+++ b/tests/unit/test_base_git.py
@@ -373,4 +373,11 @@ def test_download_remote_sources(source, package_config, expected_url, tmp_path:
 
     base_git.download_remote_sources()
 
+    flexmock(DownloadHelper).should_receive("download_file").and_raise(
+        Exception(
+            "This should not be called second time since the source is present already."
+        )
+    )
+    base_git.download_remote_sources()
+
     assert expected_path.exists()


### PR DESCRIPTION
rebase-helper downloads the file again when the archive is on a
web-server which uses compression to transfer data:

    file_size = int(r.headers.get('content-length', -1))
    if r.headers.get('content-encoding', 'identity') != 'identity':
        # use infinite progress bar in case of compressed content, there is no
        # way to determine the uncompressed size in advance
        file_size = -1

Since we literally just downloaded the file, we don't need to do it
again if it's present on the disk.