### PR TITLE
source-git update-dist-git --pkg-tool centpkg

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -196,11 +196,11 @@ class PackitAPI:
                 patches, self.package_config.patch_generation_patch_id_digits
             )
 
-        self._handle_sources(
-            add_new_sources=add_new_sources,
-            force_new_sources=force_new_sources,
-            pkg_tool=pkg_tool,
-        )
+        if add_new_sources or force_new_sources:
+            self._handle_sources(
+                force_new_sources=force_new_sources,
+                pkg_tool=pkg_tool,
+            )
 
         if commit_title:
             self.dg.commit(title=commit_title, msg=commit_msg, prefix="")
@@ -494,39 +494,41 @@ class PackitAPI:
 
     def _handle_sources(
         self,
-        add_new_sources: bool,
         force_new_sources: bool,
         pkg_tool: str = "",
     ):
         """Download upstream archive and upload it to dist-git lookaside cache.
 
         Args:
-            add_new_sources: Download and upload source archives.
-            (TODO: why? Can we just not call this method in such case?)
-            force_new_sources: Don't check the lookaside cache and perform new-sources.
-            (TODO: why? the rpkg tool won't upload it anyway if it's already there)
-            pkg_tool: fedpkg or centpkg to upload sources
+            force_new_sources: Download/upload the archive even if it's
+                name is already in the cache or in sources file.
+                Actually, fedpkg/centpkg won't upload it if archive with the same
+                name & hash is already there, so this might be useful only if
+                you want to upload archive with the same name but different hash.
+            pkg_tool: Tool to upload sources.
         """
-        if not (add_new_sources or force_new_sources):
-            return
 
-        make_new_sources = False
         # btw this is really naive: the name could be the same but the hash can be different
         # TODO: we should do something when such situation happens
-        if force_new_sources or not self.dg.is_archive_in_lookaside_cache(
+        archive_name_in_cache = self.dg.is_archive_in_lookaside_cache(
             self.dg.upstream_archive_name
+        )
+        sources_file = self.dg.local_project.working_dir / "sources"
+        archive_name_in_sources_file = (
+            sources_file.is_file()
+            and self.dg.upstream_archive_name in sources_file.read_text()
+        )
+
+        if (
+            archive_name_in_cache
+            and archive_name_in_sources_file
+            and not force_new_sources
         ):
-            make_new_sources = True
-        else:
-            sources_file = self.dg.local_project.working_dir / "sources"
-            if self.dg.upstream_archive_name not in sources_file.read_text():
-                make_new_sources = True
-        if make_new_sources:
-            archive = self.dg.download_upstream_archive()
-            self.init_kerberos_ticket()
-            self.dg.upload_to_lookaside_cache(
-                archive_path=str(archive), pkg_tool=pkg_tool
-            )
+            return
+
+        archive = self.dg.download_upstream_archive()
+        self.init_kerberos_ticket()
+        self.dg.upload_to_lookaside_cache(archive_path=str(archive), pkg_tool=pkg_tool)
 
     def build(
         self,

--- a/packit/api.py
+++ b/packit/api.py
@@ -493,7 +493,10 @@ class PackitAPI:
         )
 
     def _handle_sources(
-        self, add_new_sources: bool, force_new_sources: bool, pkg_tool: str = ""
+        self,
+        add_new_sources: bool,
+        force_new_sources: bool,
+        pkg_tool: str = "",
     ):
         """Download upstream archive and upload it to dist-git lookaside cache.
 
@@ -502,7 +505,7 @@ class PackitAPI:
             (TODO: why? Can we just not call this method in such case?)
             force_new_sources: Don't check the lookaside cache and perform new-sources.
             (TODO: why? the rpkg tool won't upload it anyway if it's already there)
-            pkg_tool: fedpkg or centpkg
+            pkg_tool: fedpkg or centpkg to upload sources
         """
         if not (add_new_sources or force_new_sources):
             return

--- a/packit/api.py
+++ b/packit/api.py
@@ -528,7 +528,7 @@ class PackitAPI:
 
         archive = self.dg.download_upstream_archive()
         self.init_kerberos_ticket()
-        self.dg.upload_to_lookaside_cache(archive_path=str(archive), pkg_tool=pkg_tool)
+        self.dg.upload_to_lookaside_cache(archive=archive, pkg_tool=pkg_tool)
 
     def build(
         self,

--- a/packit/cli/update_dist_git.py
+++ b/packit/cli/update_dist_git.py
@@ -30,10 +30,6 @@ from packit.local_project import LocalProject
     help="""Name or path of the packaging tool used to work with
     sources in the dist-git repo. A variant of 'rpkg'.
 
-    Currently the implementation of this option is incomplete and
-    'fedpkg' is used to work with sources, regardless of the value given
-    to this option.
-
     Skip retrieving and uploading source archives to the lookaside cache
     if not specified.
     """,
@@ -82,8 +78,7 @@ def update_dist_git(
 
     The source archives are retrieved from the upstream URLs specified in
     the spec-file and uploaded to the lookaside cache in dist-git only if
-    '--pkg-tool' is specified. Note that the implementation of this option
-    is incomplete so 'fedpkg' is used, regardless of the value specified.
+    '--pkg-tool' is specified.
 
     Examples:
 
@@ -125,12 +120,11 @@ def update_dist_git(
         version=None,
         upstream_ref=upstream_ref or package_config.upstream_ref,
         # Add new sources if a pkg_tool was specified.
-        # This uses fedpkg for now,
-        # TODO make the pkg_tool used configurable
         add_new_sources=bool(pkg_tool),
         force_new_sources=False,
         upstream_tag=None,
         commit_title=title,
         commit_msg=message,
         sync_default_files=False,
+        pkg_tool=pkg_tool,
     )

--- a/packit/cli/update_dist_git.py
+++ b/packit/cli/update_dist_git.py
@@ -6,6 +6,8 @@ Update a dist-git repo from a source-git repo
 """
 
 import pathlib
+from shutil import which
+
 import click
 
 from typing import Optional
@@ -100,6 +102,10 @@ def update_dist_git(
     """
     if message and file:
         raise click.BadOptionUsage("-m", "Option -m cannot be combined with -F.")
+    if not which(pkg_tool):
+        raise click.BadOptionUsage(
+            "--pkg-tool", f"{pkg_tool} is not executable or in any path"
+        )
     if file:
         with click.open_file(file, "r") as fp:
             message = fp.read()

--- a/packit/config/config.py
+++ b/packit/config/config.py
@@ -27,6 +27,7 @@ import warnings
 from enum import Enum
 from functools import lru_cache, partial
 from pathlib import Path
+from shutil import which
 from typing import Optional, Set
 
 import click
@@ -73,6 +74,8 @@ class Config:
         self.keytab_path: Optional[str] = keytab_path
         self.kerberos_realm = kerberos_realm
         self.koji_build_command = koji_build_command
+        if not which(pkg_tool):
+            raise PackitConfigException(f"{pkg_tool} is not executable or in any path")
         self.pkg_tool: str = pkg_tool
         self.upstream_git_remote = upstream_git_remote
 

--- a/packit/config/config.py
+++ b/packit/config/config.py
@@ -57,7 +57,7 @@ class Config:
         upstream_git_remote: Optional[str] = None,
         kerberos_realm: Optional[str] = "FEDORAPROJECT.ORG",
         koji_build_command: Optional[str] = "koji build",
-        fedpkg_exec: Optional[str] = "fedpkg",
+        pkg_tool: str = "fedpkg",
         command_handler: str = None,
         command_handler_work_dir: str = SANDCASTLE_WORK_DIR,
         command_handler_pvc_env_var: str = SANDCASTLE_PVC,
@@ -73,7 +73,7 @@ class Config:
         self.keytab_path: Optional[str] = keytab_path
         self.kerberos_realm = kerberos_realm
         self.koji_build_command = koji_build_command
-        self.fedpkg_exec = fedpkg_exec
+        self.pkg_tool: str = pkg_tool
         self.upstream_git_remote = upstream_git_remote
 
         self.services: Set[GitService] = set()
@@ -118,7 +118,7 @@ class Config:
             f"keytab_path='{self.keytab_path}', "
             f"kerberos_realm='{self.kerberos_realm}', "
             f"koji_build_command='{self.koji_build_command}', "
-            f"fedpkg_exec='{self.fedpkg_exec}', "
+            f"pkg_tool='{self.pkg_tool}', "
             f"upstream_git_remote='{self.upstream_git_remote}', "
             f"command_handler='{self.command_handler}', "
             f"command_handler_work_dir='{self.command_handler_work_dir}', "

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -40,7 +40,7 @@ from packit.config import (
 )
 from packit.config.common_package_config import CommonPackageConfig
 from packit.exceptions import PackitException, PackitConfigException
-from packit.fedpkg import FedPKG
+from packit.pkgtool import PkgTool
 from packit.local_project import LocalProject
 from packit.utils.commands import cwd
 from packit.utils.repo import clone_fedora_package
@@ -148,12 +148,12 @@ class DistGit(PackitRepositoryBase):
                 )
             else:
                 tmpdir = tempfile.mkdtemp(prefix="packit-dist-git")
-                f = FedPKG(
+                pkg_tool = PkgTool(
                     fas_username=self.fas_user,
                     directory=tmpdir,
-                    fedpkg_exec=self.config.fedpkg_exec,
+                    tool=self.config.pkg_tool,
                 )
-                f.clone(
+                pkg_tool.clone(
                     self.package_config.downstream_package_name,
                     tmpdir,
                     anonymous=not cccolutils.has_creds(),
@@ -349,16 +349,16 @@ class DistGit(PackitRepositoryBase):
             PackitException, if the upload fails.
         """
         logger.info("About to upload to lookaside cache.")
-        f = FedPKG(
+        pkg_tool_ = PkgTool(
             fas_username=self.config.fas_user,
             directory=self.local_project.working_dir,
-            fedpkg_exec=pkg_tool or self.config.fedpkg_exec,
+            tool=pkg_tool or self.config.pkg_tool,
         )
         try:
-            f.new_sources(sources=archive_path)
+            pkg_tool_.new_sources(sources=archive_path)
         except Exception as ex:
             logger.error(
-                f"'{f.fedpkg_exec} new-sources' failed for the following reason: {ex!r}"
+                f"'{pkg_tool_.tool} new-sources' failed for the following reason: {ex!r}"
             )
             raise PackitException(ex)
 
@@ -398,12 +398,12 @@ class DistGit(PackitRepositoryBase):
         :param nowait: don't wait on build?
         :param koji_target: koji target to pick (see `koji list-targets`)
         """
-        fpkg = FedPKG(
+        pkg_tool = PkgTool(
             fas_username=self.fas_user,
             directory=self.local_project.working_dir,
-            fedpkg_exec=self.config.fedpkg_exec,
+            tool=self.config.pkg_tool,
         )
-        fpkg.build(scratch=scratch, nowait=nowait, koji_target=koji_target)
+        pkg_tool.build(scratch=scratch, nowait=nowait, koji_target=koji_target)
 
     def create_bodhi_update(
         self,

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -324,7 +324,7 @@ class DistGit(PackitRepositoryBase):
         """
         Fetch archive for the current upstream release defined in dist-git's spec
 
-        :return: str, path to the archive
+        :return: path to the archive
         """
         with cwd(self.local_project.working_dir):
             self.download_remote_sources()
@@ -340,7 +340,7 @@ class DistGit(PackitRepositoryBase):
         """
         Upload files (archive) to the lookaside cache.
         """
-        # TODO: can we check if the tarball is already uploaded so we don't have ot re-upload?
+        # TODO: can we check if the tarball is already uploaded so we don't have to re-upload?
         logger.info("About to upload to lookaside cache.")
         f = FedPKG(
             fas_username=self.config.fas_user,
@@ -351,7 +351,7 @@ class DistGit(PackitRepositoryBase):
             f.new_sources(sources=archive_path)
         except Exception as ex:
             logger.error(
-                f"The 'fedpkg new-sources' command failed for the following reason: {ex!r}"
+                f"'{f.fedpkg_exec} new-sources' failed for the following reason: {ex!r}"
             )
             raise PackitException(ex)
 

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -336,14 +336,14 @@ class DistGit(PackitRepositoryBase):
         logger.info(f"Downloaded archive: {archive}")
         return archive
 
-    def upload_to_lookaside_cache(self, archive_path: str, pkg_tool: str = "") -> None:
+    def upload_to_lookaside_cache(self, archive: Path, pkg_tool: str = "") -> None:
         """Upload files (archive) to the lookaside cache.
 
         If the archive is already uploaded, the rpkg tool doesn't do anything.
 
         Args:
-            archive_path: Path to archive to upload to lookaside cache.
-            pkg_tool: optional, rpkg tool (fedpkg/centpkg) to use to upload.
+            archive: Path to archive to upload to lookaside cache.
+            pkg_tool: Optional, rpkg tool (fedpkg/centpkg) to use to upload.
 
         Raises:
             PackitException, if the upload fails.
@@ -355,7 +355,7 @@ class DistGit(PackitRepositoryBase):
             tool=pkg_tool or self.config.pkg_tool,
         )
         try:
-            pkg_tool_.new_sources(sources=archive_path)
+            pkg_tool_.new_sources(sources=archive)
         except Exception as ex:
             logger.error(
                 f"'{pkg_tool_.tool} new-sources' failed for the following reason: {ex!r}"

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -336,16 +336,23 @@ class DistGit(PackitRepositoryBase):
         logger.info(f"Downloaded archive: {archive}")
         return archive
 
-    def upload_to_lookaside_cache(self, archive_path: str) -> None:
+    def upload_to_lookaside_cache(self, archive_path: str, pkg_tool: str = "") -> None:
+        """Upload files (archive) to the lookaside cache.
+
+        If the archive is already uploaded, the rpkg tool doesn't do anything.
+
+        Args:
+            archive_path: Path to archive to upload to lookaside cache.
+            pkg_tool: optional, rpkg tool (fedpkg/centpkg) to use to upload.
+
+        Raises:
+            PackitException, if the upload fails.
         """
-        Upload files (archive) to the lookaside cache.
-        """
-        # TODO: can we check if the tarball is already uploaded so we don't have to re-upload?
         logger.info("About to upload to lookaside cache.")
         f = FedPKG(
             fas_username=self.config.fas_user,
             directory=self.local_project.working_dir,
-            fedpkg_exec=self.config.fedpkg_exec,
+            fedpkg_exec=pkg_tool or self.config.fedpkg_exec,
         )
         try:
             f.new_sources(sources=archive_path)

--- a/packit/fedpkg.py
+++ b/packit/fedpkg.py
@@ -31,9 +31,7 @@ from packit.utils.logging import logger
 
 class FedPKG:
     """
-    Part of the code is from release-bot:
-
-    https://github.com/user-cont/release-bot/blob/master/release_bot/fedora.py
+    Wrapper around fedpkg/centpkg which are wrappers around rpkg.
     """
 
     def __init__(

--- a/packit/fedpkg.py
+++ b/packit/fedpkg.py
@@ -56,7 +56,7 @@ class FedPKG:
 
     def new_sources(self, sources="", fail=True):
         if not self.directory.is_dir():
-            raise Exception("Cannot access fedpkg repository:")
+            raise Exception(f"Cannot access {self.fedpkg_exec} repository:")
 
         return commands.run_command_remote(
             cmd=[self.fedpkg_exec, "new-sources", sources],
@@ -107,7 +107,7 @@ class FedPKG:
                 in ex.stderr_output
             ):
                 logger.info(
-                    "The 'fedpkg build' command crashed which is a known issue: "
+                    f"'{self.fedpkg_exec} build' crashed. It is a known issue: "
                     "the build is submitted in koji anyway."
                 )
                 logger.debug(ex.stdout_output)

--- a/packit/pkgtool.py
+++ b/packit/pkgtool.py
@@ -52,12 +52,13 @@ class PkgTool:
             f"tool='{self.tool}')"
         )
 
-    def new_sources(self, sources="", fail=True):
+    def new_sources(self, sources: Optional[Path] = None, fail: bool = True):
         if not self.directory.is_dir():
             raise Exception(f"Cannot access {self.tool} repository: {self.directory}")
 
+        sources_ = str(sources) if sources else ""
         return commands.run_command_remote(
-            cmd=[self.tool, "new-sources", sources],
+            cmd=[self.tool, "new-sources", sources_],
             cwd=self.directory,
             error_message="Adding new sources failed:",
             print_live=True,

--- a/packit/pkgtool.py
+++ b/packit/pkgtool.py
@@ -29,35 +29,35 @@ from packit.utils import commands  # so we can mock utils
 from packit.utils.logging import logger
 
 
-class FedPKG:
+class PkgTool:
     """
-    Wrapper around fedpkg/centpkg which are wrappers around rpkg.
+    Wrapper around fedpkg/centpkg.
     """
 
     def __init__(
         self,
         fas_username: str = None,
         directory: Union[Path, str] = None,
-        fedpkg_exec: str = "fedpkg",
+        tool: str = "fedpkg",
     ):
         self.fas_username = fas_username
         self.directory = Path(directory) if directory else None
-        self.fedpkg_exec = fedpkg_exec
+        self.tool = tool
 
     def __repr__(self):
         return (
-            "FedPKG("
+            "PkgTool("
             f"fas_username='{self.fas_username}', "
             f"directory='{self.directory}', "
-            f"fedpkg_exec='{self.fedpkg_exec}')"
+            f"tool='{self.tool}')"
         )
 
     def new_sources(self, sources="", fail=True):
         if not self.directory.is_dir():
-            raise Exception(f"Cannot access {self.fedpkg_exec} repository:")
+            raise Exception(f"Cannot access {self.tool} repository: {self.directory}")
 
         return commands.run_command_remote(
-            cmd=[self.fedpkg_exec, "new-sources", sources],
+            cmd=[self.tool, "new-sources", sources],
             cwd=self.directory,
             error_message="Adding new sources failed:",
             print_live=True,
@@ -78,9 +78,8 @@ class FedPKG:
         :param nowait: False == wait for the build to finish
         :param koji_target: koji target to build in (`koji list-targets`)
         :param srpm_path: use selected SRPM for build, not dist-git repo & ref
-        :return:
         """
-        cmd = [self.fedpkg_exec, "build"]
+        cmd = [self.tool, "build"]
         if scratch:
             cmd.append("--scratch")
         if nowait:
@@ -105,7 +104,7 @@ class FedPKG:
                 in ex.stderr_output
             ):
                 logger.info(
-                    f"'{self.fedpkg_exec} build' crashed. It is a known issue: "
+                    f"'{self.tool} build' crashed. It is a known issue: "
                     "the build is submitted in koji anyway."
                 )
                 logger.debug(ex.stdout_output)
@@ -118,7 +117,7 @@ class FedPKG:
         clone a dist-git repo; this has to be done in current env
         b/c we don't have the keytab in sandbox
         """
-        cmd = [self.fedpkg_exec]
+        cmd = [self.tool]
         if self.fas_username:
             cmd += ["--user", self.fas_username]
         cmd += ["-q", "clone"]

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -410,7 +410,7 @@ class UserConfigSchema(Schema):
     kerberos_realm = fields.String()
     package_config_path = fields.String(default=None)
     koji_build_command = fields.String()
-    fedpkg_exec = fields.String()
+    pkg_tool = fields.String()
     repository_cache = fields.String(default=None)
     add_repositories_to_repository_cache = fields.Bool(default=True)
 

--- a/packit/source_git.py
+++ b/packit/source_git.py
@@ -439,19 +439,13 @@ class SourceGitGenerator:
 
         sources = []
         for source in LookasideCacheHelper._read_sources(basepath):
-
-            if self.config.fedpkg_exec == "fedpkg":
-                url = "{0}/{1}/{2}/{3}/{4}/{2}".format(
-                    base_url,
-                    package,
-                    source["filename"],
-                    source["hashtype"],
-                    source["hash"],
-                )
-            else:  # centpkg
-                url = "{0}/{1}/{2}/{3}/{2}".format(
-                    base_url, package, source["filename"], source["hash"]
-                )
+            url = "{0}/rpms/{1}/{2}/{3}/{4}/{2}".format(
+                base_url,
+                package,
+                source["filename"],
+                source["hashtype"],
+                source["hash"],
+            )
 
             path = source["filename"]
             sources.append({"path": path, "url": url})

--- a/packit/source_git.py
+++ b/packit/source_git.py
@@ -422,7 +422,7 @@ class SourceGitGenerator:
         self.local_project.stage(self.dist_git.source_git_downstream_suffix)
         self.local_project.commit(message="add downstream distribution sources")
 
-    def _get_lookasisde_sources(self) -> List[Dict[str, str]]:
+    def _get_lookaside_sources(self) -> List[Dict[str, str]]:
         """
         Read "sources" file from the dist-git repo and return a list of dicts
         with path and url to sources stored in the lookaside cache
@@ -436,7 +436,7 @@ class SourceGitGenerator:
         package = self.dist_git.package_config.downstream_package_name
         basepath = self.dist_git.local_project.working_dir
 
-        sources = list()
+        sources = []
         for source in LookasideCacheHelper._read_sources(basepath):
 
             if self.config.fedpkg_exec == "fedpkg":
@@ -546,7 +546,7 @@ class SourceGitGenerator:
         create a source-git repo from upstream
         """
         self._pull_upstream_ref()
-        lookaside_sources = self._get_lookasisde_sources()
+        lookaside_sources = self._get_lookaside_sources()
         self._put_downstream_sources([di["path"] for di in lookaside_sources])
         self._add_packit_config(lookaside_sources)
         if self.dist_git.specfile.get_applied_patches():

--- a/packit/source_git.py
+++ b/packit/source_git.py
@@ -427,8 +427,9 @@ class SourceGitGenerator:
         Read "sources" file from the dist-git repo and return a list of dicts
         with path and url to sources stored in the lookaside cache
         """
+        pkg_tool = "centpkg" if self.centos_package else "fedpkg"
         try:
-            config = LookasideCacheHelper._read_config(self.config.fedpkg_exec)
+            config = LookasideCacheHelper._read_config(pkg_tool)
             base_url = config["lookaside"]
         except (configparser.Error, KeyError) as e:
             raise LookasideCacheError("Failed to read rpkg configuration") from e

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -40,7 +40,7 @@ from packit.base_git import PackitRepositoryBase
 from packit.cli.utils import get_packit_api
 from packit.config import get_local_package_config
 from packit.distgit import DistGit
-from packit.fedpkg import FedPKG
+from packit.pkgtool import PkgTool
 from packit.local_project import LocalProject
 from packit.upstream import Upstream
 from packit.utils.commands import cwd
@@ -172,7 +172,7 @@ def mock_remote_functionality(distgit: Path, upstream: Path):
         if not Path(sources).is_file():
             raise RuntimeError("archive does not exist")
 
-    flexmock(FedPKG, new_sources=mocked_new_sources)
+    flexmock(PkgTool, new_sources=mocked_new_sources)
     flexmock(PackitAPI, init_kerberos_ticket=lambda: None)
     pc = get_local_package_config(str(upstream))
     pc.dist_git_clone_path = str(distgit)

--- a/tests/integration/test_source_git_generator.py
+++ b/tests/integration/test_source_git_generator.py
@@ -139,7 +139,7 @@ def test_create_packit_yaml_sources(api_instance_source_git, tmp_path: Path):
     """
     # requre lookaside_cache_url
     requre_tar_url = (
-        "https://src.fedoraproject.org/repo/pkgs/python-requre/"
+        "https://src.fedoraproject.org/repo/pkgs/rpms/python-requre/"
         "requre-0.4.0.tar.gz/sha512/85293577f56e19dd0fad13bb5e118ac2ab39d7"
         "570d640a754b9d8d8054078c89c949d4695ef018915b17a2f2428f1635032352d"
         "cf3c9a036a2d633013cc35dd9/requre-0.4.0.tar.gz"

--- a/tests/integration/test_source_git_generator.py
+++ b/tests/integration/test_source_git_generator.py
@@ -9,7 +9,7 @@ import yaml
 import pytest
 
 from packit.constants import CENTOS_DOMAIN, CENTOS_STREAM_GITLAB
-from packit.fedpkg import FedPKG
+from packit.pkgtool import PkgTool
 from packit.local_project import LocalProject
 from packit.patches import PatchMetadata
 from packit.source_git import SourceGitGenerator
@@ -107,7 +107,7 @@ def test_create_packit_yaml_upstream_project_url(
     dist_git_ref = "6b27ffacda06289ca2d546e15b3c96845243005f"
     dist_git_path = tmp_path.joinpath(pkg)
     source_git_path = tmp_path.joinpath("requre-sg")
-    FedPKG().clone(pkg, str(dist_git_path), anonymous=True)
+    PkgTool().clone(pkg, str(dist_git_path), anonymous=True)
 
     # check out specific ref
     subprocess.check_call(["git", "reset", "--hard", dist_git_ref], cwd=dist_git_path)
@@ -151,7 +151,7 @@ def test_create_packit_yaml_sources(api_instance_source_git, tmp_path: Path):
     dist_git_ref = "6b27ffacda06289ca2d546e15b3c96845243005f"
     dist_git_path = tmp_path.joinpath(pkg)
     source_git_path = tmp_path.joinpath("requre-sg")
-    FedPKG().clone(pkg, str(dist_git_path), anonymous=True)
+    PkgTool().clone(pkg, str(dist_git_path), anonymous=True)
 
     # check out specific ref
     subprocess.check_call(["git", "reset", "--hard", dist_git_ref], cwd=dist_git_path)
@@ -206,7 +206,7 @@ def test_create_srcgit_requre_clean(api_instance_source_git, tmp_path: Path):
     dist_git_ref = "6b27ffacda06289ca2d546e15b3c96845243005f"
     dist_git_path = tmp_path.joinpath(pkg)
     source_git_path = tmp_path.joinpath("requre-sg")
-    FedPKG().clone(pkg, str(dist_git_path), anonymous=True)
+    PkgTool().clone(pkg, str(dist_git_path), anonymous=True)
     dg_lp = LocalProject(working_dir=dist_git_path)
 
     # check out specific ref
@@ -265,7 +265,7 @@ def test_create_srcgit_requre_populated(api_instance_source_git, tmp_path: Path)
     dist_git_ref = "6b27ffacda06289ca2d546e15b3c96845243005f"
     dist_git_path = tmp_path.joinpath(pkg)
     source_git_path = tmp_path.joinpath("requre-sg")
-    FedPKG().clone(pkg, str(dist_git_path), anonymous=True)
+    PkgTool().clone(pkg, str(dist_git_path), anonymous=True)
     dg_lp = LocalProject(working_dir=dist_git_path)
 
     # check out specific ref

--- a/tests/integration/test_using_cockpit.py
+++ b/tests/integration/test_using_cockpit.py
@@ -32,7 +32,7 @@ from flexmock import flexmock
 from packit.api import PackitAPI
 from packit.config import get_local_package_config
 from packit.distgit import DistGit
-from packit.fedpkg import FedPKG
+from packit.pkgtool import PkgTool
 from packit.local_project import LocalProject
 from packit.utils import repo
 from packit.utils.commands import cwd
@@ -63,7 +63,7 @@ def test_update_on_cockpit_ostree(cockpit_ostree):
         if not Path(sources).is_file():
             raise RuntimeError("archive does not exist")
 
-    flexmock(FedPKG, new_sources=mocked_new_sources)
+    flexmock(PkgTool, new_sources=mocked_new_sources)
     flexmock(PackitAPI, init_kerberos_ticket=lambda: None)
 
     flexmock(

--- a/tests/integration/test_using_cockpit.py
+++ b/tests/integration/test_using_cockpit.py
@@ -70,7 +70,7 @@ def test_update_on_cockpit_ostree(cockpit_ostree):
         DistGit,
         push_to_fork=lambda *args, **kwargs: None,
         is_archive_in_lookaside_cache=lambda archive_path: False,
-        upload_to_lookaside_cache=lambda path: None,
+        upload_to_lookaside_cache=lambda archive_path, pkg_tool: None,
         download_upstream_archive=lambda: "the-archive",
     )
     flexmock(

--- a/tests/integration/test_using_cockpit.py
+++ b/tests/integration/test_using_cockpit.py
@@ -70,7 +70,7 @@ def test_update_on_cockpit_ostree(cockpit_ostree):
         DistGit,
         push_to_fork=lambda *args, **kwargs: None,
         is_archive_in_lookaside_cache=lambda archive_path: False,
-        upload_to_lookaside_cache=lambda archive_path, pkg_tool: None,
+        upload_to_lookaside_cache=lambda archive, pkg_tool: None,
         download_upstream_archive=lambda: "the-archive",
     )
     flexmock(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -187,6 +187,7 @@ def test_get_user_config(tmp_path):
         "kerberos_realm: STG.FEDORAPROJECT.ORG\n"
         "github_token: GITHUB_TOKEN\n"
         "pagure_user_token: PAGURE_TOKEN\n"
+        "pkg_tool: fedpkg-stage\n"
     )
     flexmock(os).should_receive("getenv").with_args("XDG_CONFIG_HOME").and_return(
         str(tmp_path)
@@ -196,6 +197,7 @@ def test_get_user_config(tmp_path):
     assert config.fas_user == "rambo"
     assert config.keytab_path == "./rambo.keytab"
     assert config.kerberos_realm == "STG.FEDORAPROJECT.ORG"
+    assert config.pkg_tool == "fedpkg-stage"
 
     assert GithubService(token="GITHUB_TOKEN") in config.services
     assert PagureService(token="PAGURE_TOKEN") in config.services

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -187,7 +187,6 @@ def test_get_user_config(tmp_path):
         "kerberos_realm: STG.FEDORAPROJECT.ORG\n"
         "github_token: GITHUB_TOKEN\n"
         "pagure_user_token: PAGURE_TOKEN\n"
-        "pkg_tool: fedpkg-stage\n"
     )
     flexmock(os).should_receive("getenv").with_args("XDG_CONFIG_HOME").and_return(
         str(tmp_path)
@@ -197,7 +196,7 @@ def test_get_user_config(tmp_path):
     assert config.fas_user == "rambo"
     assert config.keytab_path == "./rambo.keytab"
     assert config.kerberos_realm == "STG.FEDORAPROJECT.ORG"
-    assert config.pkg_tool == "fedpkg-stage"
+    assert config.pkg_tool == "fedpkg"
 
     assert GithubService(token="GITHUB_TOKEN") in config.services
     assert PagureService(token="PAGURE_TOKEN") in config.services

--- a/tests_recording/test_api.py
+++ b/tests_recording/test_api.py
@@ -50,7 +50,7 @@ from requre.modules_decorate_all_methods import (
 )
 @apply_decorator_to_all_methods(
     replace_module_match(
-        what="packit.fedpkg.FedPKG.clone",
+        what="packit.rpkg.PkgTool.clone",
         decorate=StoreFiles.where_arg_references(
             key_position_params_dict={"target_path": 2}
         ),

--- a/tests_recording/test_status.py
+++ b/tests_recording/test_status.py
@@ -48,7 +48,7 @@ from tests_recording.testbase import PackitTest
 )
 @apply_decorator_to_all_methods(
     replace_module_match(
-        what="packit.fedpkg.FedPKG.clone",
+        what="packit.rpkg.PkgTool.clone",
         decorate=StoreFiles.where_arg_references(
             key_position_params_dict={"target_path": 2}
         ),


### PR DESCRIPTION
Previously `--pkg-tool centpkg` of the `source-git update-dist-git` command ran `fedpkg` tool to upload an archive to the lookaside cache. Now it really uses `centpkg` tool.
Fixes #1232 

`source-git init --centos-package` now reads configuration from `/etc/rpkg/centpkg.conf` instead of from `/etc/rpkg/fedpkg.conf`.

`FedPKG` class has been renamed to `PkgTool` as it now supports both `fedpkg` and `centpkg`.

- [ ] Fix packit-service tests