### PR TITLE
Add .distro/source-git.yaml to CONFIG_FILE_NAMES

### DIFF
--- a/packit/constants.py
+++ b/packit/constants.py
@@ -3,7 +3,12 @@
 
 DG_PR_COMMENT_KEY_SG_PR = "Source-git pull request ID"
 DG_PR_COMMENT_KEY_SG_COMMIT = "Source-git commit"
+
+# we store downstream content in source-git in this subdir
+DISTRO_DIR = ".distro"
+SRC_GIT_CONFIG = "source-git.yaml"
 CONFIG_FILE_NAMES = [
+    f"{DISTRO_DIR}/{SRC_GIT_CONFIG}",
     ".packit.yaml",
     ".packit.yml",
     ".packit.json",

--- a/tests/integration/test_source_git.py
+++ b/tests/integration/test_source_git.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from packit.constants import DISTRO_DIR
 from packit.exceptions import PackitException
 from packit.patches import PatchGenerator, PatchMetadata
 from packit.specfile import Specfile
@@ -23,9 +24,6 @@ from tests.spellbook import (
     run_prep_for_srpm,
     create_history_with_patch_ids,
 )
-
-
-DISTRO_DIR = ".distro"
 
 
 def test_basic_local_update_without_patching(

--- a/tests/integration/test_source_git_init.py
+++ b/tests/integration/test_source_git_init.py
@@ -7,6 +7,7 @@ import yaml
 
 from pathlib import Path
 
+from packit.constants import SRC_GIT_CONFIG, DISTRO_DIR
 from packit.exceptions import PackitException
 from packit.source_git import SourceGitGenerator
 from packit.pkgtool import PkgTool
@@ -104,7 +105,7 @@ def check_source_git_config(source_git_config):
     assert source_git_config["upstream_ref"] == HELLO_RELEASE
     assert source_git_config["downstream_package_name"] == "hello"
     assert source_git_config["specfile_path"] == ".distro/hello.spec"
-    assert source_git_config["patch_generation_ignore_paths"] == [".distro"]
+    assert source_git_config["patch_generation_ignore_paths"] == [DISTRO_DIR]
     assert source_git_config["sync_changelog"] is True
     assert source_git_config["synced_files"] == [
         {
@@ -114,7 +115,7 @@ def check_source_git_config(source_git_config):
             "filters": [
                 "protect .git*",
                 "protect sources",
-                "exclude source-git.yaml",
+                f"exclude {SRC_GIT_CONFIG}",
                 "exclude .gitignore",
             ],
         }
@@ -147,9 +148,7 @@ def test_create_from_upstream_no_patch(hello_source_git_repo, hello_dist_git_rep
     )
     sgg.create_from_upstream()
     source_git_config = yaml.safe_load(
-        Path(
-            hello_source_git_repo.working_dir, ".distro", "source-git.yaml"
-        ).read_text()
+        Path(hello_source_git_repo.working_dir, DISTRO_DIR, SRC_GIT_CONFIG).read_text()
     )
     check_source_git_config(source_git_config)
     assert source_git_config["patch_generation_patch_id_digits"] == 1
@@ -171,22 +170,20 @@ def test_create_from_upstream_with_patch(hello_source_git_repo, hello_dist_git_r
     )
     sgg.create_from_upstream()
     source_git_config = yaml.safe_load(
-        Path(
-            hello_source_git_repo.working_dir, ".distro", "source-git.yaml"
-        ).read_text()
+        Path(hello_source_git_repo.working_dir, DISTRO_DIR, SRC_GIT_CONFIG).read_text()
     )
     check_source_git_config(source_git_config)
     assert source_git_config["patch_generation_patch_id_digits"] == 0
 
     assert (
-        Path(hello_source_git_repo.working_dir, ".distro", ".gitignore").read_text()
+        Path(hello_source_git_repo.working_dir, DISTRO_DIR, ".gitignore").read_text()
         == """\
 # Reset gitignore rules
 !*
 """
     )
-    assert not Path(hello_source_git_repo.working_dir, ".distro", "sources").exists()
-    assert not Path(hello_source_git_repo.working_dir, ".distro", ".git").exists()
+    assert not Path(hello_source_git_repo.working_dir, DISTRO_DIR, "sources").exists()
+    assert not Path(hello_source_git_repo.working_dir, DISTRO_DIR, ".git").exists()
 
     assert (
         "Hello Fedora"

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -25,6 +25,7 @@ from packit.config.package_config import (
 )
 import packit.config.package_config
 from packit.config.sources import SourcesItem
+from packit.constants import CONFIG_FILE_NAMES
 from packit.schema import PackageConfigSchema
 from packit.sync import SyncFilesItem
 from tests.spellbook import UP_OSBUILD, SYNC_FILES
@@ -1121,7 +1122,7 @@ def test_get_local_specfile_path():
 @pytest.mark.parametrize(
     "directory, local_first,local_last,config_file_name,res_pc_path",
     [
-        ([], False, True, None, Path.cwd() / ".packit.yaml"),
+        ([], False, True, None, Path.cwd() / CONFIG_FILE_NAMES[0]),
         ([], False, False, "different_conf.yaml", "different_conf.yaml"),
     ],
 )


### PR DESCRIPTION
so you don't have to add '-c path-to-sg-repo/.distro/source-git.yaml' each time you use 'packit source-git update-dist-git' or 'packit srpm' in a "new" source-git repo.

Also, have constants for '.distro' & 'source-git.yaml'.