### PR TITLE
Introduce option for not requiring %autosetup for source-git init command

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1193,6 +1193,7 @@ class PackitAPI:
         upstream_remote: Optional[str] = None,
         pkg_tool: Optional[str] = None,
         pkg_name: Optional[str] = None,
+        ignore_missing_autosetup: bool = False,
     ):
         """
         Initialize a source-git repo from dist-git, that is: add configuration, packaging files
@@ -1209,6 +1210,8 @@ class PackitAPI:
                 of the upstream project to be saved in the source-git configuration.
             pkg_tool: Packaging tool to be used to interact with the dist-git repo.
             pkg_name: Name of the package in dist-git.
+            ignore_missing_autosetup: Do not require %autosetup to be used in the %prep
+                section of specfile.
         """
         sgg = SourceGitGenerator(
             config=self.config,
@@ -1219,5 +1222,6 @@ class PackitAPI:
             upstream_remote=upstream_remote,
             pkg_tool=pkg_tool,
             pkg_name=pkg_name,
+            ignore_missing_autosetup=ignore_missing_autosetup,
         )
         sgg.create_from_upstream()

--- a/packit/cli/source_git_init.py
+++ b/packit/cli/source_git_init.py
@@ -46,6 +46,13 @@ logger = logging.getLogger(__name__)
     help="""The name of the package in the distro.
     Defaults to the directory name of DIST_GIT.""",
 )
+@click.option(
+    "--ignore-missing-autosetup",
+    is_flag=True,
+    default=False,
+    help="Do not require %autosetup macro to be used in %prep section of specfile. "
+    "By default, %autosetup is required.",
+)
 @pass_config
 @cover_packit_exception
 def source_git_init(
@@ -57,6 +64,7 @@ def source_git_init(
     upstream_remote,
     pkg_tool: Optional[str],
     pkg_name: Optional[str],
+    ignore_missing_autosetup: bool,
 ):
     """Initialize SOURCE_GIT as a source-git repo by applying downstream
     patches from DIST_GIT as Git commits on top of UPSTREAM_REF.
@@ -98,4 +106,5 @@ def source_git_init(
         upstream_remote=upstream_remote,
         pkg_tool=pkg_tool or config.pkg_tool,
         pkg_name=pkg_name,
+        ignore_missing_autosetup=ignore_missing_autosetup,
     )

--- a/packit/source_git.py
+++ b/packit/source_git.py
@@ -57,6 +57,8 @@ class SourceGitGenerator:
             of the upstream project to be saved in the source-git configuration.
         pkg_tool: Packaging tool to be used to interact with the dist-git repo.
         pkg_name: Name of the package in dist-git.
+        ignore_missing_autosetup: Do not require %autosetup to be used in
+            the %prep section of specfile.
     """
 
     def __init__(
@@ -69,6 +71,7 @@ class SourceGitGenerator:
         upstream_remote: Optional[str] = None,
         pkg_tool: Optional[str] = None,
         pkg_name: Optional[str] = None,
+        ignore_missing_autosetup: bool = False,
     ):
         self.config = config
         self.source_git = source_git
@@ -88,6 +91,7 @@ class SourceGitGenerator:
             )
         self.pkg_tool = pkg_tool
         self.pkg_name = pkg_name or Path(self.dist_git.working_dir).name
+        self.ignore_missing_autosetup = ignore_missing_autosetup
 
         self._dist_git_specfile: Optional[Specfile] = None
         self.distro_dir = Path(self.source_git.working_dir, DISTRO_DIR)
@@ -319,9 +323,16 @@ class SourceGitGenerator:
                 f"in {self.source_git.working_dir!r}."
             )
         if not self.dist_git_specfile.uses_autosetup:
-            raise PackitException(
-                "Initializing source-git repos for packages "
-                "not using %autosetup is not supported."
+            if not self.ignore_missing_autosetup:
+                raise PackitException(
+                    "Initializing source-git repos for packages "
+                    "not using %autosetup is not allowed by default. "
+                    "You can use --ignore-missing-autosetup option to enforce "
+                    "running the command without %autosetup."
+                )
+            logger.warning(
+                "Source-git repos for packages not using %autosetup may be not initialized"
+                "properly or may not work with other packit commands."
             )
 
         self._populate_distro_dir()


### PR DESCRIPTION
Introduce a new command option for packit source-git init --no-require-autosetup.
If used, command will try to initialize the source git repository even if the
%autosetup is not used, which was previously not supported.

I am not sure from the issue description, whether something else needs to be done here or not.

Fixes #1425 

---
TBD
