### PR TITLE
[get_aliases] create a list for fedora-latest

### DIFF
--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -273,6 +273,6 @@ def get_aliases() -> Dict[str, List[str]]:
     # fedora-rawhide is the last release, we want the second latest (the latest
     # non rawhide release)
     if len(aliases["fedora-all"]) >= 2:
-        aliases["fedora-latest"] = aliases["fedora-all"][-2]
+        aliases["fedora-latest"] = [aliases["fedora-all"][-2]]
 
     return aliases

--- a/tests/unit/test_config_aliases.py
+++ b/tests/unit/test_config_aliases.py
@@ -315,6 +315,9 @@ class TestGetAliases:
             expected_return["fedora-development"]
         )
         assert Counter(aliases["fedora-all"]) == Counter(expected_return["fedora-all"])
+        assert Counter(aliases["fedora-latest"]) == Counter(
+            expected_return["fedora-latest"]
+        )
         assert Counter(aliases["epel-all"]) == Counter(expected_return["epel-all"])
 
 


### PR DESCRIPTION
Fixes:
```
Build targets: {'d-x86_64', '--x86_64', 'r-x86_64', 'a-x86_64', '3-x86_64', 'f-x86_64', 'o-x86_64', 'e-x86_64', '4-x86_64'} 
...
Result set: set()
```