### PR TITLE
Reflect ogr changes in integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,7 +13,8 @@ import git
 import pytest
 from flexmock import flexmock
 from gnupg import GPG
-from ogr.abstract import PullRequest, PRStatus
+from ogr.abstract import PRStatus
+from ogr.read_only import PullRequestReadOnly
 from ogr.services.github import GithubService, GithubProject
 from ogr.services.pagure import PagureProject, PagureService, PagureUser
 
@@ -105,7 +106,7 @@ def mock_spec_download_remote_s(
 
 def mock_remote_functionality(distgit: Path, upstream: Path):
     def mocked_create_pr(*args, **kwargs):
-        return PullRequest(
+        return PullRequestReadOnly(
             title="",
             id=42,
             status=PRStatus.open,

--- a/tests/integration/test_pagure.py
+++ b/tests/integration/test_pagure.py
@@ -67,4 +67,4 @@ def test_basic_distgit_workflow(tmp_path):
 
     pr = fork.create_pr("testing PR", "serious description", "master", branch_name)
 
-    proj.pr_comment(pr.id, "howdy!")
+    pr.comment("howdy!")


### PR DESCRIPTION
I've found just these 2 required changes in packit, the rest of the deprecated methods don't seem to be used anywhere.


Fixes

Related to https://github.com/packit/ogr/pull/652

Merge before/after

---
N/A