### PR TITLE
Update `source-git` commands to mark commit origin

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -28,7 +28,7 @@ from packit.config import Config
 from packit.config.common_package_config import CommonPackageConfig
 from packit.config.package_config import find_packit_yaml, load_packit_yaml
 from packit.config.package_config_validator import PackageConfigValidator
-from packit.constants import SYNCING_NOTE, DISTRO_DIR
+from packit.constants import SYNCING_NOTE, DISTRO_DIR, FROM_DIST_GIT_TOKEN
 from packit.copr_helper import CoprHelper
 from packit.distgit import DistGit
 from packit.exceptions import (
@@ -328,7 +328,12 @@ class PackitAPI:
                 self.up.local_project.git_repo.is_dirty()
                 or self.up.local_project.git_repo.untracked_files
             ):
-                self.up.commit(title=title, msg=message, prefix="")
+                self.up.commit(
+                    title=title,
+                    msg=message,
+                    prefix="",
+                    trailers=[(FROM_DIST_GIT_TOKEN, commit.hexsha)],
+                )
             else:
                 logger.info(
                     f"Commit {commit} had no changes to be applied, skipping it."

--- a/packit/cli/source_git_init.py
+++ b/packit/cli/source_git_init.py
@@ -83,6 +83,9 @@ def source_git_init(
     out before setting up the source-git repo. This branch is expected
     to exist.
 
+    Each Git commit created in SOURCE_GIT will have a 'From-dist-git-commit'
+    trailer to mark the hash of the dist-git commit from which it is created.
+
     To learn more about source-git, please check
 
         https://packit.dev/docs/source-git/

--- a/packit/cli/update_dist_git.py
+++ b/packit/cli/update_dist_git.py
@@ -76,7 +76,9 @@ def update_dist_git(
     does not checkout branches or fetches remotes.
 
     A commit in dist-git is created only if a commit message is provided with
-    --message or --file.
+    --message or --file. This commit will have a 'From-source-git-commit'
+    Git-trailer appended to it, to mark the hash of the source-git commit
+    from which it is created.
 
     The source archives are retrieved from the upstream URLs specified in
     the spec-file and uploaded to the lookaside cache in dist-git only if
@@ -131,4 +133,5 @@ def update_dist_git(
         commit_msg=message,
         sync_default_files=False,
         pkg_tool=pkg_tool,
+        mark_commit_origin=True,
     )

--- a/packit/cli/update_source_git.py
+++ b/packit/cli/update_source_git.py
@@ -52,7 +52,10 @@ def update_source_git(
     prior to the synchronization process.
 
     Dist-git commit messages are preserved and used when creating new
-    source-git commits.
+    source-git commits, but a 'From-dist-git-commit' trailer is appended
+    to them to mark the hash of the dist-git commit from which they
+    are created.
+
 
     Examples
 

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -153,3 +153,4 @@ packit -d prepare-sources --result-dir "$resultdir" {options}
 
 # Git-trailer tokens to mark the commit origin
 FROM_DIST_GIT_TOKEN = "From-dist-git-commit"
+FROM_SOURCE_GIT_TOKEN = "From-source-git-commit"

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -150,3 +150,6 @@ resultdir=$PWD
 packit -d prepare-sources --result-dir "$resultdir" {options}
 
 """
+
+# Git-trailer tokens to mark the commit origin
+FROM_DIST_GIT_TOKEN = "From-dist-git-commit"

--- a/packit/source_git.py
+++ b/packit/source_git.py
@@ -18,7 +18,12 @@ from rebasehelper.exceptions import LookasideCacheError
 from rebasehelper.helpers.lookaside_cache_helper import LookasideCacheHelper
 
 from packit.config import Config
-from packit.constants import RPM_MACROS_FOR_PREP, DISTRO_DIR, SRC_GIT_CONFIG
+from packit.constants import (
+    RPM_MACROS_FOR_PREP,
+    DISTRO_DIR,
+    SRC_GIT_CONFIG,
+    FROM_DIST_GIT_TOKEN,
+)
 from packit.exceptions import PackitException
 from packit.patches import PatchMetadata
 from packit.pkgtool import PkgTool
@@ -225,6 +230,7 @@ class SourceGitGenerator:
                 message += "Patch-status: |\n"
             for line in patch_comments.get(metadata.name, []):
                 message += f"    # {line}\n"
+            message += f"{FROM_DIST_GIT_TOKEN}: {self.dist_git.head.commit.hexsha}"
             self.source_git.git.commit(message=message, amend=True, allow_empty=True)
 
         self.source_git.git.branch("-D", to_branch)
@@ -347,7 +353,11 @@ class SourceGitGenerator:
         spec.remove_patches()
 
         self.source_git.git.stage(DISTRO_DIR, force=True)
-        self.source_git.git.commit(message="Initialize as a source-git repository")
+        message = f"""Initialize as a source-git repository
+
+{FROM_DIST_GIT_TOKEN}: {self.dist_git.head.commit.hexsha}
+"""
+        self.source_git.git.commit(message=message)
 
         pkg_tool = PkgTool(
             fas_username=self.config.fas_user,

--- a/tests/integration/test_source_git_init.py
+++ b/tests/integration/test_source_git_init.py
@@ -159,6 +159,10 @@ def test_create_from_upstream_no_patch(hello_source_git_repo, hello_dist_git_rep
     )
     check_source_git_config(source_git_config)
     assert source_git_config["patch_generation_patch_id_digits"] == 1
+    assert (
+        f"\nFrom-dist-git-commit: {hello_dist_git_repo.head.commit.hexsha}\n"
+        in hello_source_git_repo.head.commit.message
+    )
 
 
 @pytest.mark.skipif(
@@ -206,11 +210,19 @@ def test_create_from_upstream_with_patch(hello_source_git_repo, hello_dist_git_r
     assert "Patch-name: turn-into-fedora.patch" in commit_messsage_lines
     assert "Patch-id: 1" in commit_messsage_lines
     assert "Patch-status: |" in commit_messsage_lines
+    assert (
+        f"From-dist-git-commit: {hello_dist_git_repo.head.commit.hexsha}"
+        in commit_messsage_lines
+    )
 
     commit_messsage_lines = hello_source_git_repo.commit("HEAD").message.splitlines()
     assert "Patch-name: from-git.patch" in commit_messsage_lines
     assert "Patch-id: 2" in commit_messsage_lines
     assert "Patch-status: |" in commit_messsage_lines
+    assert (
+        f"From-dist-git-commit: {hello_dist_git_repo.head.commit.hexsha}"
+        in commit_messsage_lines
+    )
 
 
 @pytest.mark.skipif(
@@ -271,8 +283,16 @@ def test_create_from_upstream_not_require_autosetup(
     assert "Patch-name: turn-into-fedora.patch" in commit_messsage_lines
     assert "Patch-id: 1" in commit_messsage_lines
     assert "Patch-status: |" in commit_messsage_lines
+    assert (
+        f"From-dist-git-commit: {hello_dist_git_repo.head.commit.hexsha}"
+        in commit_messsage_lines
+    )
 
     commit_messsage_lines = hello_source_git_repo.commit("HEAD").message.splitlines()
     assert "Patch-name: from-git.patch" in commit_messsage_lines
     assert "Patch-id: 2" in commit_messsage_lines
     assert "Patch-status: |" in commit_messsage_lines
+    assert (
+        f"From-dist-git-commit: {hello_dist_git_repo.head.commit.hexsha}"
+        in commit_messsage_lines
+    )

--- a/tests/integration/test_source_git_update_source_git.py
+++ b/tests/integration/test_source_git_update_source_git.py
@@ -115,6 +115,10 @@ def test_update_source_git(
     update_api.update_source_git("HEAD~1..")
     assert (sourcegit / DISTRO_DIR / new_file).read_text() == content
     assert "Add" in update_api.up.local_project.git_repo.head.commit.message
+    assert (
+        f"From-dist-git-commit: {update_api.dg.local_project.git_repo.head.commit.hexsha}"
+        in update_api.up.local_project.git_repo.head.commit.message
+    )
 
     # Modify the existing file
     extra_content = "\ndefgh"
@@ -124,6 +128,10 @@ def test_update_source_git(
     update_api.update_source_git("HEAD~1..")
     assert (sourcegit / DISTRO_DIR / new_file).read_text() == content + extra_content
     assert "Modify" in update_api.up.local_project.git_repo.head.commit.message
+    assert (
+        f"From-dist-git-commit: {update_api.dg.local_project.git_repo.head.commit.hexsha}"
+        in update_api.up.local_project.git_repo.head.commit.message
+    )
 
     # Rename a file
     new_name = "test.txt"
@@ -134,6 +142,10 @@ def test_update_source_git(
     with open(sourcegit / DISTRO_DIR / new_name, "r") as file:
         assert file.read() == content + extra_content
     assert "Rename" in update_api.up.local_project.git_repo.head.commit.message
+    assert (
+        f"From-dist-git-commit: {update_api.dg.local_project.git_repo.head.commit.hexsha}"
+        in update_api.up.local_project.git_repo.head.commit.message
+    )
 
     # Delete a file
     (distgit / new_name).unlink()
@@ -141,3 +153,7 @@ def test_update_source_git(
     update_api.update_source_git("HEAD~1..")
     assert not (sourcegit / DISTRO_DIR / new_name).exists()
     assert "Delete" in update_api.up.local_project.git_repo.head.commit.message
+    assert (
+        f"From-dist-git-commit: {update_api.dg.local_project.git_repo.head.commit.hexsha}"
+        in update_api.up.local_project.git_repo.head.commit.message
+    )


### PR DESCRIPTION
- [x] `source-git init`
- [x] `source-git update-source-git`
- [x] `source-git update-dist-git`
- [x] Release notes.
- [ ] Update docs on packit.dev once this is ready to be merged.

Fixes #1472.

---
RELEASE NOTES BEGIN
All `source-git`-commands were updated to append a `From-source-git-commit` or `From-dist-git-commit` Git-trailer to the commit messages they create in dist-git or source-git, in order to save the hash of the commits from which these commits were created. This information is going to be used to tell whether a source-git repository is in sync with the corresponding dist-git repository.
RELEASE NOTES END