### PR TITLE
Use upstream_git_tag when searching for a release

### DIFF
--- a/packit/utils/changelog_helper.py
+++ b/packit/utils/changelog_helper.py
@@ -45,11 +45,13 @@ class ChangelogHelper:
 
         Args:
             full_version: Version to be set in the spec-file.
-            upstream_tag: The commit message of this commit is going to be used
+            upstream_tag: The commit messages after last tag and before this tag are used
                 to update the changelog in the spec-file.
         """
         comment = self.entry_from_action or (
-            self.up.local_project.git_project.get_release(name=full_version).body
+            self.up.local_project.git_project.get_release(
+                tag_name=upstream_tag, name=full_version
+            ).body
             if self.package_config.copy_upstream_release_description
             else self.up.get_commit_messages(
                 after=self.up.get_last_tag(upstream_tag), before=upstream_tag

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -111,7 +111,9 @@ def test_basic_local_update_copy_upstream_release_description(
     mock_spec_download_remote_s(d)
     flexmock(api).should_receive("init_kerberos_ticket").at_least().once()
     release = flexmock(body="Some description of the upstream release")
-    api.up.local_project.git_project = flexmock(get_release=lambda name: release)
+    api.up.local_project.git_project = flexmock(
+        get_release=lambda name, tag_name: release
+    )
     api.package_config.copy_upstream_release_description = True
     api.sync_release(dist_git_branch="main", version="0.1.0")
 


### PR DESCRIPTION
This allows finding the correct release even when users don't use the version as a release name.

Example of the problematic release: https://github.com/varlink/libvarlink/releases/tag/23


Fixes: https://sentry.io/share/issue/16a68c95929547ccb5eeaabc83d502d2/
Signed-off-by: Frantisek Lachman <flachman@redhat.com>

---

Packit now correctly finds the release event if you don't use the version as a release title.
