### PR TITLE
Handle colon in git trailer values

### DIFF
--- a/tests/unit/test_patches.py
+++ b/tests/unit/test_patches.py
@@ -103,10 +103,12 @@ Content-Transfer-Encoding: 8bit
 
 This is an explanation why the content was added.
 
-Patch-name: clever.patch
+Patch-name: clev:er.patch
 Patch-id: 200
 Patch-status: |
-    # This needs to be here
+    # The: empty line
+    #
+    # needs to be here
 Patch-present-in-specfile: true
 Ignore-patch: true
 No-prefix: true
@@ -239,8 +241,8 @@ def test_commit_message(patch_file, strip_subject_prefix, strip_trailers, reques
         (
             "patch_with_meta",
             {
-                "name": "clever.patch",
-                "description": "# This needs to be here",
+                "name": "clev:er.patch",
+                "description": "# The: empty line\n#\n# needs to be here",
                 "present_in_specfile": True,
                 "ignore": True,
                 "patch_id": 200,


### PR DESCRIPTION
I noticed that `source-git update-dist-git` didn't create a description of one patch from a source-git commit even it was correctly stated in the `Patch-status` git trailer. The cause was a colon in the description.
The previous code didn't expect a colon in a trailer value, which can easily happen either in the `Patch-status` or in `Patch-name` or in some future trailer that would accept a dictionary (we claim the values are YAMLs).

Initially, I wanted to use parsing/unfolding via `git interpret-trailers --parse`, because it'd simplify the parsing and because the YAML block scalars are a bit different from how git-interpret-trailers parses the multiline values per RFC 822, but eventually, I chose a less invasive solution.

---

Packit now correctly handles colons in git trailer values in source-git commits.
