### PR TITLE
Skip %autochangelog tests if rpm < 4.16

### DIFF
--- a/tests/integration/test_changelog_helper.py
+++ b/tests/integration/test_changelog_helper.py
@@ -4,6 +4,7 @@
 from logging import getLogger
 
 import pytest
+import rpm
 from flexmock import flexmock
 
 from packit.actions import ActionName
@@ -106,6 +107,9 @@ def test_update_distgit_when_copy_upstream_release_description(
     )
 
 
+@pytest.mark.skipif(
+    rpm.__version__ < "4.16", reason="%autochangelog requires rpm 4.16 or higher"
+)
 def test_do_not_update_distgit_with_autochangelog(
     upstream, distgit_instance_with_autochangelog
 ):

--- a/tests/unit/test_specfile.py
+++ b/tests/unit/test_specfile.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 import pytest
+import rpm
 
 from packit.specfile import Specfile
 
@@ -43,6 +44,9 @@ Summary: evanescence
             False,
         ),
     ],
+)
+@pytest.mark.skipif(
+    rpm.__version__ < "4.16", reason="%autochangelog requires rpm 4.16 or higher"
 )
 def test_set_spec_has_autochangelog(spec_content, has_autochangelog, tmp_path):
     spec_path = tmp_path / "life.spec"


### PR DESCRIPTION
Older versions of rpm raise an error if %changelog entries don't start
with a '*'. Any test which relies on the presence %autochangelog will
fail on this. Let's skip these tests if rpm < 4.16.

This should make the epel 8 tests pass.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>

---

None.