### PR TITLE
pre-commit: The 'exclude' field is a regex, not a glob

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,12 +15,12 @@ repos:
     rev: v2.2.1
     hooks:
       - id: prettier
-        exclude: tests_recording/test_data/*
+        exclude: tests_recording/test_data/
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
       - id: check-added-large-files
-        exclude: tests_recording/test_data/test_api/*
+        exclude: tests_recording/test_data/test_api/
       - id: check-ast
       - id: check-merge-conflict
       - id: check-yaml


### PR DESCRIPTION
Fixes:
```
[WARNING] The 'exclude' field in hook 'prettier' is a regex, not a glob -- matching '/*' probably isn't what you want here
[WARNING] The 'exclude' field in hook 'check-added-large-files' is a regex, not a glob -- matching '/*' probably isn't what you want here
```