### PR TITLE
Syncing of default files can be disabled

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -173,7 +173,7 @@ class PackitAPI:
         if sync_default_files:
             synced_files = self.package_config.get_all_files_to_sync()
         else:
-            synced_files = self.package_config.synced_files
+            synced_files = self.package_config.files_to_sync
         # Make all paths absolute and check that they are within
         # the working directories of the repositories.
         for item in synced_files:
@@ -575,7 +575,7 @@ class PackitAPI:
         files = (
             [self.package_config.get_specfile_sync_files_item(from_downstream=True)]
             if sync_only_specfile
-            else self.package_config.synced_files
+            else self.package_config.files_to_sync
         )
 
         # Drop files to be excluded from the sync.

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -113,7 +113,7 @@ class CommonPackageConfig:
         warnings.warn(msg, DeprecationWarning)
         if self._files_to_sync_used:
             logger.warning(
-                "You are setting both files_to_sync and synced_file."
+                "You are setting both files_to_sync and synced_files."
                 " Packit will use files_to_sync. You should remove "
                 "synced_files since it is deprecated."
             )

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -172,6 +172,7 @@ class JobConfig(CommonPackageConfig):
         config_file_path: Optional[str] = None,
         specfile_path: Optional[str] = None,
         synced_files: Optional[List[SyncFilesItem]] = None,
+        files_to_sync: Optional[List[SyncFilesItem]] = None,
         dist_git_namespace: str = None,
         upstream_project_url: str = None,  # can be URL or path
         upstream_package_name: str = None,
@@ -198,6 +199,7 @@ class JobConfig(CommonPackageConfig):
             config_file_path=config_file_path,
             specfile_path=specfile_path,
             synced_files=synced_files,
+            files_to_sync=files_to_sync,
             dist_git_namespace=dist_git_namespace,
             upstream_project_url=upstream_project_url,
             upstream_package_name=upstream_package_name,
@@ -229,7 +231,7 @@ class JobConfig(CommonPackageConfig):
             f"JobConfig(job={self.type}, trigger={self.trigger}, meta={self.metadata}, "
             f"config_file_path='{self.config_file_path}', "
             f"specfile_path='{self.specfile_path}', "
-            f"synced_files='{self.synced_files}', "
+            f"files_to_sync='{self.files_to_sync}', "
             f"dist_git_namespace='{self.dist_git_namespace}', "
             f"upstream_project_url='{self.upstream_project_url}', "
             f"upstream_package_name='{self.upstream_package_name}', "
@@ -269,7 +271,7 @@ class JobConfig(CommonPackageConfig):
             and self.trigger == other.trigger
             and self.metadata == other.metadata
             and self.specfile_path == other.specfile_path
-            and self.synced_files == other.synced_files
+            and self.files_to_sync == other.files_to_sync
             and self.dist_git_namespace == other.dist_git_namespace
             and self.upstream_project_url == other.upstream_project_url
             and self.upstream_package_name == other.upstream_package_name

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -32,6 +32,7 @@ class PackageConfig(CommonPackageConfig):
         config_file_path: Optional[str] = None,
         specfile_path: Optional[str] = None,
         synced_files: Optional[List[SyncFilesItem]] = None,
+        files_to_sync: Optional[List[SyncFilesItem]] = None,
         jobs: Optional[List[JobConfig]] = None,
         dist_git_namespace: str = None,
         upstream_project_url: str = None,  # can be URL or path
@@ -59,6 +60,7 @@ class PackageConfig(CommonPackageConfig):
             config_file_path=config_file_path,
             specfile_path=specfile_path,
             synced_files=synced_files,
+            files_to_sync=files_to_sync,
             dist_git_namespace=dist_git_namespace,
             upstream_project_url=upstream_project_url,
             upstream_package_name=upstream_package_name,
@@ -88,7 +90,7 @@ class PackageConfig(CommonPackageConfig):
             "PackageConfig("
             f"config_file_path='{self.config_file_path}', "
             f"specfile_path='{self.specfile_path}', "
-            f"synced_files='{self.synced_files}', "
+            f"files_to_sync='{self.files_to_sync}', "
             f"jobs='{self.jobs}', "
             f"dist_git_namespace='{self.dist_git_namespace}', "
             f"upstream_project_url='{self.upstream_project_url}', "
@@ -185,7 +187,7 @@ class PackageConfig(CommonPackageConfig):
         logger.debug(f"the other configuration:\n{other.__dict__}")
         return (
             self.specfile_path == other.specfile_path
-            and self.synced_files == other.synced_files
+            and self.files_to_sync == other.files_to_sync
             and self.jobs == other.jobs
             and self.dist_git_namespace == other.dist_git_namespace
             and self.upstream_project_url == other.upstream_project_url

--- a/packit/config/package_config_validator.py
+++ b/packit/config/package_config_validator.py
@@ -53,7 +53,7 @@ class PackageConfigValidator:
         synced_files_errors = []
         if config:
             synced_files_errors = [
-                f for f in iter_srcs(config.synced_files) if not Path(f).exists()
+                f for f in iter_srcs(config.files_to_sync) if not Path(f).exists()
             ]
 
         output = f"{self.config_file_path.name} does not pass validation:\n"

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -65,7 +65,7 @@ PACKIT_CONFIG_TEMPLATE = """# See the documentation for more information:
 specfile_path: {specfile_path}
 
 # add or remove files that should be synced
-synced_files:
+files_to_sync:
     - {specfile_path}
     - .packit.yaml
 

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -291,6 +291,7 @@ class CommonConfigSchema(Schema):
         deserialize="spec_source_id_fm", serialize="spec_source_id_serialize"
     )
     synced_files = fields.List(FilesToSyncField())
+    files_to_sync = fields.List(FilesToSyncField())
     actions = ActionField(default={})
     create_pr = fields.Bool(default=True)
     sync_changelog = fields.Bool(default=False)

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -1072,7 +1072,7 @@ def test_get_package_config_from_repo(
     )
     assert isinstance(config, PackageConfig)
     assert config.specfile_path == spec_path
-    assert config.synced_files == [
+    assert config.files_to_sync == [
         SyncFilesItem(src=["packit.spec"], dest="packit.spec"),
         SyncFilesItem(src=[".packit.yaml"], dest=".packit2.yaml"),
     ]
@@ -1156,6 +1156,17 @@ def test_get_package_config_from_repo_spec_file_not_defined(content):
                 SyncFilesItem(src=["packit.yaml"], dest="packit.yaml"),
             ],
         ),
+        (
+            PackageConfig(
+                config_file_path="packit.yaml",
+                specfile_path="file.spec",
+                synced_files=[SyncFilesItem(src=["file.txt"], dest="file.txt")],
+                files_to_sync=[SyncFilesItem(src=["file.spec"], dest="file.spec")],
+            ),
+            [
+                SyncFilesItem(src=["file.spec"], dest="file.spec"),
+            ],
+        ),
     ],
 )
 def test_get_all_files_to_sync(package_config, all_synced_files):
@@ -1211,6 +1222,34 @@ def test_get_local_package_config_path(
             downstream_package_name="package",
             upstream_package_name="package",
             synced_files=[
+                SyncFilesItem(src=["fedora/package.spec"], dest="fedora/package.spec")
+            ],
+        ),
+        PackageConfig(
+            specfile_path="fedora/package.spec",
+            downstream_package_name="package",
+            upstream_package_name="package",
+            synced_files=[
+                SyncFilesItem(src=["fedora/package.spec"], dest="fedora/package.spec")
+            ],
+            files_to_sync=[
+                SyncFilesItem(src=["fedora/package.spec"], dest="fedora/package.spec")
+            ],
+        ),
+        PackageConfig(
+            specfile_path="fedora/package.spec",
+            downstream_package_name="package",
+            upstream_package_name="package",
+            synced_files=[SyncFilesItem(src=["fedora/p.spec"], dest="fedora/p.spec")],
+            files_to_sync=[
+                SyncFilesItem(src=["fedora/package.spec"], dest="fedora/package.spec")
+            ],
+        ),
+        PackageConfig(
+            specfile_path="fedora/package.spec",
+            downstream_package_name="package",
+            upstream_package_name="package",
+            files_to_sync=[
                 SyncFilesItem(src=["fedora/package.spec"], dest="fedora/package.spec")
             ],
         ),


### PR DESCRIPTION
Fixes #1357

---

Spec file and configuration file are no more automatically added to the list of files to sync when the new ```files_to_sync``` option is used. The old ```synced_files``` option is deprecated.
