### PR TITLE
Log a warning when %prep is not using (auto)setup

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -429,9 +429,9 @@ class Upstream(PackitRepositoryBase):
             if m:
                 break
         else:
-            logger.error(
-                "This package is not using %(auto)setup macro in prep, "
-                "packit can't work in this environment."
+            logger.warning(
+                "This package is not using %(auto)setup macro in prep. "
+                "Packit will not update the %prep section."
             )
             return
 


### PR DESCRIPTION
Instead of logging an error...

This should be the better thing to do, especially b/c the code doesn't
treat this case as a real error. It just won't update the %prep section.

This change should get rid of the events in Sentry raised when packages
use %forgesetup in their %prep section.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>