### PR TITLE
patches,git_am: make patch order consistent + fixes for cpython 3.9 source-git

### DIFF
--- a/packit/patches.py
+++ b/packit/patches.py
@@ -453,6 +453,8 @@ class PatchGenerator:
             except StopIteration:
                 break
 
+        # we need to reverse it back to be consistent with the order
+        new_patch_list.reverse()
         return new_patch_list
 
     @staticmethod

--- a/tests/integration/test_source_git.py
+++ b/tests/integration/test_source_git.py
@@ -490,11 +490,6 @@ def test_srpm_git_am(mock_remote_functionality_sourcegit, api_instance_source_gi
     sg_path = Path(api_instance_source_git.upstream_local_project.working_dir)
     mock_spec_download_remote_s(sg_path, sg_path / DISTRO_DIR, "0.1.0")
 
-    api_instance_source_git.up.specfile.spec_content.section("%package")[10:10] = (
-        "Patch1: citra.patch",
-        "Patch2: malt.patch",
-        "Patch8: 0001-m04r-malt.patch",
-    )
     autosetup_line = api_instance_source_git.up.specfile.spec_content.section("%prep")[
         0
     ]

--- a/tests/integration/test_source_git.py
+++ b/tests/integration/test_source_git.py
@@ -21,6 +21,7 @@ from tests.spellbook import (
     create_patch_mixed_history,
     create_history_with_empty_commit,
     run_prep_for_srpm,
+    create_history_with_patch_ids,
 )
 
 
@@ -713,3 +714,33 @@ def test_add_patch_first_id_1(api_instance_source_git):
     spec.add_patch(good_patch1)
 
     assert spec.get_applied_patches()[0].index == 1
+
+
+def test_srpm_add_patch_with_ids(
+    mock_remote_functionality_sourcegit, api_instance_source_git
+):
+    ref = "0.1.0"
+    sg_path = Path(api_instance_source_git.upstream_local_project.working_dir)
+    mock_spec_download_remote_s(sg_path, sg_path / DISTRO_DIR, ref)
+
+    create_history_with_patch_ids(sg_path)
+
+    with cwd(sg_path):
+        api_instance_source_git.create_srpm(upstream_ref=ref)
+
+    srpm_path = list(sg_path.glob("beer-0.1.0-2.*.src.rpm"))[0]
+    assert srpm_path.is_file()
+    build_srpm(srpm_path)
+
+    assert {x.name for x in sg_path.joinpath(DISTRO_DIR).glob("*.patch")} == {
+        "amarillo.patch",
+        "citra.patch",
+        "malt.patch",
+    }
+    applied_patches = api_instance_source_git.up.specfile.get_applied_patches()
+    assert Path(applied_patches[0].path).name == "amarillo.patch"
+    assert applied_patches[0].index == 3
+    assert Path(applied_patches[1].path).name == "citra.patch"
+    assert applied_patches[1].index == 4
+    assert Path(applied_patches[2].path).name == "malt.patch"
+    assert applied_patches[2].index == 100

--- a/tests/spellbook.py
+++ b/tests/spellbook.py
@@ -210,14 +210,14 @@ def create_git_am_style_history(sg: Path):
 
     hops.write_text("Citra\n")
     meta = PatchMetadata(
-        name="citra.patch", squash_commits=True, present_in_specfile=True
+        name="citra.patch", squash_commits=True, present_in_specfile=False, patch_id=10
     )
     git_add_and_commit(directory=sg, message=meta.commit_message)
 
     malt = sg.joinpath("malt")
     malt.write_text("Munich\n")
     meta = PatchMetadata(
-        name="malt.patch", squash_commits=True, present_in_specfile=True
+        name="malt.patch", squash_commits=True, present_in_specfile=False
     )
     git_add_and_commit(directory=sg, message=meta.commit_message)
 
@@ -229,7 +229,10 @@ def create_git_am_style_history(sg: Path):
 
     malt.write_text("Weyermann\n")
     meta = PatchMetadata(
-        name="0001-m04r-malt.patch", squash_commits=True, present_in_specfile=True
+        name="0001-m04r-malt.patch",
+        squash_commits=True,
+        present_in_specfile=False,
+        patch_id=100,
     )
     git_add_and_commit(directory=sg, message=meta.commit_message)
 

--- a/tests/spellbook.py
+++ b/tests/spellbook.py
@@ -261,6 +261,27 @@ def create_patch_mixed_history(sg: Path):
     git_add_and_commit(directory=sg, message=meta.commit_message)
 
 
+def create_history_with_patch_ids(sg: Path):
+    """
+    create a git history where patch_ids are set
+
+    :param sg: the repo
+    """
+    hops = sg.joinpath("hops")
+    hops.write_text("Amarillo\n")
+    meta = PatchMetadata(name="amarillo.patch", present_in_specfile=False, patch_id=3)
+    git_add_and_commit(directory=sg, message=meta.commit_message)
+
+    hops.write_text("Citra\n")
+    meta = PatchMetadata(name="citra.patch", present_in_specfile=False)
+    git_add_and_commit(directory=sg, message=meta.commit_message)
+
+    malt = sg.joinpath("malt")
+    malt.write_text("Munich\n")
+    meta = PatchMetadata(name="malt.patch", present_in_specfile=False, patch_id=100)
+    git_add_and_commit(directory=sg, message=meta.commit_message)
+
+
 def create_history_with_empty_commit(sg: Path):
     """
     create a git history with an empty commit


### PR DESCRIPTION
source-git repo: https://github.com/TomasTomecek/cpython/tree/39-sg
dist-git: git@gitlab.com:redhat/centos-stream/rpms/python3.9.git (c9s)

more details in the commit messages

Edit:
How to test?

1. Clone both repos above

2. drop patch definitions from the dist-git spec file

3. `packit -c ./.distro/source-git.yaml update-dist-git $SOURCE_GIT_PATH $DIST_GIT_PATH`

The issue:
```
$ packit -c ./.distro/source-git.yaml update-dist-git $SOURCE_GIT_PATH $DIST_GIT_PATH

...

2021-05-31 14:37:26.535 specfile.py       DEBUG  There are no patches in the spec.
2021-05-31 14:37:26.536 specfile.py       DEBUG  Adding patch 00353-architecture-names-upstream-downstream.patch to the spec file.
2021-05-31 14:37:26.536 specfile.py       VERBOSE Writing SPEC file '/home/tt/p/c/r/python3.9/python3.9.spec' to the disc
Traceback (most recent call last):
  File "/home/tt/.local/bin//packit", line 33, in <module>
    sys.exit(load_entry_point('packitos', 'console_scripts', 'packit')())
  File "/usr/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/click/decorators.py", line 73, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/tt/g/user-cont/packit/packit/cli/update_dist_git.py", line 125, in update_dist_git
    api.update_dist_git(
  File "/home/tt/g/user-cont/packit/packit/api.py", line 195, in update_dist_git
    self.dg.specfile_add_patches(
  File "/home/tt/g/user-cont/packit/packit/base_git.py", line 317, in specfile_add_patches
    self.specfile.set_patches(patch_list, patch_id_digits)
  File "/home/tt/g/rebase-helper/rebase-helper/rebasehelper/specfile.py", line 109, in wrapper
    func(spec, *args, **kwargs)
  File "/home/tt/g/user-cont/packit/packit/specfile.py", line 168, in set_patches
    self.add_patch(patch_metadata, patch_id_digits)
  File "/home/tt/g/user-cont/packit/packit/specfile.py", line 192, in add_patch
    raise PackitException(
packit.exceptions.PackitException: The 'patch_id' requested (328) for patch 00328-pyc-timestamp-invalidation-mode.patch is less than or equal to the last used patch ID (353). Re-ordering the patches using 'patch_id' is not allowed - if you want to change the order of those patches, please reorder the commits in your source-git repository.
```

Because `process_git_am_style_patches` changes order of the patches in the list, the IDs suddenly stop "making sense" and we'll get this exception even though patch IDs of the commits are sane (but because the order is reversed because of process_git_am_style_patches, we are getting such exception).