### PR TITLE
init: fix creation with %autosetup -Sgit and git_am

### DIFF
--- a/packit/constants.py
+++ b/packit/constants.py
@@ -128,10 +128,10 @@ RPM_MACROS_FOR_PREP = [
     "-D",
     "__scm_apply_git_am(qp:m:) "
     "%{__git} am %{-q} %{-p:-p%{-p*}} && "
-    "patch_name=`basename %{1}` "
-    "commit_msg=`%{__git} log --format=%B -n1` "
+    "patch_name=`basename %{1}` && "
+    "commit_msg=`%{__git} log --format=%B -n1` && "
     r'metadata_commit_msg=`printf "patch_name: $patch_name\\n'
-    r'present_in_specfile: true\\nsquash_commits: true"` '
+    r'present_in_specfile: true\\nsquash_commits: true"` && '
     '%{__git} commit --amend -m "$commit_msg" -m "$metadata_commit_msg"',
     # do the same of %autosetup -Sgit
     # that is, apply packit patch metadata to the patch commit
@@ -139,7 +139,7 @@ RPM_MACROS_FOR_PREP = [
     "-D",
     "__scm_apply_git(qp:m:) "
     "%{__git} apply --index %{-p:-p%{-p*}} - && "
-    "patch_name=`basename %{1}` "
-    r'metadata_commit_msg=`printf "patch_name: $patch_name\\npresent_in_specfile: true\\n"` '
-    '%{__git} commit %{-q} -m %{-m*} -m "$metadata_commit_msg" --author "%{__scm_author}"',
+    "patch_name=`basename %{1}` && "
+    r'metadata_commit_msg=`printf "patch_name: $patch_name\\npresent_in_specfile: true\\n"` && '
+    '%{__git} commit %{-q} -m %{-m*} -m "${metadata_commit_msg}" --author "%{__scm_author}"',
 ]


### PR DESCRIPTION
It seems something changed how rpm invokes multiline macros - now we need
to chain variable definition with '&&'. These variables are being used
to wrap patch commit messages with metadata so packit can utilize them.

Without this commit, there would be no patch metadata and SRPM creation
fails with duplicate Patch IDs.

```
tests/integration/test_source_git_generator.py::test_acl_with_git_git_am[git] PASSED
tests/integration/test_source_git_generator.py::test_acl_with_git_git_am[git_am] PASSED
```