### PR TITLE
Add entry to specfiles with empty %changelog + don't purge downstream changelog

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -361,7 +361,9 @@ class PackitRepositoryBase:
         """
         previous_changelog = self.specfile.spec_content.section("%changelog")
         self.specfile.spec_content.sections[:] = specfile.spec_content.sections[:]
-        self.specfile.spec_content.replace_section("%changelog", previous_changelog)
+        self.specfile.spec_content.replace_section(
+            "%changelog", previous_changelog or []
+        )
         self.specfile.save()
         self.specfile.set_spec_version(version=version, changelog_entry=comment)
         self.specfile.save()

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -359,9 +359,9 @@ class PackitRepositoryBase:
         :param version: version to set in self.specfile
         :param comment: new comment for the version in %changelog
         """
-        provided_changelog = specfile.spec_content.section("%changelog")
+        previous_changelog = self.specfile.spec_content.section("%changelog")
         self.specfile.spec_content.sections[:] = specfile.spec_content.sections[:]
-        self.specfile.spec_content.replace_section("%changelog", provided_changelog)
+        self.specfile.spec_content.replace_section("%changelog", previous_changelog)
         self.specfile.save()
         self.specfile.set_spec_version(version=version, changelog_entry=comment)
         self.specfile.save()

--- a/packit/specfile.py
+++ b/packit/specfile.py
@@ -80,12 +80,6 @@ class Specfile(SpecFile):
             if not changelog_entry:
                 return
 
-            if not self.spec_content.section("%changelog"):
-                logger.debug(
-                    "The specfile doesn't have any %changelog, will not set it."
-                )
-                return
-
             self.update_changelog_in_spec(changelog_entry)
 
         except RebaseHelperError as ex:


### PR DESCRIPTION
TODO:

- [x] resolve between upstream/downstream specfile for preserving changelog

---

Fixes #1335

Related to #1299

---

<!-- release notes for changelog/blog follow -->

Fixed a bug that caused purging or syncing upstream changelog (when not configured) from specfile when running `propose-downstream`. New behavior preserves downstream changelog and in case there are either no entries or no `%changelog` section present, it is created with a new entry.