### PR TITLE
Handle patch content which has unknown encoding

### DIFF
--- a/packit/patches.py
+++ b/packit/patches.py
@@ -749,7 +749,9 @@ class PatchGenerator:
             # patch-id before the change
             prev_patch = repo.git.show(f"HEAD:{relative_patch_path}")
             prev_patch = git_patch_ish(prev_patch)
-            with tempfile.TemporaryFile(mode="w+") as fp:
+            # We can't know the encoding of the patch.
+            # https://docs.python.org/3/howto/unicode.html#files-in-an-unknown-encoding
+            with tempfile.TemporaryFile(mode="w+", errors="surrogateescape") as fp:
                 fp.write(prev_patch)
                 fp.seek(0)
                 prev_patch_id = repo.git.patch_id("--stable", istream=fp).split()[0]

--- a/tests/data/patches/previous/unified-diff.patch
+++ b/tests/data/patches/previous/unified-diff.patch
@@ -7,6 +7,9 @@ In Fedora we should return only /usr/bin because /bin is just a symlink
 to /usr/bin after MoveToUsr transition (which glibc has not really
 completed).
 
+IMPORTANT: this patch file is saved with 'latin1' encoding and has a
+weird character (ù) in it, for testing purposes.
+
 diff -pruN a/sysdeps/unix/confstr.h b/sysdeps/unix/confstr.h
 --- a/sysdeps/unix/confstr.h	2012-12-25 08:32:13.000000000 +0530
 +++ b/sysdeps/unix/confstr.h	2014-09-05 20:02:55.698275219 +0530


### PR DESCRIPTION
When calculating the patch ID of the patches stored in dist-git, it
might happen, that these patch files are not UTF-8 encoded and this
might rise UnicodeEncodingErrors.

Writing this kind of string with the 'surrogateescape' error handler
solves the issue.

This issue was seen in when running the 'source-git update-dist-git'
command to transform a source-git repo for glibc to the CentOS Stream 9
dist-git repo.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>

---

Fixed an issue, which raised a `UnicodeEncodingError`, when working with dist-git patch files with an encoding other than UTF-8.
