### PR TITLE
Fix Click's default value for SRPM

### DIFF
--- a/packit/cli/types.py
+++ b/packit/cli/types.py
@@ -46,6 +46,9 @@ class LocalProjectParameter(click.ParamType):
         self.branch_param_name = branch_param_name
 
     def convert(self, value, param, ctx):
+        if isinstance(value, LocalProject):
+            return value
+
         try:
             branch_name = None
             if self.branch_param_name:


### PR DESCRIPTION
It appears that with latest release of click, the default value ($PWD)
is already converted to `LocalProject`, in case it is a `LocalProject`
object, just return it back from the `convert` method.

Fixes #1237

Signed-off-by: Matej Focko <mfocko@redhat.com>