### PR TITLE
merging PRs: PR into target, rename after

### DIFF
--- a/packit/constants.py
+++ b/packit/constants.py
@@ -17,6 +17,9 @@ CONFIG_FILE_NAMES = [
     "packit.json",
 ]
 
+# local branch name when checking out a PR before we merge it with the target branch
+LP_TEMP_PR_CHECKOUT_NAME = "pr-changes"
+
 DATETIME_FORMAT = "%Y%m%d%H%M%S%f"
 
 # we create .tar.gz archives

--- a/tests_recording/test_local_project.py
+++ b/tests_recording/test_local_project.py
@@ -19,6 +19,11 @@ class ProposeUpdate(PackitTest):
     def cassette_setup(self, cassette):
         cassette.data_miner.data_type = DataTypes.Dict
 
+    @staticmethod
+    def commit_title(lp: LocalProject):
+        commit_msg = lp.git_repo.head.commit.message
+        return commit_msg.split("\n", 1)[0]
+
     def test_checkout_pr(self):
         """Test PR checkout with and without merging"""
         project = LocalProject(
@@ -27,6 +32,11 @@ class ProposeUpdate(PackitTest):
             git_url=self._project_url,
         )
         assert project.ref == "pr/596"
+        assert (
+            self.commit_title(project)
+            == "test data for packit:tests_recording/test_local_project"
+        )
+        assert (project.working_dir / "JUNGLE").read_text() == "Julia\n"
 
     def test_checkout_pr_no_merge(self):
         """Test PR checkout with and without merging"""
@@ -37,3 +47,8 @@ class ProposeUpdate(PackitTest):
             merge_pr=False,
         )
         assert project.ref == "pr/596"
+        assert (
+            self.commit_title(project)
+            == "test data for packit:tests_recording/test_local_project"
+        )
+        assert (project.working_dir / "JUNGLE").read_text() == "Julia\n"


### PR DESCRIPTION
merge PRs: rename to pr/{pr_id} after merging

There are many ways to implement this behavior and this commit is the
least intrusive way.

I tried other ways as well but there was always some problem. The
presented solution seems the least prone to errors since it doesn't
change the merging process (except using original target_branch name
instead of pr/{pr_id}) and only renames the target_branch to pr/{pr_id}
after the merge is done.

This change is needed to keep the consistency in NVRs (they show up as
pr{pr_id} in the %release field).

Related to #1443 #1445

---
Release notes are in #1445