### PR TITLE
Update classifiers to mark support for Python 3.9 and 3.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development
     Topic :: Utilities
 keywords =


### PR DESCRIPTION
So that this is also correctly displayed on PyPI.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>

---

N/A