### PR TITLE
Add environment config option

### DIFF
--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -52,6 +52,7 @@ class JobMetadataConfig:
         fmf_ref: str = None,
         use_internal_tf: bool = False,
         skip_build: bool = False,
+        env: Dict[str, Any] = None,
     ):
         """
         Args:
@@ -73,6 +74,7 @@ class JobMetadataConfig:
             fmf_ref: - branch, tag or commit specifying the desired git revision
             use_internal_tf: if we want to use internal instance of Testing Farm
             skip_build: if we want to skip build phase for Testing Farm job
+            env: environment variables
         """
         self._targets: Dict[str, Dict[str, Any]]
         if isinstance(_targets, list):
@@ -95,6 +97,7 @@ class JobMetadataConfig:
         self.fmf_ref: str = fmf_ref
         self.use_internal_tf: bool = use_internal_tf
         self.skip_build: bool = skip_build
+        self.env: Dict[str, Any] = env or {}
 
     def __repr__(self):
         return (
@@ -113,7 +116,8 @@ class JobMetadataConfig:
             f"fmf_url={self.fmf_url}, "
             f"fmf_ref={self.fmf_ref}, "
             f"use_internal_tf={self.use_internal_tf}, "
-            f"skip_build={self.skip_build})"
+            f"skip_build={self.skip_build},"
+            f"env={self.env})"
         )
 
     def __eq__(self, other: object):
@@ -137,6 +141,7 @@ class JobMetadataConfig:
             and self.fmf_ref == other.fmf_ref
             and self.use_internal_tf == other.use_internal_tf
             and self.skip_build == other.skip_build
+            and self.env == other.env
         )
 
     @property

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -234,6 +234,7 @@ class JobMetadataSchema(Schema):
     fmf_url = fields.String(missing=None)
     fmf_ref = fields.String(missing=None)
     skip_build = fields.Boolean()
+    env = fields.Dict(keys=fields.String(), missing=None)
 
     @pre_load
     def ordered_preprocess(self, data, **_):

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -334,6 +334,25 @@ def test_package_config_not_equal(not_equal_package_config):
         (
             {
                 "specfile_path": "fedora/package.spec",
+                "jobs": [
+                    {
+                        "job": "tests",
+                        "trigger": "pull_request",
+                        "metadata": {
+                            "targets": "fedora-all",
+                            "env": {
+                                "MYVAR1": 5,
+                                "MYVAR2": "foo",
+                            },
+                        },
+                    }
+                ],
+            },
+            True,
+        ),
+        (
+            {
+                "specfile_path": "fedora/package.spec",
                 "synced_files": ["fedora/foobar.spec"],
                 "actions": {
                     "pre-sync": "some/pre-sync/command --option",


### PR DESCRIPTION
Related to https://github.com/packit/packit-service/issues/1217

---
New config option `env` has been added for specifying environment variables.