### PR TITLE
test_add_patch: use only x.y when detecting rpm's version

### DIFF
--- a/tests/integration/test_spec.py
+++ b/tests/integration/test_spec.py
@@ -35,7 +35,7 @@ def test_add_patch(specfile, patch_id_digits):
 
     Change the number of digits, too, to see that it's considered.
     """
-    if list(map(int, rpm.__version__.split("."))) < [4, 16] and patch_id_digits == 0:
+    if list(map(int, rpm.__version_info__[:2])) < [4, 16] and patch_id_digits == 0:
         pytest.xfail(
             "Versions before RPM 4.16 have incorrect patch indexing "
             "when an index is not explicitly defined. "


### PR DESCRIPTION
because the "z" part can contain string "beta" which cannot be turned
into an int: "x" and "y" seem safe

also use __version_info__ which already splits the version string into
a tuple

Signed-off-by: Tomas Tomecek <ttomecek@redhat.com>

---

N/A
