### PR TITLE
Tell user that git repository is cloning

### DIFF
--- a/packit/utils/repo.py
+++ b/packit/utils/repo.py
@@ -114,7 +114,7 @@ def get_repo(url: str, directory: Union[Path, str] = None) -> git.Repo:
         logger.debug(f"Repo already exists in {directory}.")
         repo = git.repo.Repo(directory)
     else:
-        logger.debug(f"Cloning repo {url} -> {directory}")
+        logger.info(f"Cloning repo {url} -> {directory}")
         repo = git.repo.Repo.clone_from(url=url, to_path=directory, tags=True)
 
     return repo


### PR DESCRIPTION
This information is especially helpful for bigger repositories.

State without this fix is that the user will run propose-downstream command and
waiting without any feedback. User could be easily confused that the application
is frozen.

Closes https://github.com/packit/packit/issues/1412 .