### PR TITLE
Don't use str.removeprefix()

### DIFF
--- a/packit/specfile.py
+++ b/packit/specfile.py
@@ -265,7 +265,7 @@ class Specfile(SpecFile):
                 comment = []
             # Remember a comment line.
             if line.startswith("#"):
-                comment.append(line.removeprefix("#").strip())
+                comment.append(line[1:].strip())
             # Associate comments with patches and clear the comments
             # collected.
             if line.lower().startswith("patch"):


### PR DESCRIPTION
This string method got introduced only in Python 3.9. Not all
installations have this version.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>