### PR TITLE
Run post_upstream_clone immediately when updating

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -250,6 +250,7 @@ class PackitAPI:
 
         :return created PullRequest if create_pr is True, else None
         """
+        self.up.run_action(actions=ActionName.post_upstream_clone)
         dist_git_branch = (
             dist_git_branch or self.dg.local_project.git_project.default_branch
         )
@@ -287,7 +288,6 @@ class PackitAPI:
             upstream_ref or self.package_config.upstream_ref
         )
         create_pr = create_pr and self.package_config.create_pr
-        self.up.run_action(actions=ActionName.post_upstream_clone)
 
         current_up_branch = self.up.active_branch
         try:


### PR DESCRIPTION
The specfile may be generated during post_upstream_clone. This means
that getting the version from the spec could fail, hence we always need
to do post_upstream_clone first.

Signed-off-by: František Nečas <fnecas@redhat.com>

@jkonecny12 Would you mind giving this a quick spin? Your reproducer seems to work for me now locally.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #1413