### PR TITLE
Do not mount repositorycache when not used

### DIFF
--- a/packit/utils/repo.py
+++ b/packit/utils/repo.py
@@ -35,6 +35,8 @@ class RepositoryCache:
             f"Instantiation of the repository cache at {self.cache_path}. "
             f"New projects will {'not ' if not self.add_new else ''}be added."
         )
+        self.projects_added: List[str] = []
+        self.projects_cloned_using_cache: List[str] = []
 
     @property
     def cached_projects(self) -> List[str]:
@@ -82,9 +84,11 @@ class RepositoryCache:
         if project_name not in cached_projects and self.add_new:
             logger.debug(f"Creating reference repo: {reference_repo}")
             self._clone(url=url, to_path=str(reference_repo), tags=True)
+            self.projects_added.append(project_name)
 
         if self.add_new or project_name in cached_projects:
             logger.debug(f"Using reference repo: {reference_repo}")
+            self.projects_cloned_using_cache.append(project_name)
             return self._clone(
                 url=url, to_path=directory, tags=True, reference=str(reference_repo)
             )

--- a/tests_recording/test_repository_cache.py
+++ b/tests_recording/test_repository_cache.py
@@ -44,12 +44,21 @@ class RepositoryCacheTest(unittest.TestCase):
 
         repo_cache = RepositoryCache(cache_path=cache_path, add_new=True)
         assert repo_cache.cached_projects == []
+        assert repo_cache.projects_added == []
+        assert repo_cache.projects_cloned_using_cache == []
 
         assert repo_cache.get_repo(url=TEST_PROJECT_URL_TO_CLONE, directory=clone1_path)
         assert repo_cache.cached_projects == [TEST_PROJECT_NAME]
+        assert repo_cache.projects_added == [TEST_PROJECT_NAME]
+        assert repo_cache.projects_cloned_using_cache == [TEST_PROJECT_NAME]
 
         assert repo_cache.get_repo(url=TEST_PROJECT_URL_TO_CLONE, directory=clone2_path)
         assert repo_cache.cached_projects == [TEST_PROJECT_NAME]
+        assert repo_cache.projects_added == [TEST_PROJECT_NAME]
+        assert repo_cache.projects_cloned_using_cache == [
+            TEST_PROJECT_NAME,
+            TEST_PROJECT_NAME,
+        ]
 
     def test_repository_cache_do_not_add_new_if_not_enabled(self):
         tmp_path = Path(tempfile.mkdtemp())
@@ -61,9 +70,13 @@ class RepositoryCacheTest(unittest.TestCase):
 
         repo_cache = RepositoryCache(cache_path=cache_path, add_new=False)
         assert repo_cache.cached_projects == []
+        assert repo_cache.projects_added == []
+        assert repo_cache.projects_cloned_using_cache == []
 
         assert repo_cache.get_repo(url=TEST_PROJECT_URL_TO_CLONE, directory=clone_path)
         assert repo_cache.cached_projects == []
+        assert repo_cache.projects_added == []
+        assert repo_cache.projects_cloned_using_cache == []
 
     def test_repository_cache_accept_str(self):
         tmp_path = Path(tempfile.mkdtemp())


### PR DESCRIPTION
We track the usage of repository-cache to be able to know if we need to mount the repository-cache volume to the sandcastle pods.

Fixes packit/packit-service#1181

---

N/A
