### PR TITLE
Prevent use of slashes in upstream_package_name

### DIFF
--- a/packit/constants.py
+++ b/packit/constants.py
@@ -66,7 +66,7 @@ synced_files:
     - {specfile_path}
     - .packit.yaml
 
-# name in upstream package repository/registry (e.g. in PyPI)
+# name in upstream package repository or registry (e.g. in PyPI)
 upstream_package_name: {upstream_package_name}
 # downstream (Fedora) RPM package name
 downstream_package_name: {downstream_package_name}

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -257,6 +257,16 @@ class JobMetadataSchema(Schema):
         return JobMetadataConfig(**data)
 
 
+def validate_repo_name(value):
+    """
+    marshmallow validation for a repository name. Any
+    filename is acceptable: No slash, no zero char.
+    """
+    if not all(c not in "/\0" for c in value):
+        raise ValidationError("Repository name must be a valid filename.")
+    return True
+
+
 class CommonConfigSchema(Schema):
     """
     Common methods for JobConfigSchema and PackageConfigSchema
@@ -266,7 +276,7 @@ class CommonConfigSchema(Schema):
     specfile_path = fields.String(missing=None)
     downstream_package_name = fields.String(missing=None)
     upstream_project_url = fields.String(missing=None)
-    upstream_package_name = fields.String(missing=None)
+    upstream_package_name = fields.String(missing=None, validate=validate_repo_name)
     upstream_ref = fields.String(missing=None)
     upstream_tag_template = fields.String()
     archive_root_dir_template = fields.String()

--- a/tests/integration/test_validate_config.py
+++ b/tests/integration/test_validate_config.py
@@ -166,6 +166,20 @@ from packit.utils.commands import cwd
                 """,
             "* field allowed_gpg_keys: Not a valid list.",
         ),
+        (
+            """
+                {
+                    "config_file_path": "packit.json",
+                    "dist_git_base_url": "https: //packit.dev/",
+                    "downstream_package_name": "packit",
+                    "upstream_ref": "last_commit",
+                    "upstream_package_name": "packit/upstream",
+                    "allowed_gpg_keys": ["gpg"],
+                    "dist_git_namespace": "awesome"
+                }
+                """,
+            " Repository name must be a valid filename.",
+        ),
     ],
     ids=[
         "valid_1",
@@ -179,6 +193,7 @@ from packit.utils.commands import cwd
         "create_pr",
         "valid_4",
         "allowed_gpg",
+        "slash_in_package_name",
     ],
 )
 def test_schema_validation(tmpdir, raw_package_config, expected_output):


### PR DESCRIPTION
Check for invalid chars in .packit.yaml upstream_package_name
    
Since `upstream_package_name` is used as a filename, it may not
have characters illegal in filenames: The slash char, and null char.
Check for these and throw a `ValidationError` when used.

Change comment suggesting '/' in `.packit.yaml` `upstream_package_name`
    
This comment suggests people use a package name containing a project/repo
syntax with a slash in it. In fact using a slash in the name causes
packit to fail.
    
Fixes #1432
