### PR TITLE
Do not log failed merges with error

### DIFF
--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -519,7 +519,7 @@ class LocalProject:
         try:
             self.git_repo.git.merge(f"pr-changes/{pr_id}")
         except GitCommandError as ex:
-            logger.error(f"Merge failed with: {ex}")
+            logger.warning(f"Merge failed with: {ex}")
             if "Merge conflict" in str(ex):
                 raise PackitMergeException(ex)
             raise PackitException(ex)


### PR DESCRIPTION
Logging merge fails with error results in Sentry catching it as an issue. Since
it is a user-facing error, do not log it as an error.

Signed-off-by: Matej Focko <mfocko@redhat.com>
