### PR TITLE
repr(config): only output configured values

### DIFF
--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -177,10 +177,11 @@ class CommonPackageConfig:
 
     @property
     def dist_git_package_url(self):
-        return (
-            f"{self.dist_git_base_url}{self.dist_git_namespace}/"
-            f"{self.downstream_package_name}.git"
-        )
+        if self.downstream_package_name:
+            return (
+                f"{self.dist_git_base_url}{self.dist_git_namespace}/"
+                f"{self.downstream_package_name}.git"
+            )
 
     def get_specfile_sync_files_item(self, from_downstream: bool = False):
         """

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -101,26 +101,37 @@ class JobMetadataConfig:
         self.skip_build: bool = skip_build
         self.env: Dict[str, Any] = env or {}
 
-    def __repr__(self):
-        return (
-            f"JobMetadataConfig("
-            f"targets={self._targets}, "
-            f"timeout={self.timeout}, "
-            f"owner={self.owner}, "
-            f"project={self.project}, "
+    def __repr__(self) -> str:
+        """Show values that were set in this job metadata config"""
+        content = (
+            f"timeout={self.timeout}, " if self.timeout else "",
+            f"owner={self.owner}, " if self.owner else "",
+            f"project={self.project}, " if self.project else "",
             f"dist_git_branches={self.dist_git_branches}, "
-            f"branch={self.branch}, "
-            f"scratch={self.scratch}, "
+            if self.dist_git_branches
+            else "",
+            f"branch={self.branch}, " if self.branch else "",
+            f"scratch={self.scratch}, " if self.scratch else "",
             f"list_on_homepage={self.list_on_homepage}, "
+            if self.list_on_homepage
+            else "",
             f"preserve_project={self.preserve_project}, "
+            if self.preserve_project
+            else "",
             f"additional_packages={self.additional_packages}, "
+            if self.additional_packages
+            else "",
             f"additional_repos={self.additional_repos}, "
-            f"fmf_url={self.fmf_url}, "
-            f"fmf_ref={self.fmf_ref}, "
-            f"use_internal_tf={self.use_internal_tf}, "
-            f"skip_build={self.skip_build},"
-            f"env={self.env})"
+            if self.additional_repos
+            else "",
+            f"fmf_url={self.fmf_url}, " if self.fmf_url else "",
+            f"fmf_ref={self.fmf_ref}, " if self.fmf_ref else "",
+            f"use_internal_tf={self.use_internal_tf}, " if self.use_internal_tf else "",
+            f"skip_build={self.skip_build}," if self.skip_build else "",
+            f"env={self.env}, " if self.env else "",
         )
+        # -2 = drop trailing ", "
+        return f"JobMetadataConfig(targets={self._targets}, {''.join(content)[:-2]})"
 
     def __eq__(self, other: object):
         if not isinstance(other, JobMetadataConfig):
@@ -228,32 +239,65 @@ class JobConfig(CommonPackageConfig):
         self.trigger: JobConfigTriggerType = trigger
         self.metadata: JobMetadataConfig = metadata or JobMetadataConfig()
 
-    def __repr__(self):
-        return (
-            f"JobConfig(job={self.type}, trigger={self.trigger}, meta={self.metadata}, "
+    def __repr__(self) -> str:
+        """Show values that were set in this job config"""
+        content = (
             f"config_file_path='{self.config_file_path}', "
-            f"specfile_path='{self.specfile_path}', "
-            f"files_to_sync='{self.files_to_sync}', "
+            if self.config_file_path
+            else "",
+            f"specfile_path='{self.specfile_path}', " if self.specfile_path else "",
+            f"files_to_sync='{self.files_to_sync}', " if self.files_to_sync else "",
             f"dist_git_namespace='{self.dist_git_namespace}', "
+            if self.dist_git_namespace
+            else "",
             f"upstream_project_url='{self.upstream_project_url}', "
+            if self.upstream_project_url
+            else "",
             f"upstream_package_name='{self.upstream_package_name}', "
+            if self.upstream_package_name
+            else "",
             f"downstream_project_url='{self.downstream_project_url}', "
+            if self.downstream_project_url
+            else "",
             f"downstream_package_name='{self.downstream_package_name}', "
+            if self.downstream_package_name
+            else "",
             f"dist_git_base_url='{self.dist_git_base_url}', "
-            f"actions='{self.actions}', "
-            f"upstream_ref='{self.upstream_ref}', "
+            if self.dist_git_base_url
+            else "",
+            f"actions='{self.actions}', " if self.actions else "",
+            f"upstream_ref='{self.upstream_ref}', " if self.upstream_ref else "",
             f"allowed_gpg_keys='{self.allowed_gpg_keys}', "
-            f"create_pr='{self.create_pr}', "
-            f"sync_changelog='{self.sync_changelog}', "
+            if self.allowed_gpg_keys
+            else "",
+            f"create_pr='{self.create_pr}', " if not self.create_pr else "",
+            f"sync_changelog='{self.sync_changelog}', " if self.sync_changelog else "",
             f"create_sync_note='{self.create_sync_note}', "
-            f"spec_source_id='{self.spec_source_id}', "
+            if self.create_sync_note
+            else "",
+            f"spec_source_id='{self.spec_source_id}', " if self.spec_source_id else "",
             f"upstream_tag_template='{self.upstream_tag_template}', "
-            f"patch_generation_ignore_paths='{self.patch_generation_ignore_paths}',"
-            f"patch_generation_patch_id_digits='{self.patch_generation_patch_id_digits}',"
-            f"copy_upstream_release_description='{self.copy_upstream_release_description}',"
-            f"sources='{self.sources}', "
+            if self.upstream_tag_template
+            else "",
+            f"patch_generation_ignore_paths='{self.patch_generation_ignore_paths}', "
+            if self.patch_generation_ignore_paths
+            else "",
+            f"patch_generation_patch_id_digits='{self.patch_generation_patch_id_digits}', "
+            if self.patch_generation_patch_id_digits
+            else "",
+            f"copy_upstream_release_description='{self.copy_upstream_release_description}', "
+            if self.copy_upstream_release_description
+            else "",
+            f"sources='{self.sources}', " if self.sources else "",
             f"merge_pr_in_ci={self.merge_pr_in_ci}, "
-            f"srpm_build_deps={self.srpm_build_deps})"
+            if not self.merge_pr_in_ci
+            else "",
+            f"srpm_build_deps={self.srpm_build_deps}, " if self.srpm_build_deps else "",
+        )
+        # -2 = drop trailing ", "
+        return (
+            f"JobConfig(job={self.type}, trigger={self.trigger}, "
+            f"meta={self.metadata}, {''.join(content)[:-2]})"
         )
 
     @classmethod

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -88,33 +88,63 @@ class PackageConfig(CommonPackageConfig):
         self.jobs: List[JobConfig] = jobs or []
 
     def __repr__(self):
-        return (
-            "PackageConfig("
+        content = (
             f"config_file_path='{self.config_file_path}', "
-            f"specfile_path='{self.specfile_path}', "
-            f"files_to_sync='{self.files_to_sync}', "
-            f"jobs='{self.jobs}', "
+            if self.config_file_path
+            else "",
+            f"files_to_sync='{self.files_to_sync}', " if self.files_to_sync else "",
             f"dist_git_namespace='{self.dist_git_namespace}', "
+            if self.dist_git_namespace
+            else "",
             f"upstream_project_url='{self.upstream_project_url}', "
+            if self.upstream_project_url
+            else "",
             f"upstream_package_name='{self.upstream_package_name}', "
+            if self.upstream_package_name
+            else "",
             f"downstream_project_url='{self.downstream_project_url}', "
+            if self.downstream_project_url
+            else "",
             f"downstream_package_name='{self.downstream_package_name}', "
+            if self.downstream_package_name
+            else "",
             f"dist_git_base_url='{self.dist_git_base_url}', "
-            f"actions='{self.actions}', "
-            f"upstream_ref='{self.upstream_ref}', "
+            if self.dist_git_base_url
+            else "",
+            f"upstream_ref='{self.upstream_ref}', " if self.upstream_ref else "",
             f"allowed_gpg_keys='{self.allowed_gpg_keys}', "
-            f"create_pr='{self.create_pr}', "
-            f"sync_changelog='{self.sync_changelog}', "
+            if self.allowed_gpg_keys
+            else "",
+            f"create_pr='{self.create_pr}', " if not self.create_pr else "",
+            f"sync_changelog='{self.sync_changelog}', " if self.sync_changelog else "",
             f"create_sync_note='{self.create_sync_note}', "
-            f"spec_source_id='{self.spec_source_id}', "
+            if self.create_sync_note
+            else "",
+            f"spec_source_id='{self.spec_source_id}', " if self.spec_source_id else "",
             f"upstream_tag_template='{self.upstream_tag_template}', "
+            if self.upstream_tag_template
+            else "",
             f"archive_root_dir_template={self.archive_root_dir_template}', "
+            if self.archive_root_dir_template
+            else "",
             f"patch_generation_ignore_paths='{self.patch_generation_ignore_paths}', "
+            if self.patch_generation_ignore_paths
+            else "",
             f"patch_generation_patch_id_digits='{self.patch_generation_patch_id_digits}', "
+            if self.patch_generation_patch_id_digits
+            else "",
             f"copy_upstream_release_description='{self.copy_upstream_release_description}',"
-            f"sources='{self.sources}', "
+            if self.copy_upstream_release_description
+            else "",
+            f"sources='{self.sources}', " if self.sources else "",
             f"merge_pr_in_ci={self.merge_pr_in_ci}, "
-            f"srpm_build_deps={self.srpm_build_deps})"
+            if not self.merge_pr_in_ci
+            else "",
+            f"srpm_build_deps={self.srpm_build_deps}, " if self.srpm_build_deps else "",
+        )
+        return (
+            f"PackageConfig(specfile_path='{self.specfile_path}', jobs='{self.jobs}', "
+            f"actions='{self.actions}', {''.join(content)[:-2]})"
         )
 
     @classmethod

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -13,6 +13,7 @@ from packit.config import (
     JobConfig,
     JobType,
     JobConfigTriggerType,
+    PackageConfig,
 )
 from packit.config.aliases import DEFAULT_VERSION
 from packit.config.job_config import JobMetadataConfig
@@ -257,3 +258,26 @@ def test_job_metadata_targets(config, is_valid):
     else:
         with pytest.raises(ValidationError):
             JobMetadataSchema().load(config)
+
+
+def test_repr_simple_packageconfig(job_config_simple):
+    assert str(PackageConfig()) == (
+        "PackageConfig(specfile_path='None', jobs='[]', actions='{}', "
+        "dist_git_namespace='rpms', dist_git_base_url='https://src.fedoraproject.org/', "
+        "create_sync_note='True', spec_source_id='Source0', "
+        "upstream_tag_template='{version}', archive_root_dir_template="
+        "{upstream_pkg_name}-{version}', patch_generation_patch_id_digits='4')"
+    )
+
+
+def test_repr_simple_jobconfig(job_config_simple):
+    assert (
+        str(job_config_simple.metadata) == "JobMetadataConfig(targets={}, timeout=7200)"
+    )
+    assert str(job_config_simple) == (
+        "JobConfig(job=JobType.build, trigger=JobConfigTriggerType.release, "
+        "meta=JobMetadataConfig(targets={}, timeout=7200), dist_git_namespace='rpms', "
+        "dist_git_base_url='https://src.fedoraproject.org/', create_sync_note='True', "
+        "spec_source_id='Source0', upstream_tag_template='{version}', "
+        "patch_generation_patch_id_digits='4')"
+    )


### PR DESCRIPTION
Make it easier to read package config from logs of a job.

TODO:
* [ ] agree on design and implementation

Current status: we need to conclude on next steps, IRC chat log:
```
09:50 <TomasTomecek[m]> PTAL https://github.com/packit/packit/pull/1494 this was on my todo list for a long time - was anyone else upset about it as well?
09:52 <csomh[m]> I don't think this is a good idea, or at least, I find it more valuable to have all the values listed at one place, and don't have to second guess defaults.
09:53 <csomh[m]> Much more valuable for debugging, imho.
09:53 <TomasTomecek[m]> but it's really hard to see what has actually changed if the list contains 30 values and most of them are None or False
09:54 <csomh[m]> Yes, I do understand that, but then why not add a link to the .packit.yaml from which the config object was created? Or make it easy to get to it in some other way?
09:55 <TomasTomecek[m]> alternatively we could pretty-print it, since we already do that
09:55 <csomh[m]> I can imagine debugging situations when knowing for sure that something is None or False can be important, even if that one is the default.
09:57 <TomasTomecek[m]> yes, that's true - if it's not printed, it means it's either False, None or ""
09:57 <TomasTomecek[m]> (LocalProject arguments are printed as one line each: https://dashboard.packit.dev/results/srpm-builds/56143 )
09:59 <csomh[m]> TomasTomecek[m]: > Explicit is better than implicit.
09:59 <FrantisekLachman> I see multiple topics/improvements here:
09:59 <FrantisekLachman> * Print the config nicely (+1)
09:59 <FrantisekLachman> * Print some URL to the config (+1, but not 100% reliable since the ref can be removed, etc.)
09:59 <FrantisekLachman> * Print only relevant info (What about printing only non-default values?)
10:01 <FrantisekLachman> And I agree with the goal of this -- with the current state, it's really hard to work with the logged version of config.
10:02 <TomasTomecek[m]> maybe sorting them: print important and often used values first
10:02 <TomasTomecek[m]> and print every job on a single line
10:04 <FrantisekLachman> The sorting can help, but i am not sure with the job per line. The job config can be huge. Using some indenting looks better to me.
10:05 <FrantisekLachman> And a related question -- are we more interested in the raw content or the final one with defaults, deprecations, etc...?
10:06 <FrantisekLachman> s/one/state/
10:07 <TomasTomecek[m]> FrantisekLachman: maybe even both - to see how the config was processed
```


RELEASE NOTES BEGIN

TBD

RELEASE NOTES END