### PR TITLE
Prepare sources

### DIFF
--- a/packit/cli/packit_base.py
+++ b/packit/cli/packit_base.py
@@ -15,6 +15,7 @@ from packit.cli.push_updates import push_updates
 from packit.cli.srpm import srpm
 from packit.cli.status import status
 from packit.cli.sync_from_downstream import sync_from_downstream
+from packit.cli.prepare_sources import prepare_sources
 from packit.cli.propose_downstream import propose_downstream
 from packit.cli.validate_config import validate_config
 from packit.cli.source_git import source_git
@@ -99,6 +100,7 @@ packit_base.add_command(init)
 packit_base.add_command(local_build)
 packit_base.add_command(validate_config)
 packit_base.add_command(source_git)
+packit_base.add_command(prepare_sources)
 
 if __name__ == "__main__":
     packit_base()

--- a/packit/cli/prepare_sources.py
+++ b/packit/cli/prepare_sources.py
@@ -1,0 +1,125 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+import logging
+import os
+from pathlib import Path
+
+import click
+
+from packit.cli.types import LocalProjectParameter
+from packit.cli.utils import cover_packit_exception, get_packit_api
+from packit.config import pass_config, get_context_settings
+from packit.schema import JobConfigSchema
+
+logger = logging.getLogger("packit")
+
+
+def load_job_config(job_config):
+    if job_config:
+        try:
+            return JobConfigSchema().loads(job_config)
+        except Exception as ex:
+            logger.error(f"Loading of JobConfig wasn't successful: {ex}")
+    return None
+
+
+@click.command("prepare-sources", context_settings=get_context_settings())
+@click.option(
+    "--result-dir",
+    metavar="DIR",
+    help="Copy the sources into DIR. By default, `prepare_sources_result` directory "
+    "in the current working directory is created.",
+)
+@click.option(
+    "--upstream-ref",
+    default=None,
+    help="Git ref of the last upstream commit in the current branch "
+    "from which packit should generate patches "
+    "(this option implies the repository is source-git).",
+)
+@click.option(
+    "--bump/--no-bump",
+    default=True,
+    help="Specifies whether to bump version or not.",
+)
+@click.option(
+    "--release-suffix",
+    default=None,
+    type=click.STRING,
+    help="Specifies release suffix. Allows to override default generated:"
+    "{current_time}.{sanitized_current_branch}{git_desc_suffix}",
+)
+@click.option(
+    "--job-config",
+    default=None,
+    type=click.STRING,
+    help="Internal option to override package config found in the repository "
+    "(needed for packit service).",
+)
+@click.option(
+    "--ref",
+    default="",
+    type=click.STRING,
+    help="Git reference to checkout.",
+)
+@click.option(
+    "--pr-id",
+    default=None,
+    type=click.STRING,
+    help="Specifies PR to checkout.",
+)
+@click.option(
+    "--merge-pr/--no-merge-pr",
+    is_flag=True,
+    default=True,
+    help="Specifies whether to merge PR into the base branch in case pr-id is specified.",
+)
+@click.argument(
+    "path_or_url",
+    type=LocalProjectParameter(
+        ref_param_name="ref",
+        pr_id_param_name="pr_id",
+        merge_pr_param_name="merge_pr",
+    ),
+    default=os.path.curdir,
+)
+@pass_config
+@cover_packit_exception
+def prepare_sources(
+    config,
+    path_or_url,
+    job_config,
+    upstream_ref,
+    bump,
+    release_suffix,
+    result_dir,
+    ref,
+    pr_id,
+    merge_pr,
+):
+    """
+    Prepare sources for a new SRPM build using content of the upstream repository.
+    Determine version, create an archive or download upstream and create patches for sourcegit,
+    fix/update the specfile to use the right archive, download the remote sources.
+    Behaviour can be customized by specifying actions (post-upstream-clone, get-current-version,
+    create-archive, create-patches, fix-spec-file) in the configuration.
+
+    PATH_OR_URL argument is a local path or a URL to the upstream git repository,
+    it defaults to the current working directory
+    """
+    job_config = load_job_config(job_config)
+
+    if not result_dir:
+        result_dir = Path.cwd().joinpath("prepare_sources_result")
+        logger.debug(f"Setting result_dir to the default one: {result_dir}")
+
+    api = get_packit_api(
+        config=config, local_project=path_or_url, job_config=job_config
+    )
+
+    api.prepare_sources(
+        upstream_ref=upstream_ref,
+        bump_version=bump,
+        release_suffix=release_suffix,
+        result_dir=result_dir,
+    )

--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -11,6 +11,7 @@ import click
 from github import GithubException
 
 from ogr.parsing import parse_git_repo
+from packit.config.common_package_config import CommonPackageConfig
 from packit.config.package_config import PackageConfig
 
 from packit.api import PackitAPI
@@ -91,11 +92,14 @@ def get_packit_api(
     local_project: LocalProject,
     dist_git_path: str = None,
     load_packit_yaml: bool = True,
+    job_config: Optional[CommonPackageConfig] = None,
 ) -> PackitAPI:
     """
     Load the package config, set other options and return the PackitAPI
     """
-    if load_packit_yaml:
+    if job_config:
+        package_config = job_config
+    elif load_packit_yaml:
         package_config = get_local_package_config(
             local_project.working_dir,
             repo_name=local_project.repo_name,

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -109,6 +109,7 @@ class LocalProject:
             f"remote: {remote}\n"
             f"pr_id: {pr_id}\n"
             f"cache: {cache}\n"
+            f"merge_pr: {merge_pr}\n"
         )
 
         if refresh:

--- a/tests/functional/test_prepare_sources.py
+++ b/tests/functional/test_prepare_sources.py
@@ -1,0 +1,42 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+"""
+Functional tests for prepare-sources command
+"""
+from pathlib import Path
+
+from packit.utils.commands import cwd
+from tests.functional.spellbook import call_real_packit
+
+
+def test_prepare_sources_command_for_path(upstream_or_distgit_path, tmp_path):
+    with cwd(tmp_path):
+        call_real_packit(
+            parameters=[
+                "--debug",
+                "prepare-sources",
+                "--result-dir",
+                Path.cwd(),
+                str(upstream_or_distgit_path),
+            ]
+        )
+
+        tarball_path = list(Path.cwd().glob("*.tar.gz"))[0]
+        assert tarball_path.exists()
+        specfile_path = list(Path.cwd().glob("*.spec"))[0]
+        assert specfile_path.exists()
+
+
+def test_prepare_sources_command(cwd_upstream_or_distgit):
+    call_real_packit(
+        parameters=["--debug", "prepare-sources"],
+        cwd=cwd_upstream_or_distgit,
+    )
+    result_dir = cwd_upstream_or_distgit.joinpath("prepare_sources_result")
+    assert result_dir.exists()
+
+    tarball_path = list(result_dir.glob("*.tar.gz"))[0]
+    assert tarball_path.exists()
+    specfile_path = list(result_dir.glob("*.spec"))[0]
+    assert specfile_path.exists()

--- a/tests/unit/test_prepare_sources.py
+++ b/tests/unit/test_prepare_sources.py
@@ -1,0 +1,41 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+from packit.cli.prepare_sources import load_job_config
+from packit.config import JobConfig, JobType, JobConfigTriggerType
+from packit.config.job_config import JobMetadataConfig
+
+
+@pytest.mark.parametrize(
+    "raw_job_config,expected",
+    [
+        pytest.param(
+            '{"upstream_package_name": null, "downstream_package_name": null, '
+            '"archive_root_dir_template": "{upstream_pkg_name}-{version}", '
+            '"patch_generation_ignore_paths": [], "dist_git_namespace": "rpms", "actions": {}, '
+            '"upstream_project_url": null, "sources": [], "create_pr": true, "merge_pr_in_ci": '
+            'true, "job": "copr_build", "upstream_ref": null, "upstream_tag_template": '
+            '"{version}", "config_file_path": null, "synced_files": [], "sync_changelog": false,'
+            ' "patch_generation_patch_id_digits": 4, "metadata": {"preserve_project": false, '
+            '"branch": null, "additional_repos": [], "env": {}, "additional_packages": [], '
+            '"skip_build": false, "scratch": false, "targets": {}, "fmf_url": null, "fmf_ref":'
+            ' null, "owner": null, "use_internal_tf": false, "list_on_homepage": false, '
+            '"project": "example1", "dist_git_branches": [], "timeout": 7200}, '
+            '"notifications": {"pull_request": {"successful_build": false}}, '
+            '"copy_upstream_release_description": false, "specfile_path": null, '
+            '"dist_git_base_url": "https://src.fedoraproject.org/", "trigger": "release", '
+            '"spec_source_id": "Source0", "allowed_gpg_keys": null}',
+            JobConfig(
+                type=JobType.copr_build,
+                trigger=JobConfigTriggerType.release,
+                metadata=JobMetadataConfig(project="example1"),
+            ),
+            id="valid",
+        ),
+        pytest.param('{"config_file_path": null}', None, id="invalid"),
+    ],
+)
+def test_load_job_config(raw_job_config, expected):
+    assert load_job_config(raw_job_config) == expected


### PR DESCRIPTION
TODO:

- [x] agree on the CLI interface:
```
packit prepare-sources --help
Usage: packit prepare-sources [OPTIONS] [PATH_OR_URL]

  Prepare sources for a new SRPM build using content of the upstream
  repository. Determine version, create an archive or download upstream and
  create patches for sourcegit, fix/update the specfile to use the right
  archive, download the remote sources. Behaviour can be customized by
  specifying actions (post-upstream-clone, get-current-version, create-
  archive, create-patches, fix-spec-file) in the configuration.

  PATH_OR_URL argument is a local path or a URL to the upstream git
  repository, it defaults to the current working directory

Options:
  --result-dir DIR            Copy the sources into DIR. By default,
                              `prepare_sources_result` directory in the
                              current working directory is created.

  --upstream-ref TEXT         Git ref of the last upstream commit in the
                              current branch from which packit should generate
                              patches (this option implies the repository is
                              source-git).

  --bump / --no-bump          Specifies whether to bump version or not.
  --release-suffix TEXT       Specifies release suffix. Allows to override
                              default generated:{current_time}.{sanitized_curr
                              ent_branch}{git_desc_suffix}

  --ref TEXT                  Git reference to checkout.
  --pr-id TEXT                Specifies PR to checkout.
  --merge-pr / --no-merge-pr  Specifies whether to merge PR into the base
                              branch in case pr-id is specified.

  -h, --help                  Show this message and exit.

```
- [x] discuss copying of the sources, how to make it better
- [x] more tests
- [ ] make sure `branch_param_name` is not used anywhere

The additional parameters are added based on [what needs to be passed from packit service](https://github.com/packit/packit-service/blob/ebb661702ac8417c95067c0b92e726809d63cd08/packit_service/worker/build/build_helper.py#L86)

Fixes #1409 



---
TBD
