### PR TITLE
tests: Fix checking the version of 'rpm'

### DIFF
--- a/tests/integration/test_spec.py
+++ b/tests/integration/test_spec.py
@@ -35,7 +35,7 @@ def test_add_patch(specfile, patch_id_digits):
 
     Change the number of digits, too, to see that it's considered.
     """
-    if list(map(int, rpm.__version__.split("."))) < [4, 16] and patch_id_digits == 0:
+    if rpm.__version__ < "4.16" and patch_id_digits == 0:
         pytest.xfail(
             "Versions before RPM 4.16 have incorrect patch indexing "
             "when an index is not explicitly defined. "


### PR DESCRIPTION
The version numbers of 'rpm' are not always just numbers. A 'beta' might
show up here and there, for example, which will make the int conversion
fail.

In order to fix this, use simple string comparison to tell if the
current installed version of 'rpm' is lower than '4.16'.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>