### PR TITLE
Make __version__ work

### DIFF
--- a/packit/__init__.py
+++ b/packit/__init__.py
@@ -23,7 +23,7 @@
 from pkg_resources import get_distribution, DistributionNotFound
 
 try:
-    __version__ = get_distribution(__name__).version
+    __version__ = get_distribution("packitos").version
 except DistributionNotFound:
     # package is not installed
     pass


### PR DESCRIPTION
The package/distribution is 'packitos', while `__name__` is 'packit'.