### PR TITLE
Change 'pkg_tool not in path' exception to a warning

### DIFF
--- a/packit/config/config.py
+++ b/packit/config/config.py
@@ -75,7 +75,7 @@ class Config:
         self.kerberos_realm = kerberos_realm
         self.koji_build_command = koji_build_command
         if not which(pkg_tool):
-            raise PackitConfigException(f"{pkg_tool} is not executable or in any path")
+            logger.warning(f"{pkg_tool} is not executable or in any path")
         self.pkg_tool: str = pkg_tool
         self.upstream_git_remote = upstream_git_remote
 


### PR DESCRIPTION
In packit-service, we inherit `ServiceConfig` (`packit-service.yaml`) from `Config` and use it in worker and service and in `stg` `packit-service.yaml` we have
```yaml
pkg_tool: fedpkg-stage
```
but we don't have it installed in the service image (only in worker).
So this can't be an exception, just a warning.