### PR TITLE
Introduce PackitMissingConfigException class

### DIFF
--- a/packit/exceptions.py
+++ b/packit/exceptions.py
@@ -36,6 +36,10 @@ class PackitConfigException(PackitException):
     pass
 
 
+class PackitMissingConfigException(PackitConfigException):
+    pass
+
+
 class PackitCoprException(PackitException):
     pass
 


### PR DESCRIPTION
This is to differentiate between missing config file and bad config file in packit-service more easily.


Related to [packit-service#1296](https://github.com/packit/packit-service/pull/1296)

