### PR TITLE
Remove workaround to install requre from git

### DIFF
--- a/files/install-requirements-pip.yaml
+++ b/files/install-requirements-pip.yaml
@@ -13,4 +13,3 @@
         - sandcastle
         - requre
       become: true
-    - include_tasks: tasks/requre.yaml

--- a/files/install-requirements-rpms.yaml
+++ b/files/install-requirements-rpms.yaml
@@ -11,4 +11,3 @@
       dnf:
         name: python3-requre
       become: true
-    - include_tasks: tasks/requre.yaml

--- a/plans/session-recording.fmf
+++ b/plans/session-recording.fmf
@@ -4,11 +4,6 @@ discover:
   filter: tier:2
 execute:
   how: tmt
-prepare:
-  # woraround until new requre will be shipped
-  how: shell
-  script: pip3 install git+https://github.com/packit/requre
-  order: 99
 adjust:
   when: "distro <= rhel-8 or distro <= centos-8"
   prepare:


### PR DESCRIPTION
Let's merge it after new requre (>0.9.0) will land as fedora package
