### PR TITLE
fix passing changelog from source-git repo to dist-git

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -373,7 +373,7 @@ class PackitAPI:
             # no downstream spec file: this is either a mistake or
             # there is no spec file in dist-git yet, hence warning
             logger.warning(
-                f"There is not spec file downstream: {ex}, copying the one from upstream."
+                f"Unable to find a spec file in downstream: {ex}, copying the one from upstream."
             )
             shutil.copy2(
                 self.up.absolute_specfile_path,

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -359,14 +359,12 @@ class PackitRepositoryBase:
         :param version: version to set in self.specfile
         :param comment: new comment for the version in %changelog
         """
-        this_changelog = self.specfile.spec_content.section("%changelog")
-        this_version = self.specfile.get_version()
+        provided_changelog = specfile.spec_content.section("%changelog")
         self.specfile.spec_content.sections[:] = specfile.spec_content.sections[:]
-        self.specfile.save()
-        self.specfile.spec_content.replace_section("%changelog", this_changelog)
-        self.specfile.set_version(this_version)
+        self.specfile.spec_content.replace_section("%changelog", provided_changelog)
         self.specfile.save()
         self.specfile.set_spec_version(version=version, changelog_entry=comment)
+        self.specfile.save()
 
     def refresh_specfile(self):
         self._specfile = None

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -431,6 +431,12 @@ class Upstream(PackitRepositoryBase):
         # ambiguous argument '0.1.0..HEAD': unknown revision or path not in the working tree.
         # Use '--' to separate paths from revisions, like this
         commits_range = f"{after}..{before}" if after else before
+        if not before:
+            raise PackitException(
+                "Unable to get a list of commit messages in range "
+                f"{commits_range} because the upper bound is not "
+                f"defined ({before!r})."
+            )
         cmd = [
             "git",
             "log",

--- a/tests/data/sourcegit/source_git/.distro/beer.spec
+++ b/tests/data/sourcegit/source_git/.distro/beer.spec
@@ -20,3 +20,6 @@ BuildArch:      noarch
 %changelog
 * Mon Feb 25 2019 Tomas Tomecek <ttomecek@redhat.com> - 0.1.0-1
 - Initial brewing
+
+* Sun Feb 24 2019 Tomas Tomecek <ttomecek@redhat.com> - 0.0.0-1
+- No brewing, yet.

--- a/tests/data/sourcegit/source_git/.packit.yaml
+++ b/tests/data/sourcegit/source_git/.packit.yaml
@@ -8,6 +8,7 @@ patch_generation_ignore_paths: ["ignored_file.txt"]
 upstream_package_name: beerware
 downstream_package_name: beer
 create_pr: false
+sync_changelog: true
 jobs:
   - job: propose_downstream
     trigger: release

--- a/tests/data/upstream_git/beer.spec
+++ b/tests/data/upstream_git/beer.spec
@@ -20,3 +20,6 @@ BuildArch:      noarch
 %changelog
 * Mon Feb 25 2019 Tomas Tomecek <ttomecek@redhat.com> - 0.1.0-1
 - Initial brewing
+
+* Sun Feb 24 2019 Tomas Tomecek <ttomecek@redhat.com> - 0.0.0-1
+- No brewing, yet.

--- a/tests/integration/test_source_git.py
+++ b/tests/integration/test_source_git.py
@@ -146,10 +146,7 @@ Source0:        %{upstream_name}-%{version}.tar.gz
 
     assert (
         """ - 0.1.0-1
-+- commit with data (Packit Test Suite)
-+- empty commit #2 (Packit Test Suite)
-+- empty commit #1 (Packit Test Suite)
-+- empty commit #0 (Packit Test Suite)
++- Initial brewing
 +
  * Sun Feb 24 2019 Tomas Tomecek <ttomecek@redhat.com> - 0.0.0-1
  - No brewing, yet."""


### PR DESCRIPTION
TODO:
- [x] rebase
- [x] get a consensus how upstream_tag should work
- [x] make sure copying %changelog works correctly for python3.9 source-git
- [x] create a test case for `set_specfile_content`
- [x] docs: make sure people know how to update changelog based on our docs https://github.com/packit/packit.dev/pull/294

This PR fixes passing %changelog to dist-git when sync_changelog=True for propose-downstream and update-dist-git.