### PR TITLE
Explicitly require git & rpm-build 

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -29,12 +29,6 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(setuptools-scm)
 BuildRequires:  python3dist(setuptools-scm-git-archive)
 BuildRequires:  python3-bodhi-client
-# new-sources
-Requires:       fedpkg
-# Copying files between repositories
-Requires:       rsync
-# bumpspec
-Requires:       rpmdevtools
 Requires:       python3-%{real_name} = %{version}-%{release}
 
 %description
@@ -43,6 +37,12 @@ projects into Fedora operating system.
 
 %package -n     python3-%{real_name}
 Summary:        %{summary}
+# new-sources
+Requires:       fedpkg
+# Copying files between repositories
+Requires:       rsync
+# bumpspec
+Requires:       rpmdevtools
 # See setup.cfg for details
 Requires:       python3-koji
 %{?python_provide:%python_provide python3-%{real_name}}

--- a/packit.spec
+++ b/packit.spec
@@ -37,6 +37,9 @@ projects into Fedora operating system.
 
 %package -n     python3-%{real_name}
 Summary:        %{summary}
+Requires:       git
+# rpmbuild
+Requires:       rpm-build
 # new-sources
 Requires:       fedpkg
 # Copying files between repositories

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,9 +53,8 @@ install_requires =
     # Python's pkg_resources doesn't recognize it, because it doesn't have egg-info.
     # Consequently packit fails with:
     # pkg_resources.DistributionNotFound: The 'koji' distribution was not found and is required by packitos
-    # It was supposed to be fixed with https://bugzilla.redhat.com/show_bug.cgi?id=1750391
-    # but the real culprit is https://pagure.io/koji/issue/912 (fixed upstream)
-    # Should be fixed (and uncommented here) once koji > 1.24.1 lands in Fedora.
+    # Fixed upstream https://pagure.io/koji/issue/912
+    # But not downstream (yet) https://bugzilla.redhat.com/show_bug.cgi?id=1968618
     # koji
 python_requires = >=3.6
 include_package_data = True


### PR DESCRIPTION
We call [git](https://github.com/packit/packit/blob/389fa266e9aac6e8acac16e42f7b90a64c5c475e/packit/patches.py#L296) and [rpmbuild](https://github.com/packit/packit/blob/389fa266e9aac6e8acac16e42f7b90a64c5c475e/packit/source_git.py#L372) directly.

Fixes #1193