### PR TITLE
Use packit config  as place to  create reference to tests

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,15 +1,9 @@
 ---
-# Don't sync the test files to dist-git, until we figure
-# out how to do it the right way.
-# synced_files:
-#   - src: tests/
-#     dest: tests/
-#   - src: plans/
-#     dest: plans/
-#   - src: .fmf/
-#     dest: .fmf/
-#   - src: tests_recording/
-#     dest: tests_recording/
+synced_files:
+  - src: plans/
+    dest: plans/
+  - src: .fmf/
+    dest: .fmf/
 # packit was already taken on PyPI
 upstream_package_name: packitos
 upstream_project_url: https://github.com/packit/packit
@@ -21,6 +15,9 @@ actions:
     - "sh -c 'echo packitos-$(python3 setup.py --version).tar.gz'"
   get-current-version:
     - "python3 setup.py --version"
+  pre-sync:
+    # FMF  has to be installed on system where you are calling this tool.
+    - python3 plans/git_reference.py
 
 allowed_gpg_keys:
   - 5DE3E0509C47EA3CF04A42D34AEE18F83AFDEB23

--- a/plans/full.fmf
+++ b/plans/full.fmf
@@ -1,6 +1,3 @@
 summary: Unit, integration & functional tests.
-discover:
-  how: fmf
+discover+:
   filter: tier:1
-execute:
-  how: tmt

--- a/plans/git_reference.py
+++ b/plans/git_reference.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+
+import fmf
+from pathlib import Path
+import subprocess
+
+tree_root = Path.cwd().absolute()
+node = fmf.Tree(tree_root).find("/plans")
+with node as data:
+    data["discover"]["url"] = "https://github.com/packit/packit.git"
+    data["discover"]["ref"] = (
+        subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+    )

--- a/plans/main.fmf
+++ b/plans/main.fmf
@@ -1,0 +1,4 @@
+execute:
+    how: tmt
+discover:
+    how: fmf

--- a/plans/session-recording.fmf
+++ b/plans/session-recording.fmf
@@ -1,9 +1,6 @@
 summary: Session recording testcases
-discover:
-  how: fmf
+discover+:
   filter: tier:2
-execute:
-  how: tmt
 prepare:
   # woraround until new requre will be shipped
   how: shell

--- a/plans/smoke.fmf
+++ b/plans/smoke.fmf
@@ -1,6 +1,3 @@
 summary: Basic simple tests
-discover:
-  how: fmf
+discover+:
   filter: tier:0
-execute:
-  how: tmt


### PR DESCRIPTION
It needs to update packit-service image to contain `python3-fmf` package if not already there.