### PR TITLE
Uncomment koji requires in setup.cfg

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -46,8 +46,10 @@ Requires:       fedpkg
 Requires:       rsync
 # bumpspec
 Requires:       rpmdevtools
-# See setup.cfg for details
+%if 0%{?rhel}
+# rhbz#1968618 still not fixed for epel-8
 Requires:       python3-koji
+%endif
 %{?python_provide:%python_provide python3-%{real_name}}
 
 %description -n python3-%{real_name}
@@ -59,6 +61,11 @@ check out packit package for the executable.
 %autosetup -n %{pypi_name}-%{version}
 # Remove bundled egg-info
 rm -rf %{pypi_name}.egg-info
+
+%if 0%{?rhel}
+# rhbz#1968618 still not fixed for epel-8
+sed -i -e 's|koji|# koji|' setup.cfg
+%endif
 
 %build
 %py3_build

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,13 +49,7 @@ install_requires =
     setuptools
     tabulate
     bodhi-client
-    # Packit installed from rpm pulls in python3-koji as dependency, but
-    # Python's pkg_resources doesn't recognize it, because it doesn't have egg-info.
-    # Consequently packit fails with:
-    # pkg_resources.DistributionNotFound: The 'koji' distribution was not found and is required by packitos
-    # Fixed upstream https://pagure.io/koji/issue/912
-    # But not downstream (yet) https://bugzilla.redhat.com/show_bug.cgi?id=1968618
-    # koji
+    koji
 python_requires = >=3.6
 include_package_data = True
 setup_requires =


### PR DESCRIPTION
[rhbz#1968618](https://bugzilla.redhat.com/show_bug.cgi?id=1968618) has been fixed in fedora, i.e. the `python3-koji` RPM package now provides egg-info, so we can have `koji` as a requirement in `setup.cfg` and don't have to explicitly require it in the spec file.

It however hasn't been fixed in epel-8, so we need to have a workaround in the spec for that case.