### PR TITLE
Make it possible to clone from staging dist-git with DistGit.clone()

### DIFF
--- a/packit/pkgtool.py
+++ b/packit/pkgtool.py
@@ -111,7 +111,13 @@ class PkgTool:
             else:
                 raise
 
-    def clone(self, package_name: str, target_path: str, anonymous: bool = False):
+    def clone(
+        self,
+        package_name: str,
+        target_path: Union[Path, str],
+        branch: str = None,
+        anonymous: bool = False,
+    ):
         """
         clone a dist-git repo; this has to be done in current env
         b/c we don't have the keytab in sandbox
@@ -120,12 +126,14 @@ class PkgTool:
         if self.fas_username:
             cmd += ["--user", self.fas_username]
         cmd += ["-q", "clone"]
+        if branch:
+            cmd += ["--branch", branch]
         if anonymous:
-            cmd += ["-a"]
-        cmd += [package_name, target_path]
+            cmd += ["--anonymous"]
+        cmd += [package_name, str(target_path)]
 
         error_msg = (
-            f"Packit failed to clone the repository {package_name}; "
+            f"{self.tool} failed to clone repository {package_name}; "
             "please make sure that you are authorized to clone repositories "
             "from Fedora dist-git - this may require SSH keys set up or "
             "Kerberos ticket being active."

--- a/packit/utils/repo.py
+++ b/packit/utils/repo.py
@@ -3,17 +3,15 @@
 
 import logging
 import re
+import subprocess
 import tempfile
 from pathlib import Path
 from typing import Tuple, Optional, Union, List
 
 import git
 import yaml
-import subprocess
+
 from ogr.parsing import RepoUrl, parse_git_repo
-
-from packit.utils.commands import run_command
-
 from packit.exceptions import PackitException
 
 logger = logging.getLogger(__name__)
@@ -198,28 +196,6 @@ def get_current_version_command(
         "--match",
         glob_pattern,
     ]
-
-
-def clone_fedora_package(
-    package_name: str,
-    dist_git_path: Path,
-    branch: str = None,
-    namespace: str = "rpms",
-    stg: bool = False,
-):
-    """
-    clone selected package from Fedora's src.fedoraproject.org
-    """
-    command = [
-        "git",
-        "clone",
-        f"https://src{'.stg' if stg else ''}.fedoraproject.org/{namespace}/{package_name}.git",
-        str(dist_git_path),
-    ]
-    if branch:
-        command += ["-b", branch]
-
-    run_command(command)
 
 
 def create_new_repo(cwd: Path, switches: List[str]):


### PR DESCRIPTION
One just has to add `pkg_tool: fedpkg-stage` to the packit config.

This PR/commit moves `packit.utils.clone_fedora_package()` to `DistGit.clone_package()` and rewrites it so that it uses configured `PkgTool`.

Initially, I was about to remove the `DistGit.clone()` and `clone_fedora_package()` as they are unused (I think they should have been removed in 5fe352684), when I spotted #1282 where @Zlopez initially [tried to use the `DistGit.clone()`](https://github.com/packit/packit/issues/1282#issuecomment-878198105), but ended up using `clone_fedora_package()` because [one can't clone from staging dist-git with DistGit.clone()](https://github.com/packit/packit/issues/1282#issuecomment-878851226).