### PR TITLE
Log the head commit hash when checking out a PR

### DIFF
--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -448,6 +448,7 @@ class LocalProject:
         rem.fetch(f"{remote_ref}:{local_ref}")
         self.git_repo.create_head(local_branch, f"{remote_name}/{local_branch}")
         self.git_repo.branches[local_branch].checkout()
+        logger.info(f"Checked out commit {self.git_repo.head.commit}")
 
     def checkout_release(self, tag: str) -> None:
         logger.info(f"Checking out upstream version {tag}.")


### PR DESCRIPTION
B/c it's a good idea, in general, but also b/c it will help to
understand what's happening in #1202.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>