### PR TITLE
Add 'srpm_build_deps' configuration key for package config

### DIFF
--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -61,6 +61,7 @@ class CommonPackageConfig:
         copy_upstream_release_description: bool = False,
         sources: Optional[List[SourcesItem]] = None,
         merge_pr_in_ci: bool = True,
+        srpm_build_deps: Optional[List[str]] = None,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -105,6 +106,7 @@ class CommonPackageConfig:
         self.copy_upstream_release_description = copy_upstream_release_description
         self.sources = sources or []
         self.merge_pr_in_ci = merge_pr_in_ci
+        self.srpm_build_deps = srpm_build_deps
 
     def _warn_user(self):
         logger = logging.getLogger(__name__)
@@ -163,7 +165,8 @@ class CommonPackageConfig:
             f"patch_generation_patch_id_digits='{self.patch_generation_patch_id_digits}',"
             f"copy_upstream_release_description='{self.copy_upstream_release_description}',"
             f"sources='{self.sources}', "
-            f"merge_pr_in_ci={self.merge_pr_in_ci})"
+            f"merge_pr_in_ci={self.merge_pr_in_ci}, "
+            f"srpm_build_deps={self.srpm_build_deps})"
         )
 
     @property

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -194,6 +194,7 @@ class JobConfig(CommonPackageConfig):
         copy_upstream_release_description: bool = False,
         sources: Optional[List[SourcesItem]] = None,
         merge_pr_in_ci: bool = True,
+        srpm_build_deps: Optional[List[str]] = None,
     ):
         super().__init__(
             config_file_path=config_file_path,
@@ -221,6 +222,7 @@ class JobConfig(CommonPackageConfig):
             copy_upstream_release_description=copy_upstream_release_description,
             sources=sources,
             merge_pr_in_ci=merge_pr_in_ci,
+            srpm_build_deps=srpm_build_deps,
         )
         self.type: JobType = type
         self.trigger: JobConfigTriggerType = trigger
@@ -250,7 +252,8 @@ class JobConfig(CommonPackageConfig):
             f"patch_generation_patch_id_digits='{self.patch_generation_patch_id_digits}',"
             f"copy_upstream_release_description='{self.copy_upstream_release_description}',"
             f"sources='{self.sources}', "
-            f"merge_pr_in_ci={self.merge_pr_in_ci})"
+            f"merge_pr_in_ci={self.merge_pr_in_ci}, "
+            f"srpm_build_deps={self.srpm_build_deps})"
         )
 
     @classmethod
@@ -289,6 +292,7 @@ class JobConfig(CommonPackageConfig):
             == other.copy_upstream_release_description
             and self.sources == other.sources
             and self.merge_pr_in_ci == other.merge_pr_in_ci
+            and self.srpm_build_deps == other.srpm_build_deps
         )
 
 

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -55,6 +55,7 @@ class PackageConfig(CommonPackageConfig):
         copy_upstream_release_description: bool = False,
         sources: Optional[List[SourcesItem]] = None,
         merge_pr_in_ci: bool = True,
+        srpm_build_deps: Optional[List[str]] = None,
     ):
         super().__init__(
             config_file_path=config_file_path,
@@ -82,6 +83,7 @@ class PackageConfig(CommonPackageConfig):
             copy_upstream_release_description=copy_upstream_release_description,
             sources=sources,
             merge_pr_in_ci=merge_pr_in_ci,
+            srpm_build_deps=srpm_build_deps,
         )
         self.jobs: List[JobConfig] = jobs or []
 
@@ -111,7 +113,8 @@ class PackageConfig(CommonPackageConfig):
             f"patch_generation_patch_id_digits='{self.patch_generation_patch_id_digits}', "
             f"copy_upstream_release_description='{self.copy_upstream_release_description}',"
             f"sources='{self.sources}', "
-            f"merge_pr_in_ci={self.merge_pr_in_ci})"
+            f"merge_pr_in_ci={self.merge_pr_in_ci}, "
+            f"srpm_build_deps={self.srpm_build_deps})"
         )
 
     @classmethod
@@ -206,6 +209,7 @@ class PackageConfig(CommonPackageConfig):
             == other.copy_upstream_release_description
             and self.sources == other.sources
             and self.merge_pr_in_ci == other.merge_pr_in_ci
+            and self.srpm_build_deps == other.srpm_build_deps
         )
 
 

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -304,6 +304,7 @@ class CommonConfigSchema(Schema):
     copy_upstream_release_description = fields.Bool(default=False)
     sources = fields.List(fields.Nested(SourceSchema), missing=None)
     merge_pr_in_ci = fields.Bool(default=True)
+    srpm_build_deps = fields.List(fields.String(), missing=None)
 
     @staticmethod
     def spec_source_id_serialize(value: PackageConfig):

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -1303,6 +1303,17 @@ def test_get_local_package_config_path(
                 ),
             ],
         ),
+        PackageConfig(
+            specfile_path="fedora/package.spec",
+            actions={
+                ActionName.pre_sync: "some/pre-sync/command --option",
+                ActionName.get_current_version: "get-me-version",
+            },
+            jobs=[],
+            upstream_project_url="https://github.com/asd/qwe",
+            upstream_package_name="qwe",
+            srpm_build_deps=["make", "tar", "findutils"],
+        ),
     ],
 )
 def test_serialize_and_deserialize(package_config):


### PR DESCRIPTION
This will be used in packit-service for configuring dependencies for SRPM built in Copr.

Initially, I wanted to add the key into the `actions` section, but when looking into the config and schema validation, I think actions should really include only actions with predefined names, so I added it as a top-level key.

RELEASE NOTES BEGIN

RELEASE NOTES END
