### PR TITLE
Allow job metadata targets to be specified as dict as well

### DIFF
--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -4,7 +4,7 @@
 from copy import deepcopy
 from enum import Enum
 from logging import getLogger
-from typing import List, Set, Dict, Optional, Union
+from typing import List, Set, Dict, Optional, Union, Any
 
 from packit.actions import ActionName
 from packit.config.aliases import DEFAULT_VERSION
@@ -37,7 +37,7 @@ class JobConfigTriggerType(Enum):
 class JobMetadataConfig:
     def __init__(
         self,
-        targets: List[str] = None,
+        _targets: Union[List[str], Dict[str, Dict[str, Any]]] = None,
         timeout: int = 7200,
         owner: str = None,
         project: str = None,
@@ -55,7 +55,10 @@ class JobMetadataConfig:
     ):
         """
         Args:
-            targets: copr_build job, mock chroots where to build
+            _targets: copr_build, mock chroots where to build
+                      tests, builds to test
+                      The _ prefix is used because 'targets' without it
+                      is now used for backward compatibility.
             timeout: copr_build, give up watching a build after timeout, defaults to 7200s
             owner: copr_build, a namespace in COPR where the build should happen
             project: copr_build, a name of the copr project
@@ -66,10 +69,16 @@ class JobMetadataConfig:
             preserve_project: if set, project will not be created as temporary
             additional_packages: buildroot packages for the chroot [DOES NOT WORK YET]
             additional_repos: buildroot additional additional_repos
-            use_internal_tf: if we want to use internal instance for Testing Farm
+            fmf_url: - git repository containing the metadata (FMF) tree
+            fmf_ref: - branch, tag or commit specifying the desired git revision
+            use_internal_tf: if we want to use internal instance of Testing Farm
             skip_build: if we want to skip build phase for Testing Farm job
         """
-        self.targets: Set[str] = set(targets) if targets else set()
+        self._targets: Dict[str, Dict[str, Any]]
+        if isinstance(_targets, list):
+            self._targets = {key: {} for key in _targets}
+        else:
+            self._targets = _targets or {}
         self.timeout: int = timeout
         self.owner: str = owner
         self.project: str = project
@@ -82,15 +91,15 @@ class JobMetadataConfig:
         self.preserve_project: bool = preserve_project
         self.additional_packages: List[str] = additional_packages or []
         self.additional_repos: List[str] = additional_repos or []
-        self.fmf_url = fmf_url
-        self.fmf_ref = fmf_ref
-        self.use_internal_tf = use_internal_tf
-        self.skip_build = skip_build
+        self.fmf_url: str = fmf_url
+        self.fmf_ref: str = fmf_ref
+        self.use_internal_tf: bool = use_internal_tf
+        self.skip_build: bool = skip_build
 
     def __repr__(self):
         return (
             f"JobMetadataConfig("
-            f"targets={self.targets}, "
+            f"targets={self._targets}, "
             f"timeout={self.timeout}, "
             f"owner={self.owner}, "
             f"project={self.project}, "
@@ -113,7 +122,7 @@ class JobMetadataConfig:
                 "Provided object is not a JobMetadataConfig instance."
             )
         return (
-            self.targets == other.targets
+            self._targets == other._targets
             and self.timeout == other.timeout
             and self.owner == other.owner
             and self.project == other.project
@@ -129,6 +138,15 @@ class JobMetadataConfig:
             and self.use_internal_tf == other.use_internal_tf
             and self.skip_build == other.skip_build
         )
+
+    @property
+    def targets_dict(self):
+        return self._targets
+
+    @property
+    def targets(self):
+        """For backward compatibility."""
+        return set(self._targets.keys())
 
 
 class JobConfig(CommonPackageConfig):
@@ -272,12 +290,12 @@ def get_default_jobs() -> List[Dict]:
             {
                 "job": "copr_build",
                 "trigger": "pull_request",
-                "metadata": {"targets": DEFAULT_VERSION},
+                "metadata": {"targets": [DEFAULT_VERSION]},
             },
             {
                 "job": "tests",
                 "trigger": "pull_request",
-                "metadata": {"targets": DEFAULT_VERSION},
+                "metadata": {"targets": [DEFAULT_VERSION]},
             },
             {
                 "job": "propose_downstream",

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -7,6 +7,7 @@ from logging import getLogger
 from typing import List, Set, Dict, Optional, Union
 
 from packit.actions import ActionName
+from packit.config.aliases import DEFAULT_VERSION
 from packit.config.common_package_config import CommonPackageConfig
 from packit.config.notifications import NotificationsConfig
 from packit.config.sources import SourcesItem
@@ -271,12 +272,12 @@ def get_default_jobs() -> List[Dict]:
             {
                 "job": "copr_build",
                 "trigger": "pull_request",
-                "metadata": {"targets": "fedora-stable"},
+                "metadata": {"targets": DEFAULT_VERSION},
             },
             {
                 "job": "tests",
                 "trigger": "pull_request",
-                "metadata": {"targets": "fedora-stable"},
+                "metadata": {"targets": DEFAULT_VERSION},
             },
             {
                 "job": "propose_downstream",

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -33,6 +33,7 @@ from packit.config import (
     JobType,
     JobConfigTriggerType,
 )
+from packit.config.aliases import DEFAULT_VERSION
 from packit.config.job_config import JobMetadataConfig
 from packit.schema import JobConfigSchema
 
@@ -100,13 +101,13 @@ def get_default_job_config(**kwargs):
         JobConfig(
             type=JobType.copr_build,
             trigger=JobConfigTriggerType.pull_request,
-            metadata=JobMetadataConfig(targets=["fedora-stable"]),
+            metadata=JobMetadataConfig(targets=[DEFAULT_VERSION]),
             **kwargs,
         ),
         JobConfig(
             type=JobType.tests,
             trigger=JobConfigTriggerType.pull_request,
-            metadata=JobMetadataConfig(targets=["fedora-stable"]),
+            metadata=JobMetadataConfig(targets=[DEFAULT_VERSION]),
             **kwargs,
         ),
         JobConfig(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,24 +1,5 @@
-# MIT License
-#
-# Copyright (c) 2019 Red Hat, Inc.
-
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
 
 import os
 
@@ -35,7 +16,7 @@ from packit.config import (
 )
 from packit.config.aliases import DEFAULT_VERSION
 from packit.config.job_config import JobMetadataConfig
-from packit.schema import JobConfigSchema
+from packit.schema import JobConfigSchema, JobMetadataSchema
 
 
 def get_job_config_dict_simple(**update):
@@ -101,13 +82,13 @@ def get_default_job_config(**kwargs):
         JobConfig(
             type=JobType.copr_build,
             trigger=JobConfigTriggerType.pull_request,
-            metadata=JobMetadataConfig(targets=[DEFAULT_VERSION]),
+            metadata=JobMetadataConfig(_targets=[DEFAULT_VERSION]),
             **kwargs,
         ),
         JobConfig(
             type=JobType.tests,
             trigger=JobConfigTriggerType.pull_request,
-            metadata=JobMetadataConfig(targets=[DEFAULT_VERSION]),
+            metadata=JobMetadataConfig(_targets=[DEFAULT_VERSION]),
             **kwargs,
         ),
         JobConfig(
@@ -255,3 +236,24 @@ def test_serialize_and_deserialize_job_config(config):
     serialized = schema.dump(config)
     new_config = schema.load(serialized)
     assert new_config == config
+
+
+@pytest.mark.parametrize(
+    "config,is_valid",
+    [
+        ({}, True),
+        ({"targets": []}, True),
+        ({"targets": {}}, True),
+        ({"targets": ["this", "is", "list"]}, True),
+        ({"targets": {"a": {}, "b": {"distros": ["rhel-7"]}}}, True),
+        ({"targets": {"a": {}, "b": {"unknown": ["rhel-7"]}}}, False),
+        ({"targets": {"a": {}, "b": {"distros": "not a list"}}}, False),
+        ({"targets": {"this", "is", "set"}}, False),
+    ],
+)
+def test_job_metadata_targets(config, is_valid):
+    if is_valid:
+        JobMetadataSchema().load(config)
+    else:
+        with pytest.raises(ValidationError):
+            JobMetadataSchema().load(config)


### PR DESCRIPTION
It can still be a `list[str]` to be backward compatible.

But because we need to be able to enrich the targets with some attributes it can now be a `dict` {'targets': {'more info': Any} as well.

The `JobMetadataConfig.targets` is now a property returning a set of target names for backward compatibility.
The dictionary of targets with attributes is stored in `_targets` and you can get it also with `targets_dict` property.

The `_` prefixed `_targets` in `JobMetadataConfig.__init__()` looks strange, but it's needed because of the schema validation.

Related to: packit/packit-service#1230

packit-service tests are expected to fail because of the `targets` -> `_targets` change in `JobMetadataConfig.__init__()`
They will be fixed in packit/packit-service#1269 after merging this.

---

N/A (it's just a change of the job config schema, it's not utilized anywhere yet)
