### PR TITLE
Specfile path in config file

### DIFF
--- a/packit/cli/init.py
+++ b/packit/cli/init.py
@@ -35,6 +35,7 @@ from packit.cli.types import LocalProjectParameter
 from packit.cli.utils import cover_packit_exception
 from packit.config import get_context_settings
 from packit.config.config import pass_config
+from packit.config.package_config import get_local_specfile_path
 from packit.constants import CONFIG_FILE_NAMES, PACKIT_CONFIG_TEMPLATE
 from packit.exceptions import PackitException
 
@@ -71,9 +72,15 @@ def init(
         # Use default name
         config_path = working_dir / ".packit.yaml"
 
+    specfile_path = get_local_specfile_path(working_dir)
     template_data = {
         "upstream_package_name": path_or_url.repo_name,
         "downstream_package_name": path_or_url.repo_name,
+        "specfile_path": (
+            specfile_path
+            if specfile_path is not None
+            else f"{path_or_url.repo_name}.spec"
+        ),
     }
 
     generate_config(
@@ -101,12 +108,14 @@ def generate_config(
     {
         "upstream_package_name": "packitos",
         "downstream_package_name": "packit",
+        "specfile_path": packit.spec,
     }
     :return: str, generated config
     """
     output_config = PACKIT_CONFIG_TEMPLATE.format(
         downstream_package_name=template_data["downstream_package_name"],
         upstream_package_name=template_data["upstream_package_name"],
+        specfile_path=template_data["specfile_path"],
     )
 
     if write_to_file:

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -337,6 +337,7 @@ def get_package_config_from_repo(
             f"Cannot load package config {config_file_name!r}. {ex}"
         )
     if not spec_file_path:
+        logger.warning(f"Spec file path is not specified in {config_file_name}.")
         spec_file_path = get_specfile_path_from_repo(project=project, ref=ref)
 
     return parse_loaded_config(

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -57,11 +57,11 @@ COPR2GITHUB_STATE = {
 PACKIT_CONFIG_TEMPLATE = """# See the documentation for more information:
 # https://packit.dev/docs/configuration/
 
-specfile_path: {downstream_package_name}.spec
+specfile_path: {specfile_path}
 
 # add or remove files that should be synced
 synced_files:
-    - {downstream_package_name}.spec
+    - {specfile_path}
     - .packit.yaml
 
 # name in upstream package repository/registry (e.g. in PyPI)

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -22,3 +22,23 @@ def test_init_fail(cwd_upstream_or_distgit):
     result = call_packit(parameters=["init"], working_dir=str(cwd_upstream_or_distgit))
 
     assert result.exit_code == 2  # packit config already exists --force needed
+
+
+def test_init_search_for_specfile_root(upstream_without_config):
+    with cwd(upstream_without_config):
+        (upstream_without_config / "file.spec").touch()
+        call_packit(parameters=["init"])
+
+        with open(upstream_without_config / ".packit.yaml") as f:
+            assert "\nspecfile_path: file.spec\n" in f.read()
+
+
+def test_init_search_for_specfile_recursive(upstream_without_config):
+    with cwd(upstream_without_config):
+        nested_path = upstream_without_config / "awesome_directory" / "nested"
+        nested_path.mkdir(parents=True, exist_ok=True)
+        (nested_path / "pickle.spec").touch()
+        call_packit(parameters=["init"])
+
+        with open(upstream_without_config / ".packit.yaml") as f:
+            assert "\nspecfile_path: awesome_directory/nested/pickle.spec\n" in f.read()


### PR DESCRIPTION
According to #1028 

- User gets warning when specfile path is not specified in config file.
- `packit init` looks up the specfile path (recursively if needed) and sets it in `.packit.yaml` 

note: I am not sure if my changes are backwards compatible.