### PR TITLE
Configure git user and mail in the source script

### DIFF
--- a/packit/constants.py
+++ b/packit/constants.py
@@ -144,6 +144,8 @@ RPM_MACROS_FOR_PREP = [
 COPR_SOURCE_SCRIPT = """
 #!/bin/sh
 
+git config --global user.email "user-cont-team@redhat.com"
+git config --global user.name "Packit"
 resultdir=$PWD
 packit -d prepare-sources --result-dir "$resultdir" {options}
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -440,6 +440,8 @@ def test_create_source_script(
         == f"""
 #!/bin/sh
 
+git config --global user.email "user-cont-team@redhat.com"
+git config --global user.name "Packit"
 resultdir=$PWD
 {command}
 
@@ -465,6 +467,8 @@ def test_create_source_script_with_job_config():
         == f"""
 #!/bin/sh
 
+git config --global user.email "user-cont-team@redhat.com"
+git config --global user.name "Packit"
 resultdir=$PWD
 {expected_command}
 


### PR DESCRIPTION
For some commands used in prepare-sources, git user needs to be configured.
Tested with this change here: https://download.copr.fedorainfracloud.org/results/lbarczio/test-custom-source/srpm-builds/03265822/builder-live.log.gz

---
N/A
