### PR TITLE
Update the examples in the 'update-dist-git' help text

### DIFF
--- a/packit/cli/update_dist_git.py
+++ b/packit/cli/update_dist_git.py
@@ -88,17 +88,15 @@ def update_dist_git(
     to the lookaside cache and creating a commit with the updates, run:
 
     \b
-        $ packit -c src/curl/.distro/source-git.yaml update-dist-git \\
-                src/curl rpms/curl
+        $ packit source-git update-dist-git src/curl rpms/curl
 
 
     To also commit the changes and upload the source-archive to the lookaside-cache
     specify -m and --pkg-tool:
 
     \b
-        $ packit -c src/curl/.distro/source-git.yaml update-dist-git \\
-                -m'Update from source-git' --pkg-tool fedpkg \\
-                src/curl rpms/curl
+        $ packit source-git update-dist-git -m'Update from source-git' \\
+                --pkg-tool fedpkg src/curl rpms/curl
     """
     if message and file:
         raise click.BadOptionUsage("-m", "Option -m cannot be combined with -F.")


### PR DESCRIPTION
The command is under 'source-git' now and does not require to explicitly
specify the package configuration.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>

---

n/a