### PR TITLE
logging: warn -> debug when not doing kinit

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -974,7 +974,7 @@ class PackitAPI:
             or not self.config.keytab_path
             or not Path(self.config.keytab_path).is_file()
         ):
-            logger.warning("Won't be doing kinit, no credentials provided.")
+            logger.debug("Won't be doing kinit, no credentials provided.")
             return
 
         self._run_kinit()


### PR DESCRIPTION
This is not a warning since in the CI workflow kinit is not needed, only
when interacting with the Fedora infra.

#1378

---

Packit no longer prints a warning when a FAS username is not supplied for sake of getting a Kerberos ticket.