### PR TITLE
patch metadata: add patch_id

### DIFF
--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -489,14 +489,18 @@ class LocalProject:
         self.git_repo.git.add(path, force=force)
 
     def commit(
-        self, message: str, body: Optional[str] = None, allow_empty: bool = True
+        self,
+        message: str,
+        body: Optional[str] = None,
+        allow_empty: bool = True,
+        amend: bool = False,
     ):
         """Commit staged changes"""
         other_message_kwargs = {"message": body} if body else {}
         # some of the commits may be empty and it's not an error,
         # e.g. extra source files
         self.git_repo.git.commit(
-            allow_empty=allow_empty, m=message, **other_message_kwargs
+            allow_empty=allow_empty, m=message, amend=amend, **other_message_kwargs
         )
 
     def get_commits(self, ref: str = "HEAD") -> Iterator[git.Commit]:

--- a/tests/integration/test_source_git_generator.py
+++ b/tests/integration/test_source_git_generator.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 import fileinput
+import re
 import subprocess
 from pathlib import Path
 import yaml
@@ -378,3 +379,4 @@ def test_acl_with_git_git_am(apply_option, api_instance_source_git, tmp_path: Pa
     patch_commit_message = sgg.local_project.git_repo.head.commit.message
     assert "present_in_specfile: true" in patch_commit_message
     assert "patch_name: 0001-acl-2.2.53-test-runwrapper.patch" in patch_commit_message
+    assert re.findall(r"patch_id: \d", patch_commit_message)


### PR DESCRIPTION
TODO:
* [x] tests
* [x] ~~wait for #1244~~ actually it's just a single-hunk conflict and it doesn't really matter who does the rebase
* [x] try init (worked well with rawhide rpm)
* [x] try srpm (dtto)

The ID represents the index within PatchNNNN definition in the spec.

This is being set in `packit init` when cherry-picking patch commits from
dist-git.

We don't allow tampering the patch order. patch_id needs to be higher
than previous patch.