### PR TITLE
lp,no-merge-pr: check out to pr/{pr_id}

### DIFF
--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -119,9 +119,9 @@ class LocalProject:
         # since we want to have 'pr123' in the release field, let's check out
         # the PR itself, so if both are specified, PR ID > ref
         if pr_id:
-            self.checkout_pr(pr_id)
+            pr_head = self.checkout_pr(pr_id)
             if merge_pr:
-                self.merge_pr(pr_id)
+                self.merge_pr(pr_id, pr_head)
         elif ref:
             self.checkout_ref(ref)
 
@@ -458,11 +458,18 @@ class LocalProject:
         """
         remote = self.remote or "origin"
         self.git_repo.remotes[remote].fetch(f"{remote_ref}:{local_ref}")
-        self.git_repo.create_head(local_branch, f"{remote}/{local_branch}")
+        # overwrite the local checkout when needed, remote is always accurate
+        self.git_repo.create_head(local_branch, f"{remote}/{local_branch}", force=True)
 
-    def checkout_pr(self, pr_id: Union[str, int]):
+    def checkout_pr(self, pr_id: Union[str, int]) -> git.Commit:
         """
-        Fetch selected PR and check it out.
+        Fetch selected PR and check it out in a local branch `pr/{pr_id}`.
+
+        Args:
+            pr_id: ID of the PR we are merging.
+
+        Returns:
+            HEAD of the checked out PR.
         """
         logger.info(f"Checking out PR {pr_id}.")
         is_gitlab = isinstance(self.git_service, GitlabService)
@@ -470,8 +477,8 @@ class LocalProject:
             "merge-requests" if is_gitlab else "pull", pr_id
         )
         remote_name = self.remote or "origin"
-        local_ref = f"refs/remotes/{remote_name}/pr-changes/{pr_id}"
-        local_branch = f"pr-changes/{pr_id}"
+        local_ref = f"refs/remotes/{remote_name}/pr/{pr_id}"
+        local_branch = f"pr/{pr_id}"
 
         self._fetch_as_branch(remote_ref, local_ref, local_branch)
         self.git_repo.branches[local_branch].checkout()
@@ -481,8 +488,9 @@ class LocalProject:
             f"Checked out commit\n"
             f"({shorten_commit_hash(head_commit.hexsha)})\t{head_commit.summary}"
         )
+        return head_commit
 
-    def merge_pr(self, pr_id: Union[str, int]) -> None:
+    def merge_pr(self, pr_id: Union[str, int], pr_head: git.Commit) -> None:
         """
         Merge given PR into target branch. Fetches and switches to base branch
         (where changes from the PR are to be merged) and then merges branch with
@@ -490,6 +498,7 @@ class LocalProject:
 
         Args:
             pr_id: ID of the PR we are merging.
+            pr_head: git.Commit HEAD of the checked out PR.
 
         Raises:
             PackitException: In case merge fails.
@@ -512,7 +521,7 @@ class LocalProject:
             f"({commit_sha})\t{target_branch.commit.summary}"
         )
         try:
-            self.git_repo.git.merge(f"pr-changes/{pr_id}")
+            self.git_repo.git.merge(pr_head)
         except GitCommandError as ex:
             logger.warning(f"Merge failed with: {ex}")
             if "Merge conflict" in str(ex):

--- a/tests_recording/test_data/test_local_project/ProposeUpdate.test_checkout_pr.yaml
+++ b/tests_recording/test_data/test_local_project/ProposeUpdate.test_checkout_pr.yaml
@@ -1,0 +1,590 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://api.github.com:443/repos/packit/hello-world:
+      - metadata:
+          latency: 0.4006834030151367
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests_recording.test_local_project
+          - packit.local_project
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.github.pull_request
+          - ogr.services.github.project
+          - github.MainClass
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            allow_auto_merge: false
+            allow_forking: true
+            allow_merge_commit: true
+            allow_rebase_merge: true
+            allow_squash_merge: true
+            allow_update_branch: false
+            archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+            archived: false
+            assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+            blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+            branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+            clone_url: https://github.com/packit/hello-world.git
+            collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+            comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+            commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+            compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+            contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+            contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+            created_at: '2019-05-02T18:54:46Z'
+            default_branch: main
+            delete_branch_on_merge: false
+            deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+            description: The most progresive command-line tool in the world.
+            disabled: false
+            downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+            events_url: https://api.github.com/repos/packit/hello-world/events
+            fork: false
+            forks: 20
+            forks_count: 20
+            forks_url: https://api.github.com/repos/packit/hello-world/forks
+            full_name: packit/hello-world
+            git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+            git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+            git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+            git_url: git://github.com/packit/hello-world.git
+            has_downloads: true
+            has_issues: true
+            has_pages: false
+            has_projects: true
+            has_wiki: true
+            homepage: null
+            hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+            html_url: https://github.com/packit/hello-world
+            id: 184635124
+            is_template: false
+            issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+            issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+            issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+            keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+            labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+            language: Python
+            languages_url: https://api.github.com/repos/packit/hello-world/languages
+            license:
+              key: mit
+              name: MIT License
+              node_id: MDc6TGljZW5zZTEz
+              spdx_id: MIT
+              url: https://api.github.com/licenses/mit
+            merges_url: https://api.github.com/repos/packit/hello-world/merges
+            milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+            mirror_url: null
+            name: hello-world
+            network_count: 20
+            node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+            notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+            open_issues: 57
+            open_issues_count: 57
+            organization:
+              avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+              events_url: https://api.github.com/users/packit/events{/privacy}
+              followers_url: https://api.github.com/users/packit/followers
+              following_url: https://api.github.com/users/packit/following{/other_user}
+              gists_url: https://api.github.com/users/packit/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/packit
+              id: 46870917
+              login: packit
+              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+              organizations_url: https://api.github.com/users/packit/orgs
+              received_events_url: https://api.github.com/users/packit/received_events
+              repos_url: https://api.github.com/users/packit/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/packit/subscriptions
+              type: Organization
+              url: https://api.github.com/users/packit
+            owner:
+              avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+              events_url: https://api.github.com/users/packit/events{/privacy}
+              followers_url: https://api.github.com/users/packit/followers
+              following_url: https://api.github.com/users/packit/following{/other_user}
+              gists_url: https://api.github.com/users/packit/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/packit
+              id: 46870917
+              login: packit
+              node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+              organizations_url: https://api.github.com/users/packit/orgs
+              received_events_url: https://api.github.com/users/packit/received_events
+              repos_url: https://api.github.com/users/packit/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/packit/subscriptions
+              type: Organization
+              url: https://api.github.com/users/packit
+            permissions:
+              admin: true
+              maintain: true
+              pull: true
+              push: true
+              triage: true
+            private: false
+            pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+            pushed_at: '2022-01-07T17:48:00Z'
+            releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+            size: 59
+            ssh_url: git@github.com:packit/hello-world.git
+            stargazers_count: 4
+            stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+            statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+            subscribers_count: 9
+            subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+            subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+            svn_url: https://github.com/packit/hello-world
+            tags_url: https://api.github.com/repos/packit/hello-world/tags
+            teams_url: https://api.github.com/repos/packit/hello-world/teams
+            temp_clone_token: ''
+            topics: []
+            trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+            updated_at: '2021-11-30T09:33:55Z'
+            url: https://api.github.com/repos/packit/hello-world
+            visibility: public
+            watchers: 4
+            watchers_count: 4
+          _next: null
+          elapsed: 0.39722
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 07 Jan 2022 17:56:02 GMT
+            ETag: W/"cad969bec821c8b7182c0f49a48de8b0fb5b0b1219bdd9e869c8e7d2900d72eb"
+            Last-Modified: Tue, 30 Nov 2021 09:33:55 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: repo
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: D286:8345:BF0E86:C27A9E:61D87EB1
+            X-OAuth-Scopes: repo, user, workflow
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4979'
+            X-RateLimit-Reset: '1641580678'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '21'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      https://api.github.com:443/repos/packit/hello-world/pulls/596:
+      - metadata:
+          latency: 0.42461419105529785
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests_recording.test_local_project
+          - packit.local_project
+          - ogr.abstract
+          - ogr.utils
+          - ogr.abstract
+          - ogr.services.github.pull_request
+          - github.Repository
+          - github.Requester
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            _links:
+              comments:
+                href: https://api.github.com/repos/packit/hello-world/issues/596/comments
+              commits:
+                href: https://api.github.com/repos/packit/hello-world/pulls/596/commits
+              html:
+                href: https://github.com/packit/hello-world/pull/596
+              issue:
+                href: https://api.github.com/repos/packit/hello-world/issues/596
+              review_comment:
+                href: https://api.github.com/repos/packit/hello-world/pulls/comments{/number}
+              review_comments:
+                href: https://api.github.com/repos/packit/hello-world/pulls/596/comments
+              self:
+                href: https://api.github.com/repos/packit/hello-world/pulls/596
+              statuses:
+                href: https://api.github.com/repos/packit/hello-world/statuses/2778ece1bf28d76a3c569880509ca16f3ce806f9
+            active_lock_reason: null
+            additions: 1
+            assignee: null
+            assignees: []
+            author_association: MEMBER
+            auto_merge: null
+            base:
+              label: packit:main
+              ref: main
+              repo:
+                allow_forking: true
+                archive_url: https://api.github.com/repos/packit/hello-world/{archive_format}{/ref}
+                archived: false
+                assignees_url: https://api.github.com/repos/packit/hello-world/assignees{/user}
+                blobs_url: https://api.github.com/repos/packit/hello-world/git/blobs{/sha}
+                branches_url: https://api.github.com/repos/packit/hello-world/branches{/branch}
+                clone_url: https://github.com/packit/hello-world.git
+                collaborators_url: https://api.github.com/repos/packit/hello-world/collaborators{/collaborator}
+                comments_url: https://api.github.com/repos/packit/hello-world/comments{/number}
+                commits_url: https://api.github.com/repos/packit/hello-world/commits{/sha}
+                compare_url: https://api.github.com/repos/packit/hello-world/compare/{base}...{head}
+                contents_url: https://api.github.com/repos/packit/hello-world/contents/{+path}
+                contributors_url: https://api.github.com/repos/packit/hello-world/contributors
+                created_at: '2019-05-02T18:54:46Z'
+                default_branch: main
+                deployments_url: https://api.github.com/repos/packit/hello-world/deployments
+                description: The most progresive command-line tool in the world.
+                disabled: false
+                downloads_url: https://api.github.com/repos/packit/hello-world/downloads
+                events_url: https://api.github.com/repos/packit/hello-world/events
+                fork: false
+                forks: 20
+                forks_count: 20
+                forks_url: https://api.github.com/repos/packit/hello-world/forks
+                full_name: packit/hello-world
+                git_commits_url: https://api.github.com/repos/packit/hello-world/git/commits{/sha}
+                git_refs_url: https://api.github.com/repos/packit/hello-world/git/refs{/sha}
+                git_tags_url: https://api.github.com/repos/packit/hello-world/git/tags{/sha}
+                git_url: git://github.com/packit/hello-world.git
+                has_downloads: true
+                has_issues: true
+                has_pages: false
+                has_projects: true
+                has_wiki: true
+                homepage: null
+                hooks_url: https://api.github.com/repos/packit/hello-world/hooks
+                html_url: https://github.com/packit/hello-world
+                id: 184635124
+                is_template: false
+                issue_comment_url: https://api.github.com/repos/packit/hello-world/issues/comments{/number}
+                issue_events_url: https://api.github.com/repos/packit/hello-world/issues/events{/number}
+                issues_url: https://api.github.com/repos/packit/hello-world/issues{/number}
+                keys_url: https://api.github.com/repos/packit/hello-world/keys{/key_id}
+                labels_url: https://api.github.com/repos/packit/hello-world/labels{/name}
+                language: Python
+                languages_url: https://api.github.com/repos/packit/hello-world/languages
+                license:
+                  key: mit
+                  name: MIT License
+                  node_id: MDc6TGljZW5zZTEz
+                  spdx_id: MIT
+                  url: https://api.github.com/licenses/mit
+                merges_url: https://api.github.com/repos/packit/hello-world/merges
+                milestones_url: https://api.github.com/repos/packit/hello-world/milestones{/number}
+                mirror_url: null
+                name: hello-world
+                node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUxMjQ=
+                notifications_url: https://api.github.com/repos/packit/hello-world/notifications{?since,all,participating}
+                open_issues: 57
+                open_issues_count: 57
+                owner:
+                  avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+                  events_url: https://api.github.com/users/packit/events{/privacy}
+                  followers_url: https://api.github.com/users/packit/followers
+                  following_url: https://api.github.com/users/packit/following{/other_user}
+                  gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                  gravatar_id: ''
+                  html_url: https://github.com/packit
+                  id: 46870917
+                  login: packit
+                  node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                  organizations_url: https://api.github.com/users/packit/orgs
+                  received_events_url: https://api.github.com/users/packit/received_events
+                  repos_url: https://api.github.com/users/packit/repos
+                  site_admin: false
+                  starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                  subscriptions_url: https://api.github.com/users/packit/subscriptions
+                  type: Organization
+                  url: https://api.github.com/users/packit
+                private: false
+                pulls_url: https://api.github.com/repos/packit/hello-world/pulls{/number}
+                pushed_at: '2022-01-07T17:48:00Z'
+                releases_url: https://api.github.com/repos/packit/hello-world/releases{/id}
+                size: 59
+                ssh_url: git@github.com:packit/hello-world.git
+                stargazers_count: 4
+                stargazers_url: https://api.github.com/repos/packit/hello-world/stargazers
+                statuses_url: https://api.github.com/repos/packit/hello-world/statuses/{sha}
+                subscribers_url: https://api.github.com/repos/packit/hello-world/subscribers
+                subscription_url: https://api.github.com/repos/packit/hello-world/subscription
+                svn_url: https://github.com/packit/hello-world
+                tags_url: https://api.github.com/repos/packit/hello-world/tags
+                teams_url: https://api.github.com/repos/packit/hello-world/teams
+                topics: []
+                trees_url: https://api.github.com/repos/packit/hello-world/git/trees{/sha}
+                updated_at: '2021-11-30T09:33:55Z'
+                url: https://api.github.com/repos/packit/hello-world
+                visibility: public
+                watchers: 4
+                watchers_count: 4
+              sha: 0840e2dac94668176ceb6ecfc0f14e2b95118e75
+              user:
+                avatar_url: https://avatars.githubusercontent.com/u/46870917?v=4
+                events_url: https://api.github.com/users/packit/events{/privacy}
+                followers_url: https://api.github.com/users/packit/followers
+                following_url: https://api.github.com/users/packit/following{/other_user}
+                gists_url: https://api.github.com/users/packit/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/packit
+                id: 46870917
+                login: packit
+                node_id: MDEyOk9yZ2FuaXphdGlvbjQ2ODcwOTE3
+                organizations_url: https://api.github.com/users/packit/orgs
+                received_events_url: https://api.github.com/users/packit/received_events
+                repos_url: https://api.github.com/users/packit/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/packit/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/packit/subscriptions
+                type: Organization
+                url: https://api.github.com/users/packit
+            body: null
+            changed_files: 1
+            closed_at: '2022-01-07T17:48:12Z'
+            comments: 0
+            comments_url: https://api.github.com/repos/packit/hello-world/issues/596/comments
+            commits: 1
+            commits_url: https://api.github.com/repos/packit/hello-world/pulls/596/commits
+            created_at: '2022-01-07T17:48:00Z'
+            deletions: 0
+            diff_url: https://github.com/packit/hello-world/pull/596.diff
+            draft: false
+            head:
+              label: TomasTomecek:packit-lp-tests-merge
+              ref: packit-lp-tests-merge
+              repo:
+                allow_forking: true
+                archive_url: https://api.github.com/repos/TomasTomecek/hello-world/{archive_format}{/ref}
+                archived: false
+                assignees_url: https://api.github.com/repos/TomasTomecek/hello-world/assignees{/user}
+                blobs_url: https://api.github.com/repos/TomasTomecek/hello-world/git/blobs{/sha}
+                branches_url: https://api.github.com/repos/TomasTomecek/hello-world/branches{/branch}
+                clone_url: https://github.com/TomasTomecek/hello-world.git
+                collaborators_url: https://api.github.com/repos/TomasTomecek/hello-world/collaborators{/collaborator}
+                comments_url: https://api.github.com/repos/TomasTomecek/hello-world/comments{/number}
+                commits_url: https://api.github.com/repos/TomasTomecek/hello-world/commits{/sha}
+                compare_url: https://api.github.com/repos/TomasTomecek/hello-world/compare/{base}...{head}
+                contents_url: https://api.github.com/repos/TomasTomecek/hello-world/contents/{+path}
+                contributors_url: https://api.github.com/repos/TomasTomecek/hello-world/contributors
+                created_at: '2019-05-02T18:55:43Z'
+                default_branch: master
+                deployments_url: https://api.github.com/repos/TomasTomecek/hello-world/deployments
+                description: The most progresive command-line tool in the world.
+                disabled: false
+                downloads_url: https://api.github.com/repos/TomasTomecek/hello-world/downloads
+                events_url: https://api.github.com/repos/TomasTomecek/hello-world/events
+                fork: true
+                forks: 0
+                forks_count: 0
+                forks_url: https://api.github.com/repos/TomasTomecek/hello-world/forks
+                full_name: TomasTomecek/hello-world
+                git_commits_url: https://api.github.com/repos/TomasTomecek/hello-world/git/commits{/sha}
+                git_refs_url: https://api.github.com/repos/TomasTomecek/hello-world/git/refs{/sha}
+                git_tags_url: https://api.github.com/repos/TomasTomecek/hello-world/git/tags{/sha}
+                git_url: git://github.com/TomasTomecek/hello-world.git
+                has_downloads: true
+                has_issues: false
+                has_pages: false
+                has_projects: true
+                has_wiki: true
+                homepage: null
+                hooks_url: https://api.github.com/repos/TomasTomecek/hello-world/hooks
+                html_url: https://github.com/TomasTomecek/hello-world
+                id: 184635270
+                is_template: false
+                issue_comment_url: https://api.github.com/repos/TomasTomecek/hello-world/issues/comments{/number}
+                issue_events_url: https://api.github.com/repos/TomasTomecek/hello-world/issues/events{/number}
+                issues_url: https://api.github.com/repos/TomasTomecek/hello-world/issues{/number}
+                keys_url: https://api.github.com/repos/TomasTomecek/hello-world/keys{/key_id}
+                labels_url: https://api.github.com/repos/TomasTomecek/hello-world/labels{/name}
+                language: null
+                languages_url: https://api.github.com/repos/TomasTomecek/hello-world/languages
+                license:
+                  key: mit
+                  name: MIT License
+                  node_id: MDc6TGljZW5zZTEz
+                  spdx_id: MIT
+                  url: https://api.github.com/licenses/mit
+                merges_url: https://api.github.com/repos/TomasTomecek/hello-world/merges
+                milestones_url: https://api.github.com/repos/TomasTomecek/hello-world/milestones{/number}
+                mirror_url: null
+                name: hello-world
+                node_id: MDEwOlJlcG9zaXRvcnkxODQ2MzUyNzA=
+                notifications_url: https://api.github.com/repos/TomasTomecek/hello-world/notifications{?since,all,participating}
+                open_issues: 0
+                open_issues_count: 0
+                owner:
+                  avatar_url: https://avatars.githubusercontent.com/u/1662493?v=4
+                  events_url: https://api.github.com/users/TomasTomecek/events{/privacy}
+                  followers_url: https://api.github.com/users/TomasTomecek/followers
+                  following_url: https://api.github.com/users/TomasTomecek/following{/other_user}
+                  gists_url: https://api.github.com/users/TomasTomecek/gists{/gist_id}
+                  gravatar_id: ''
+                  html_url: https://github.com/TomasTomecek
+                  id: 1662493
+                  login: TomasTomecek
+                  node_id: MDQ6VXNlcjE2NjI0OTM=
+                  organizations_url: https://api.github.com/users/TomasTomecek/orgs
+                  received_events_url: https://api.github.com/users/TomasTomecek/received_events
+                  repos_url: https://api.github.com/users/TomasTomecek/repos
+                  site_admin: false
+                  starred_url: https://api.github.com/users/TomasTomecek/starred{/owner}{/repo}
+                  subscriptions_url: https://api.github.com/users/TomasTomecek/subscriptions
+                  type: User
+                  url: https://api.github.com/users/TomasTomecek
+                private: false
+                pulls_url: https://api.github.com/repos/TomasTomecek/hello-world/pulls{/number}
+                pushed_at: '2022-01-07T17:47:51Z'
+                releases_url: https://api.github.com/repos/TomasTomecek/hello-world/releases{/id}
+                size: 26
+                ssh_url: git@github.com:TomasTomecek/hello-world.git
+                stargazers_count: 0
+                stargazers_url: https://api.github.com/repos/TomasTomecek/hello-world/stargazers
+                statuses_url: https://api.github.com/repos/TomasTomecek/hello-world/statuses/{sha}
+                subscribers_url: https://api.github.com/repos/TomasTomecek/hello-world/subscribers
+                subscription_url: https://api.github.com/repos/TomasTomecek/hello-world/subscription
+                svn_url: https://github.com/TomasTomecek/hello-world
+                tags_url: https://api.github.com/repos/TomasTomecek/hello-world/tags
+                teams_url: https://api.github.com/repos/TomasTomecek/hello-world/teams
+                topics: []
+                trees_url: https://api.github.com/repos/TomasTomecek/hello-world/git/trees{/sha}
+                updated_at: '2019-05-02T18:55:46Z'
+                url: https://api.github.com/repos/TomasTomecek/hello-world
+                visibility: public
+                watchers: 0
+                watchers_count: 0
+              sha: 2778ece1bf28d76a3c569880509ca16f3ce806f9
+              user:
+                avatar_url: https://avatars.githubusercontent.com/u/1662493?v=4
+                events_url: https://api.github.com/users/TomasTomecek/events{/privacy}
+                followers_url: https://api.github.com/users/TomasTomecek/followers
+                following_url: https://api.github.com/users/TomasTomecek/following{/other_user}
+                gists_url: https://api.github.com/users/TomasTomecek/gists{/gist_id}
+                gravatar_id: ''
+                html_url: https://github.com/TomasTomecek
+                id: 1662493
+                login: TomasTomecek
+                node_id: MDQ6VXNlcjE2NjI0OTM=
+                organizations_url: https://api.github.com/users/TomasTomecek/orgs
+                received_events_url: https://api.github.com/users/TomasTomecek/received_events
+                repos_url: https://api.github.com/users/TomasTomecek/repos
+                site_admin: false
+                starred_url: https://api.github.com/users/TomasTomecek/starred{/owner}{/repo}
+                subscriptions_url: https://api.github.com/users/TomasTomecek/subscriptions
+                type: User
+                url: https://api.github.com/users/TomasTomecek
+            html_url: https://github.com/packit/hello-world/pull/596
+            id: 816552546
+            issue_url: https://api.github.com/repos/packit/hello-world/issues/596
+            labels: []
+            locked: false
+            maintainer_can_modify: false
+            merge_commit_sha: 550ec2c838ecdb41d4eb3ee2663934497b69a8af
+            mergeable: true
+            mergeable_state: unstable
+            merged: false
+            merged_at: null
+            merged_by: null
+            milestone: null
+            node_id: PR_kwDOCwFO9M4wq5pi
+            number: 596
+            patch_url: https://github.com/packit/hello-world/pull/596.patch
+            rebaseable: false
+            requested_reviewers: []
+            requested_teams: []
+            review_comment_url: https://api.github.com/repos/packit/hello-world/pulls/comments{/number}
+            review_comments: 0
+            review_comments_url: https://api.github.com/repos/packit/hello-world/pulls/596/comments
+            state: closed
+            statuses_url: https://api.github.com/repos/packit/hello-world/statuses/2778ece1bf28d76a3c569880509ca16f3ce806f9
+            title: test data for packit:tests_recording/test_local_project
+            updated_at: '2022-01-07T17:48:13Z'
+            url: https://api.github.com/repos/packit/hello-world/pulls/596
+            user:
+              avatar_url: https://avatars.githubusercontent.com/u/1662493?v=4
+              events_url: https://api.github.com/users/TomasTomecek/events{/privacy}
+              followers_url: https://api.github.com/users/TomasTomecek/followers
+              following_url: https://api.github.com/users/TomasTomecek/following{/other_user}
+              gists_url: https://api.github.com/users/TomasTomecek/gists{/gist_id}
+              gravatar_id: ''
+              html_url: https://github.com/TomasTomecek
+              id: 1662493
+              login: TomasTomecek
+              node_id: MDQ6VXNlcjE2NjI0OTM=
+              organizations_url: https://api.github.com/users/TomasTomecek/orgs
+              received_events_url: https://api.github.com/users/TomasTomecek/received_events
+              repos_url: https://api.github.com/users/TomasTomecek/repos
+              site_admin: false
+              starred_url: https://api.github.com/users/TomasTomecek/starred{/owner}{/repo}
+              subscriptions_url: https://api.github.com/users/TomasTomecek/subscriptions
+              type: User
+              url: https://api.github.com/users/TomasTomecek
+          _next: null
+          elapsed: 0.421311
+          encoding: utf-8
+          headers:
+            Access-Control-Allow-Origin: '*'
+            Access-Control-Expose-Headers: ETag, Link, Location, Retry-After, X-GitHub-OTP,
+              X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource,
+              X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+              X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation,
+              Sunset
+            Cache-Control: private, max-age=60, s-maxage=60
+            Content-Encoding: gzip
+            Content-Security-Policy: default-src 'none'
+            Content-Type: application/json; charset=utf-8
+            Date: Fri, 07 Jan 2022 17:56:02 GMT
+            ETag: W/"e822808654488a1f626a90e2cfa85e18a7ff1767ac6f4209ffbcb1eb70307aad"
+            Last-Modified: Fri, 07 Jan 2022 17:48:13 GMT
+            Referrer-Policy: origin-when-cross-origin, strict-origin-when-cross-origin
+            Server: GitHub.com
+            Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
+            Transfer-Encoding: chunked
+            Vary: Accept, Authorization, Cookie, X-GitHub-OTP, Accept-Encoding, Accept,
+              X-Requested-With
+            X-Accepted-OAuth-Scopes: ''
+            X-Content-Type-Options: nosniff
+            X-Frame-Options: deny
+            X-GitHub-Media-Type: github.v3; format=json
+            X-GitHub-Request-Id: D286:8345:BF0F1B:C27B42:61D87EB2
+            X-OAuth-Scopes: repo, user, workflow
+            X-RateLimit-Limit: '5000'
+            X-RateLimit-Remaining: '4978'
+            X-RateLimit-Reset: '1641580678'
+            X-RateLimit-Resource: core
+            X-RateLimit-Used: '22'
+            X-XSS-Protection: '0'
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests_recording/test_data/test_local_project/ProposeUpdate.test_checkout_pr_no_merge.yaml
+++ b/tests_recording/test_data/test_local_project/ProposeUpdate.test_checkout_pr_no_merge.yaml
@@ -1,0 +1,4 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3

--- a/tests_recording/test_local_project.py
+++ b/tests_recording/test_local_project.py
@@ -1,0 +1,39 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+from requre.cassette import DataTypes
+from requre.online_replacing import (
+    record_requests_for_all_methods,
+)
+
+from packit.local_project import LocalProject
+from tests_recording.testbase import PackitTest
+
+
+@record_requests_for_all_methods()
+class ProposeUpdate(PackitTest):
+    def setUp(self):
+        super().setUp()
+        self._project_url = "https://github.com/packit/hello-world"
+
+    def cassette_setup(self, cassette):
+        cassette.data_miner.data_type = DataTypes.Dict
+
+    def test_checkout_pr(self):
+        """Test PR checkout with and without merging"""
+        project = LocalProject(
+            git_project=self.project,
+            pr_id="596",
+            git_url=self._project_url,
+        )
+        assert project.ref == "pr/596"
+
+    def test_checkout_pr_no_merge(self):
+        """Test PR checkout with and without merging"""
+        project = LocalProject(
+            git_project=self.project,
+            pr_id="596",
+            git_url=self._project_url,
+            merge_pr=False,
+        )
+        assert project.ref == "pr/596"


### PR DESCRIPTION
...instead of `pr-changes/{pr_id}` which is inconsistent with the original
behaviour

This commit makes the local PR checkout naming consistent with
merge/no-merge scenarios.

Fixes #1443

---
Packit now names local branch `pr/{pr_id}` when checking out a PR, even when it's not being merged with the target branch. This results into NVR of the build containing `pr{pr_id}` instead of `pr.changes{pr_id}`.

