### PR TITLE
Print output of 'fedpkg new-sources'

### DIFF
--- a/packit/fedpkg.py
+++ b/packit/fedpkg.py
@@ -62,6 +62,7 @@ class FedPKG:
             cmd=[self.fedpkg_exec, "new-sources", sources],
             cwd=self.directory,
             error_message="Adding new sources failed:",
+            print_live=True,
             fail=fail,
         )
 


### PR DESCRIPTION
Without this output we don't get progress, we don't get error
messages about not being authenticated.