### PR TITLE
validate command: check that files to be synced are present

### DIFF
--- a/tests/integration/test_validate_config.py
+++ b/tests/integration/test_validate_config.py
@@ -229,6 +229,9 @@ def test_schema_validation(tmpdir, raw_package_config, expected_output):
     with cwd(tmpdir):
         Path("packit.json").write_text(raw_package_config)
         Path("packit.spec").write_text("hello")
+        Path("a.md").write_text("a")
+        Path("b.md").write_text("b")
+        Path("c.txt").write_text("c")
 
         output = PackitAPI.validate_package_config(Path("."))
         assert expected_output in output

--- a/tests/integration/test_validate_synced_files.py
+++ b/tests/integration/test_validate_synced_files.py
@@ -1,0 +1,88 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+import pytest
+
+from packit.api import PackitAPI
+from packit.utils.commands import cwd
+
+
+@pytest.mark.parametrize(
+    "existing_files,existing_directories,raw_package_config,expected_output",
+    [
+        (
+            ["a.md", "b.md"],
+            ["./a_dir"],
+            """
+            {
+                "config_file_path": "packit.json",
+                "dist_git_base_url": "https://packit.dev/",
+                "downstream_package_name": "packit",
+                "upstream_ref": "last_commit",
+                "upstream_package_name": "packit_upstream",
+                "create_tarball_command": ["commands"],
+                "allowed_gpg_keys": ["gpg"],
+                "dist_git_namespace": "awesome",
+                "synced_files": [{ "src": "a.md", "dest": "aaa.md" }, "a_dir"]
+            }
+            """,
+            "packit.json is valid and ready to be used",
+        ),
+        (
+            ["a.md", "b.md"],
+            ["./a_dir"],
+            """
+            {
+                "config_file_path": "packit.json",
+                "dist_git_base_url": "https://packit.dev/",
+                "downstream_package_name": "packit",
+                "upstream_ref": "last_commit",
+                "upstream_package_name": "packit_upstream",
+                "create_tarball_command": ["commands"],
+                "allowed_gpg_keys": ["gpg"],
+                "dist_git_namespace": "awesome",
+                "synced_files": ["a.md", "b.md", "c.txt", "a_dir"]
+            }
+            """,
+            "The following path is configured to be synced but does not exist: c.txt",
+        ),
+        (
+            ["a.md"],
+            [],
+            """
+             {
+                 "config_file_path": "packit.json",
+                 "dist_git_base_url": "https://packit.dev/",
+                 "downstream_package_name": "packit",
+                 "upstream_ref": "last_commit",
+                 "upstream_package_name": "packit_upstream",
+                 "create_tarball_command": ["commands"],
+                 "allowed_gpg_keys": ["gpg"],
+                 "dist_git_namespace": "awesome",
+                 "synced_files": ["a.md", "b.md", "c.txt"]
+             }
+             """,
+            "The following paths are configured to be synced but do not exist: b.md, c.txt",
+        ),
+    ],
+    ids=[
+        "none_missing",
+        "one_missing",
+        "two_missing",
+    ],
+)
+def test_validate_paths(
+    tmpdir, existing_files, existing_directories, raw_package_config, expected_output
+):
+    with cwd(tmpdir):
+        Path("packit.json").write_text(raw_package_config)
+        Path("packit.spec").write_text("hello")
+        for existing_file in existing_files:
+            Path(existing_file).write_text("")
+        for existing_directory in existing_directories:
+            Path(existing_directory).mkdir()
+
+        output = PackitAPI.validate_package_config(Path("."))
+        assert expected_output in output


### PR DESCRIPTION
Hi all, 

I started working on issue #1333.

I have some doubts:
  1. I checked upstream file existance looking for local files; I believe there is a local cache of the upstream repo, but I am not sure at all.
  2. If there is any config schema error then the upstream file existence is not checked. I am not sure this is enough; maybe do you want them checked even if the schema errors are not related with the synced_files field?
  3. In the integration tests I created, maybe, there is too much copy&paste.

Let me know how I can improve it.

Should fix #1333