### PR TITLE
Do not ignore --no-bump and --release-suffix for src-git repos

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -889,14 +889,18 @@ class SRPMBuilder:
 
         return self.get_path(out)
 
-    def _prepare_upstream_using_source_git(self) -> None:
+    def _prepare_upstream_using_source_git(
+        self, bump_version: bool, release_suffix: Optional[str]
+    ) -> None:
         """
         Fetch the tarball and don't check out the upstream ref.
         """
         self.upstream.fetch_upstream_archive()
         self.upstream.create_patches_and_update_specfile(self.upstream_ref)
 
-        ChangelogHelper(self.upstream).prepare_upstream_using_source_git()
+        ChangelogHelper(self.upstream).prepare_upstream_using_source_git(
+            bump_version, release_suffix
+        )
 
     def _fix_specfile_to_use_local_archive(
         self, archive: str, bump_version: bool, release_suffix: Optional[str]
@@ -931,7 +935,7 @@ class SRPMBuilder:
 
     def prepare(self, bump_version: bool, release_suffix: Optional[str] = None):
         if self.upstream_ref:
-            self._prepare_upstream_using_source_git()
+            self._prepare_upstream_using_source_git(bump_version, release_suffix)
         else:
             created_archive = self.upstream.create_archive(
                 version=self.current_git_describe_version

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -357,7 +357,7 @@ class Upstream(PackitRepositoryBase):
 
     def get_spec_release(
         self, bump_version: bool = True, release_suffix: Optional[str] = None
-    ) -> str:
+    ) -> Optional[str]:
         """Assemble pieces of the spec file %release field we intend to set
         within the default fix-spec-file action
 
@@ -375,7 +375,7 @@ class Upstream(PackitRepositoryBase):
             return f"{original_release_number}.{release_suffix}"
 
         if not bump_version:
-            return original_release_number
+            return None
 
         # we only care about the first number in the release
         # so that we can re-run `packit srpm`

--- a/packit/utils/changelog_helper.py
+++ b/packit/utils/changelog_helper.py
@@ -70,20 +70,38 @@ class ChangelogHelper:
                 self.dg.get_absolute_specfile_path(),
             )
 
-    def prepare_upstream_using_source_git(self) -> None:
-        """
-        Updates changelog when creating SRPM within source-git repository.
-        """
+    def _get_release_for_source_git(
+        self, current_commit: str, bump_version: bool, release_suffix: Optional[str]
+    ) -> str:
         old_release = self.up.specfile.get_release_number()
+        if release_suffix:
+            return f"{old_release}.{release_suffix}"
+
+        if not bump_version:
+            return old_release
+
         try:
             old_release_int = int(old_release)
             new_release = str(old_release_int + 1)
         except ValueError:
             new_release = str(old_release)
 
+        return f"{new_release}.g{current_commit}"
+
+    def prepare_upstream_using_source_git(
+        self, bump_version: bool, release_suffix: Optional[str]
+    ) -> None:
+        """
+        Updates changelog when creating SRPM within source-git repository.
+        """
         current_commit = self.up.local_project.commit_hexsha
-        release_to_update = f"{new_release}.g{current_commit}"
-        msg = self.entry_from_action or f"- Downstream changes ({current_commit})"
+        release_to_update = self._get_release_for_source_git(
+            current_commit, bump_version, release_suffix
+        )
+
+        msg = self.entry_from_action
+        if not msg and bump_version:
+            msg = f"- Downstream changes ({current_commit})"
         self.up.specfile.set_spec_version(
             release=release_to_update, changelog_entry=msg
         )

--- a/packit/utils/changelog_helper.py
+++ b/packit/utils/changelog_helper.py
@@ -72,13 +72,13 @@ class ChangelogHelper:
 
     def _get_release_for_source_git(
         self, current_commit: str, bump_version: bool, release_suffix: Optional[str]
-    ) -> str:
+    ) -> Optional[str]:
         old_release = self.up.specfile.get_release_number()
         if release_suffix:
             return f"{old_release}.{release_suffix}"
 
         if not bump_version:
-            return old_release
+            return None
 
         try:
             old_release_int = int(old_release)


### PR DESCRIPTION
Fixes #1451

Signed-off-by: Matej Focko <mfocko@redhat.com>

---

<!-- release notes for changelog/blog follow -->
Bug in Packit while creating SRPMs when the `--no-bump` and `--release-suffix` options are ignored for source-git repositories has been fixed. Packit also doesn't touch `Release` field in specfile unless it needs to be changed (the macros are not expanded that way when not necessary).