### PR TITLE
Fix flexmock imports

### DIFF
--- a/tests/integration/test_patches.py
+++ b/tests/integration/test_patches.py
@@ -4,9 +4,9 @@
 import git
 import pytest
 import shutil
-import flexmock
 import textwrap
 
+from flexmock import flexmock
 from pathlib import Path
 from packit.patches import PatchGenerator, PatchMetadata
 from packit.exceptions import PackitException

--- a/tests/integration/test_source_git_init.py
+++ b/tests/integration/test_source_git_init.py
@@ -1,10 +1,10 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-import flexmock
 import pytest
 import yaml
 
+from flexmock import flexmock
 from pathlib import Path
 
 from packit.constants import SRC_GIT_CONFIG, DISTRO_DIR

--- a/tests/integration/test_spec.py
+++ b/tests/integration/test_spec.py
@@ -1,12 +1,12 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-import flexmock
 import pytest
 import textwrap
 import shutil
 import rpm
 
+from flexmock import flexmock
 from pathlib import Path
 
 from packit.specfile import Specfile

--- a/tests/unit/test_patches.py
+++ b/tests/unit/test_patches.py
@@ -1,8 +1,9 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-import flexmock
 import pytest
+
+from flexmock import flexmock
 
 from packit.patches import commit_message, remove_prefixes, PatchMetadata
 


### PR DESCRIPTION
Support for plain 'import flexmock' was removed in [flexmock 0.11.0].
Get ready for this.

[flexmock 0.11.0]: https://flexmock.readthedocs.io/en/latest/changelog/#release-0110

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>
