### PR TITLE
fmf tests: correctly detect a host running CentOS Stream 8

### DIFF
--- a/plans/session-recording.fmf
+++ b/plans/session-recording.fmf
@@ -2,14 +2,8 @@ summary: Session recording testcases
 discover+:
   filter: tier:2
 adjust:
-  when: "distro <= rhel-8 or distro <= centos-8"
+  when: "distro <= rhel-8 or distro <= centos-8 or distro == centos-stream-8"
   prepare:
     - how: install
-      name: ensure_copr_plugin
-      order: 10
-      package:
-        - dnf-plugins-core
-    - how: shell
-      name: requre_copr
-      order: 20
-      script: 'dnf -y copr enable packit/packit-requre-main'
+      name: Enable the Copr-repo for Requre
+      copr: packit/packit-requre-main


### PR DESCRIPTION
Because 'centos-stream-8 > centos-8', the EPEL tests using recordings
did not have the Copr repo for Requre enabled and so installation of
Requre [failed](http://artifacts.dev.testing-farm.io/2db23bb0-be08-418b-8740-8929d74a5b6a/).

Fix this and also simplify enabling the Copr repo as recommended by
@psss. Docs: https://tmt.readthedocs.io/en/latest/spec/plans.html#install .

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>