### PR TITLE
api.sync_release: Log when the PR already exists

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -337,12 +337,17 @@ class PackitAPI:
             if create_pr:
                 title = title or f"Update to upstream release {version}"
 
-                if not self.dg.pr_exists(title, description.rstrip(), dist_git_branch):
+                existing_pr = self.dg.existing_pr(
+                    title, description.rstrip(), dist_git_branch
+                )
+                if not existing_pr:
                     new_pr = self.push_and_create_pr(
                         pr_title=title,
                         pr_description=description,
                         dist_git_branch=dist_git_branch,
                     )
+                else:
+                    logger.debug(f"PR already exists: {existing_pr.url}")
             else:
                 self.dg.push(refspec=f"HEAD:{dist_git_branch}")
         finally:

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -472,13 +472,15 @@ class DistGit(PackitRepositoryBase):
             return self.downstream_config.allowed_gpg_keys
         return None
 
-    def pr_exists(self, title: str, description: str, branch: str):
+    def existing_pr(
+        self, title: str, description: str, branch: str
+    ) -> Optional[PullRequest]:
         distgit_prs = self.local_project.git_project.get_pr_list()
-        return any(
-            (
+        for pr in distgit_prs:
+            if (
                 pr.title == title
                 and pr.description == description
                 and pr.target_branch == branch
-            )
-            for pr in distgit_prs
-        )
+            ):
+                return pr
+        return None

--- a/tests/unit/test_dg.py
+++ b/tests/unit/test_dg.py
@@ -53,7 +53,7 @@ from packit.local_project import LocalProject
         ),
     ],
 )
-def test_pr_exists(title, description, branch, prs, exists):
+def test_existing_pr(title, description, branch, prs, exists):
     local_project = LocalProject(
         git_project=flexmock(service="something", get_pr_list=lambda: prs),
         refresh=False,
@@ -63,4 +63,8 @@ def test_pr_exists(title, description, branch, prs, exists):
         package_config=flexmock(PackageConfig()),
         local_project=local_project,
     )
-    assert distgit.pr_exists(title, description, branch) == exists
+    pr = distgit.existing_pr(title, description, branch)
+    if exists:
+        assert pr is not None
+    else:
+        assert pr is None


### PR DESCRIPTION
otherwise, it's hard to tell from logs why the changes were not pushed and no PR has been created.

---
N/A