### PR TITLE
packit: Use C locale for updating %changelog

### DIFF
--- a/tests/integration/test_spec.py
+++ b/tests/integration/test_spec.py
@@ -44,6 +44,7 @@ def test_write_spec_content():
         spec.spec_content = SpecContent(content)
         spec.write_spec_content()
 
+
 def test_changelog_non_c_locale():
     (fd, specfile) = tempfile.mkstemp(prefix="packittest", suffix=".spec")
     shutil.copyfile(SPECFILE, specfile)


### PR DESCRIPTION
Having the wrong locale running on your machine shouldn't
result in a changelog with foreign characters.

Example of a bad date here:

https://src.fedoraproject.org/rpms/oci-kvm-hook/pull-request/2#request_diff