### PR TITLE
Allow git trees with .git gitdir reference files

### DIFF
--- a/packit/utils/repo.py
+++ b/packit/utils/repo.py
@@ -99,9 +99,9 @@ class RepositoryCache:
 def is_git_repo(directory: Union[Path, str]) -> bool:
     """
     Test, if the directory is a git repo.
-    (Has .git subdirectory?)
+    (Has .git subdirectory or 'gitdir' file?)
     """
-    return Path(directory, ".git").is_dir()
+    return Path(directory, ".git").exists()
 
 
 def get_repo(url: str, directory: Union[Path, str] = None) -> git.Repo:


### PR DESCRIPTION
When working with the worktree feature of git (`git worktree`), the
extra working trees don't get a .git directory, but rather a normal
file, with a single line that looks like

  gitdir: /path/to/main/repo/.git/worktrees/abc

We're a bit too strict in our check requiring the current directory to
contain a file called ".git" and for it to be a directory: relax that
check to merely checking if ".git" exists, regardless of type.