### PR TITLE
Merge into base branch when checking out PRs

### DIFF
--- a/packit/exceptions.py
+++ b/packit/exceptions.py
@@ -90,6 +90,10 @@ class PackitSRPMException(PackitException):
     """Problem with the SRPM"""
 
 
+class PackitMergeException(PackitException):
+    """Failed to merge PR into base branch"""
+
+
 class PackitSRPMNotFoundException(PackitSRPMException):
     """SRPM created but not found"""
 

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -33,7 +33,13 @@ from ogr.abstract import GitProject, GitService
 from ogr.parsing import parse_git_repo
 
 from packit.exceptions import PackitException, PackitMergeException
-from packit.utils.repo import RepositoryCache, is_git_repo, get_repo, is_a_git_ref
+from packit.utils.repo import (
+    RepositoryCache,
+    is_git_repo,
+    get_repo,
+    is_a_git_ref,
+    shorten_commit_hash,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -171,9 +177,9 @@ class LocalProject:
         :return: first 8 characters of the current commit
         """
         if self.git_repo.head.is_detached:
-            return self.git_repo.head.commit.hexsha[:8]
+            return shorten_commit_hash(self.git_repo.head.commit.hexsha)
         else:
-            return self.git_repo.active_branch.commit.hexsha[:8]
+            return shorten_commit_hash(self.git_repo.active_branch.commit.hexsha)
 
     def clean(self):
         if self.working_dir_temporary:
@@ -475,10 +481,10 @@ class LocalProject:
 
         self._fetch_as_branch(remote_ref, local_ref, local_branch)
 
-        commit_sha = str(self.git_repo.head.commit)[:7]
+        head_commit = self.git_repo.branches[local_branch].commit
         logger.info(
             f"Checked out commit\n"
-            f"({commit_sha})\t{self.git_repo.head.commit.summary}"
+            f"({shorten_commit_hash(head_commit.hexsha)})\t{head_commit.summary}"
         )
 
     def merge_pr(self, pr_id: Union[str, int]) -> None:
@@ -505,7 +511,7 @@ class LocalProject:
         self.git_repo.branches[local_target_branch].checkout()
         target_branch = self.git_repo.branches[local_target_branch]
 
-        commit_sha = str(target_branch.commit)[:7]
+        commit_sha = shorten_commit_hash(target_branch.commit.hexsha)
         logger.info(
             f"Merging ({pr.target_branch}) with commit:\n"
             f"({commit_sha})\t{target_branch.commit.summary}"

--- a/packit/utils/repo.py
+++ b/packit/utils/repo.py
@@ -314,3 +314,16 @@ def get_metadata_from_message(commit: git.Commit) -> Optional[dict]:
             return loaded_part
 
     return None
+
+
+def shorten_commit_hash(commit_hash: str) -> str:
+    """
+    Shortens commit hash to first 8 characters.
+
+    Args:
+        commit_hash: Commit hash to be shortened.
+
+    Returns:
+        First 8 characters of the commit hash.
+    """
+    return commit_hash[:8]

--- a/tests/integration/test_local_project.py
+++ b/tests/integration/test_local_project.py
@@ -7,6 +7,7 @@ from ogr import GithubService, GitlabService
 from packit.local_project import LocalProject
 from packit.utils.repo import create_new_repo
 
+from flexmock import flexmock
 from tests.spellbook import initiate_git_repo
 
 
@@ -33,12 +34,16 @@ def test_pr_id_and_ref(tmp_path: Path):
     )
     subprocess.check_call(["git", "branch", "-D", local_tmp_branch], cwd=upstream_git)
 
+    git_project = flexmock(repo="random_name", namespace="random_namespace")
+    git_project.should_receive("get_pr").and_return(flexmock(target_branch="main"))
+
     LocalProject(
         working_dir=upstream_git,
         offline=True,
         pr_id=pr_id,
         ref=ref,
         git_service=GithubService(),
+        git_project=git_project,
     )
 
     assert (
@@ -79,12 +84,16 @@ def test_pr_id_and_ref_gitlab(tmp_path: Path):
     )
     subprocess.check_call(["git", "branch", "-D", local_tmp_branch], cwd=upstream_git)
 
+    git_project = flexmock(repo="random_name", namespace="random_namespace")
+    git_project.should_receive("get_pr").and_return(flexmock(target_branch="main"))
+
     LocalProject(
         working_dir=upstream_git,
         offline=True,
         pr_id=pr_id,
         ref=ref,
         git_service=GitlabService(token="12345"),
+        git_project=git_project,
     )
 
     assert (


### PR DESCRIPTION
TODO:

- [X] Ensure it works properly, either in local deployment or on stage
    checked on stage, works OK
- [x] How to handle conflicts? Packit raises an exception, should we reflect it in SRPM status as a unique thing? I am not sure how to handle this thing in general, since the exception message contains list much more information than just failed merge. Also I am not sure about other ways how it could crash apart from _merge conflicts_.
    **«On the other hand, GitHub shows merge conflict too, so failed SRPM status without being specific about merge conflict could be fine, I guess»**
- [X] Specfile updates
    ```
    Wrote: ./hello-0.74-1.20210819144656138822.pr442.base.9.g3138a8b.fc34.src.rpm
    ```
    1. We probably want to get rid of the `base` part, could be done by renaming the branches that are created (changes from PR and the base where the PR is merged)
       **Done**
    2. The hash is taken from the „merge commit“, not sure if we want to move to rebasing instead of merging…
       Not going to get into it, since there is a pretty strange issue regarding rebasing.¹

¹ This [merge request](https://gitlab.com/packit-service/ogr-tests/-/merge_requests/77) can be merged, but I cannot seem to rebase it. My guess is that rebase detects [these changes](https://gitlab.com/packit-service/ogr-tests/-/merge_requests/77/diffs) that **look like** unresolved merge conflicts and thus proclaims merge conflict… Merging doesn't raise this issue, the question is if we would like that kind of behavior from safety perspective, but on the other hand, it is quite generic piece of text that could be included even in tests for some git-related projects… :man_shrugging: 

Fixes packit/packit-service#245

Merge before packit/packit-service#1206

---

<!-- release notes for changelog/blog follow -->

Packit by default locally merges checked out pull requests into target branch. Logging for checking out pull requests was improved to contain hashes and summaries of last commit on both source and target branches.