### PR TITLE
Implement update-source-git command

### DIFF
--- a/packit/cli/source_git.py
+++ b/packit/cli/source_git.py
@@ -6,6 +6,7 @@
 import click
 
 from packit.cli.update_dist_git import update_dist_git
+from packit.cli.update_source_git import update_source_git
 from packit.cli.source_git_init import source_git_init
 
 
@@ -16,4 +17,5 @@ def source_git():
 
 
 source_git.add_command(update_dist_git)
+source_git.add_command(update_source_git)
 source_git.add_command(source_git_init)

--- a/packit/cli/update_source_git.py
+++ b/packit/cli/update_source_git.py
@@ -40,6 +40,9 @@ def update_source_git(
     exits with return code 2. Such changes are not supported by this
     command, code changes should happen in the source-git repo.
 
+    Inapplicable changes to the .gitignore file are ignored since the
+    file may not be synchronized between dist-git and source-git.
+
     This command, by default, performs only local operations and uses the
     content of the source-git and dist-git repositories as it is, no checkout
     or fetch is performed.

--- a/packit/cli/update_source_git.py
+++ b/packit/cli/update_source_git.py
@@ -1,0 +1,78 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+
+"""
+Update a source-git repo from a dist-git repo
+"""
+
+import pathlib
+
+import click
+
+from packit.config import pass_config
+from packit.config import Config, get_local_package_config
+from packit.api import PackitAPI
+from packit.local_project import LocalProject
+from packit.cli.utils import cover_packit_exception
+
+
+@click.command("update-source-git")
+@click.argument("dist-git", type=click.Path(exists=True, file_okay=False))
+@click.argument("source-git", type=click.Path(exists=True, file_okay=False))
+@click.argument("revision-range")
+@pass_config
+@cover_packit_exception()
+def update_source_git(
+    config: Config, source_git: str, dist_git: str, revision_range: str
+):
+    """Update a source-git repository based on a dist-git repository.
+
+    Update a source-git repository with the selected checkout of a spec file
+    and additional packaging files from a dist-git repository.
+
+    Revision range represents part of dist-git history which is supposed
+    to be synchronized. Use `HEAD~..` if you want to synchronize the last
+    commit from dist-git. For more information on possible revision range
+    formats, see gitrevisions(7).
+
+    If patches or the sources file in the spec file changed, the command
+    exits with return code 2. Such changes are not supported by this
+    command, code changes should happen in the source-git repo.
+
+    This command, by default, performs only local operations and uses the
+    content of the source-git and dist-git repositories as it is, no checkout
+    or fetch is performed.
+
+    After the synchronization is done, packit will inform about the changes
+    it has performed and about differences between source-git and dist-git
+    prior to the synchronization process.
+
+    Dist-git commit messages are preserved and used when creating new
+    source-git commits.
+
+    Examples
+
+    Take the last commit (HEAD) of systemd dist-git repo and copy the
+    spec file and other packaging files into the source-git repo:
+
+    \b
+        $ packit source-git update-source-git rpms/systemd src/systemd HEAD~..
+
+    Synchronize changes from the last three dist-git commits:
+
+    \b
+        $ packit source-git update-source-git rpms/systemd src/systemd HEAD~3..
+    """
+    source_git_path = pathlib.Path(source_git).resolve()
+    dist_git_path = pathlib.Path(dist_git).resolve()
+    package_config = get_local_package_config(
+        source_git_path, package_config_path=config.package_config_path
+    )
+    api = PackitAPI(
+        config=config,
+        package_config=package_config,
+        upstream_local_project=LocalProject(working_dir=source_git_path, offline=True),
+        downstream_local_project=LocalProject(working_dir=dist_git_path, offline=True),
+    )
+    api.update_source_git(revision_range=revision_range)

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -578,8 +578,8 @@ class LocalProject:
             allow_empty=allow_empty, m=message, amend=amend, **other_message_kwargs
         )
 
-    def get_commits(self, ref: str = "HEAD") -> Iterator[git.Commit]:
-        return self.git_repo.iter_commits(ref)
+    def get_commits(self, ref: str = "HEAD", **kwargs) -> Iterator[git.Commit]:
+        return self.git_repo.iter_commits(ref, **kwargs)
 
     def fetch(self, remote: str, refspec: Optional[str] = None):
         """

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: MIT
 
 import logging
+import re
 import shutil
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional, Union, Iterable, Iterator
+from typing import Optional, Union, Iterable, Iterator, List
 
 import git
 from git.exc import GitCommandError
@@ -580,6 +581,37 @@ class LocalProject:
 
     def get_commits(self, ref: str = "HEAD", **kwargs) -> Iterator[git.Commit]:
         return self.git_repo.iter_commits(ref, **kwargs)
+
+    @staticmethod
+    def get_commit_diff(commit: git.Commit) -> List[git.Diff]:
+        """Get modified files of the given commit."""
+        if len(commit.parents) == 1:
+            return commit.parents[0].diff(commit, create_patch=True)
+        elif len(commit.parents) == 0:
+            # First commit in the repo
+            return commit.diff(git.NULL_TREE, create_patch=True)
+        else:
+            # Probably a merge commit, we can't do much about it
+            return []
+
+    def get_commit_hunks(self, commit: git.Commit) -> List[str]:
+        """Get a list of hunks of the given commit."""
+        patch = self.git_repo.git.show(commit, format="", color="never")
+        hunk_start_re = re.compile(r"diff --git a/.+ b/.+")
+        section_start = 0
+        result = []
+        patch_lines = patch.splitlines()
+        for i, line in enumerate(patch_lines):
+            if hunk_start_re.match(line):
+                section = patch_lines[section_start:i]
+                if section:
+                    result.append("\n".join(section))
+                section_start = i
+        # The last section
+        section = patch_lines[section_start:]
+        if section:
+            result.append("\n".join(section))
+        return result
 
     def fetch(self, remote: str, refspec: Optional[str] = None):
         """

--- a/tests/integration/test_source_git_update_source_git.py
+++ b/tests/integration/test_source_git_update_source_git.py
@@ -1,0 +1,103 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+from packit.exceptions import PackitException
+from packit.patches import PatchMetadata
+from packit.constants import DISTRO_DIR
+
+
+@pytest.fixture
+def update_api(api_instance_source_git):
+    # The version in dg is different from up, sync it
+    version = api_instance_source_git.up.specfile.get_version()
+    api_instance_source_git.dg.specfile.set_version(version)
+    api_instance_source_git.dg.specfile.save()
+    api_instance_source_git.dg.commit("Update spec", "")
+    return api_instance_source_git
+
+
+def test_update_source_git_sources_changed(
+    sourcegit_and_remote,
+    distgit_and_remote,
+    update_api,
+):
+    """Checks that an error is thrown when sources in dist-git were modified."""
+    sourcegit, _ = sourcegit_and_remote
+    distgit, _ = distgit_and_remote
+    (distgit / "sources").write_text("abcd")
+    update_api.dg.commit("Update sources", "")
+    with pytest.raises(PackitException):
+        update_api.update_source_git("HEAD~1..")
+
+
+def test_update_source_git_patch_changed(
+    sourcegit_and_remote,
+    distgit_and_remote,
+    update_api,
+):
+    """Checks that an error is thrown when a patch was modified in the
+    given commit."""
+    sourcegit, _ = sourcegit_and_remote
+    distgit, _ = distgit_and_remote
+
+    patch = "something.patch"
+    (distgit / patch).write_text("abcd")
+    update_api.dg.specfile.add_patch(PatchMetadata(name=patch))
+    update_api.dg.specfile.save()
+    update_api.dg.commit("Add a patch", "")
+    with pytest.raises(PackitException):
+        update_api.update_source_git("HEAD~1..")
+
+
+def test_update_source_git(
+    sourcegit_and_remote,
+    distgit_and_remote,
+    update_api,
+):
+    """Updates source-git based on multiple 'extra' commits in the dist-git,
+    tests the various possible types of changes of the commit:
+
+    - file creation
+    - file modification
+    - file rename
+    - file removal
+    """
+    sourcegit, _ = sourcegit_and_remote
+    distgit, _ = distgit_and_remote
+
+    # Create a new file
+    new_file = "test_file.txt"
+    content = "abcd"
+    (distgit / new_file).write_text(content)
+    update_api.dg.commit("Add", "")
+    update_api.update_source_git("HEAD~1..")
+    assert (sourcegit / DISTRO_DIR / new_file).read_text() == content
+    assert "Add" in update_api.up.local_project.git_repo.head.commit.message
+
+    # Modify the existing file
+    extra_content = "\ndefgh"
+    with open(distgit / new_file, "a") as file:
+        file.write(extra_content)
+    update_api.dg.commit("Modify", "")
+    update_api.update_source_git("HEAD~1..")
+    assert (sourcegit / DISTRO_DIR / new_file).read_text() == content + extra_content
+    assert "Modify" in update_api.up.local_project.git_repo.head.commit.message
+
+    # Rename a file
+    new_name = "test.txt"
+    (distgit / new_file).rename(distgit / new_name)
+    update_api.dg.commit("Rename", "")
+    update_api.update_source_git("HEAD~1..")
+    assert not (sourcegit / DISTRO_DIR / new_file).exists()
+    with open(sourcegit / DISTRO_DIR / new_name, "r") as file:
+        assert file.read() == content + extra_content
+    assert "Rename" in update_api.up.local_project.git_repo.head.commit.message
+
+    # Delete a file
+    (distgit / new_name).unlink()
+    update_api.dg.commit("Delete", "")
+    update_api.update_source_git("HEAD~1..")
+    assert not (sourcegit / DISTRO_DIR / new_name).exists()
+    assert "Delete" in update_api.up.local_project.git_repo.head.commit.message


### PR DESCRIPTION
<!-- notes for reviewers -->

Just a few notes about the problems I ran into while working on this and which directly influence the current state of the command:
 - the check for patch changes is very simple, just an extension check for now. Taking the current dist-git spec file and using its patches for the checks is not sufficient as the patches may have been removed by a commit. If we wanted to be really precise with this check, we would have to check-out to each commit in the revision range and parse the spec file and its patches there, though I am not sure if that's what we want, seems a bit too complicated. Moreover, changing checkout on the provided local dist-git doesn't seem like very user-friendly IMO.
 - GitPython manipulation with diffs is quite inconvenient, there is no way how to reconstruct the patch that can be applied directly from a `Diff` object. There were 2 approaches that came to my mind to solve this:
    1. Check-out dist-git repo to the given commit and copy the modified files over to source-git.
    2. Use raw git API to get the raw patch and then git-apply to apply the changes and then commit
  - I don't really like the idea of checkout, as mentioned above, so I ended up going with 2) while handling renames and removals separately.

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes: #1414 

---

<!-- release notes for changelog/blog follow -->
A new `packit source-git update-source-git` command has been introduced for taking new changes from dist-git (specified by a revision range) to source-git. These may include any changes except source code, patches and `Version` tag changes in the spec file.
