### PR TITLE
drop location_in_specfile patch metadata key

### DIFF
--- a/_packitpatch
+++ b/_packitpatch
@@ -61,7 +61,7 @@ fi
 
 if [ "$patch_id" != "%{2}" ]; then
   # concat 2 strings and separate them with \n - a nightmare to do in bash
-  printf -v commit_message "${commit_message}\nlocation_in_specfile: ${patch_id}"
+  printf -v commit_message "${commit_message}"
 fi
 
 git add -f .

--- a/packit/patches.py
+++ b/packit/patches.py
@@ -28,7 +28,6 @@ class PatchMetadata:
         self,
         name: Optional[str] = None,
         path: Optional[Path] = None,
-        location_in_specfile: Optional[str] = None,
         description: Optional[str] = None,
         commit: Optional[git.Commit] = None,
         present_in_specfile: bool = False,
@@ -42,7 +41,6 @@ class PatchMetadata:
 
         :param name: name of the patch file
         :param path: Path of the patch file
-        :param location_in_specfile: index of the patch in spec-file
         :param description: will be attached as a comment above path in spec-file
                             (if present_in_specfile=False)
         :param commit: git.Commit relevant to this patch file
@@ -59,7 +57,6 @@ class PatchMetadata:
         """
         self.name = name
         self.path = path
-        self.location_in_specfile = location_in_specfile
         self.description = description
         self.commit = commit
         self.present_in_specfile = present_in_specfile
@@ -88,9 +85,6 @@ class PatchMetadata:
 
         if self.name:
             msg += f"\npatch_name: {self.name}"
-
-        if self.location_in_specfile:
-            msg += f"\nlocation_in_specfile: {self.location_in_specfile}"
 
         if self.description:
             msg += f"\ndescription: {self.description}"
@@ -146,7 +140,6 @@ class PatchMetadata:
             path=patch_path,
             description=metadata.get("description"),
             present_in_specfile=metadata.get("present_in_specfile"),
-            location_in_specfile=metadata.get("location_in_specfile"),
             ignore=metadata.get("ignore"),
             commit=commit,
             squash_commits=metadata.get("squash_commits"),

--- a/tests/data/patches/regenerated/git-diff.patch
+++ b/tests/data/patches/regenerated/git-diff.patch
@@ -5,7 +5,6 @@ Subject: [PATCH 07/20] Apply patch glibc-rh819430.patch
 
 patch_name: glibc-rh819430.patch
 present_in_specfile: true
-location_in_specfile: 7
 ---
  posix/fnmatch.c | 33 +++++++++++++--------------------
  1 file changed, 13 insertions(+), 20 deletions(-)

--- a/tests/data/patches/regenerated/missing-diff-line.patch
+++ b/tests/data/patches/regenerated/missing-diff-line.patch
@@ -5,7 +5,6 @@ Subject: [PATCH 05/20] Apply patch glibc-fedora-manual-dircategory.patch
 
 patch_name: glibc-fedora-manual-dircategory.patch
 present_in_specfile: true
-location_in_specfile: 5
 ---
  manual/libc.texinfo | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/tests/data/patches/regenerated/unified-diff.patch
+++ b/tests/data/patches/regenerated/unified-diff.patch
@@ -5,7 +5,6 @@ Subject: [PATCH 11/20] Apply patch glibc-cs-path.patch
 
 patch_name: glibc-cs-path.patch
 present_in_specfile: true
-location_in_specfile: 11
 ---
  sysdeps/unix/confstr.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/tests/data/patches/regenerated/weird-identical.patch
+++ b/tests/data/patches/regenerated/weird-identical.patch
@@ -5,7 +5,6 @@ Subject: [PATCH 09/20] Apply patch glibc-rh1070416.patch
 
 patch_name: glibc-rh1070416.patch
 present_in_specfile: true
-location_in_specfile: 9
 ---
  nscd/nscd.service | 2 ++
  nscd/nscd.socket  | 8 ++++++++


### PR DESCRIPTION
it's not being utilized anywhere and is just confusing what it actually
means - we are planning to replace it with patch_id attribute