### PR TITLE
tests: check that merged PR matches main's HEAD

### DIFF
--- a/tests_recording/test_local_project.py
+++ b/tests_recording/test_local_project.py
@@ -44,10 +44,10 @@ class TestLocalProject(PackitTest):
             working_dir=self.static_tmp,
         )
         assert project.ref == f"pr/{PR_ID}"
-        assert (
-            self.commit_title(project)
-            == "Merge pull request #227 from lachmanfrantisek/koji-builds"
-        )
+        # check that HEAD of the merge matches HEAD of main
+        main = project.git_repo.heads["main"]
+        # 'Merge pull request #231 from packit/pre-commit-ci-update-config
+        assert self.commit_title(project) == main.commit.message.split("\n", 1)[0]
         assert "koji_build" in (project.working_dir / ".packit.yaml").read_text()
 
     @pytest.mark.skipif(


### PR DESCRIPTION
Make sure that the locally checked out PR has the same HEAD commit title
as the commit from main

We could also set up git-recording but this commit is a simpler fix.


Related to CI failures in https://github.com/packit/packit/pull/1454

---

N/A, tests fix