### PR TITLE
feat(copr): allow disabling of network for Copr builds

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1249,24 +1249,33 @@ class PackitAPI:
         additional_packages: List[str] = None,
         additional_repos: List[str] = None,
         request_admin_if_needed: bool = False,
+        enable_net: bool = True,
     ) -> Tuple[int, str]:
         """
         Submit a build to copr build system using an SRPM using the current checkout.
 
-        :param project: name of the copr project to build
-                        inside (defaults to something long and ugly)
-        :param chroots: a list of COPR chroots (targets) e.g. fedora-rawhide-x86_64
-        :param owner: defaults to username from copr config file
-        :param description: description of the project
-        :param instructions: installation instructions for the project
-        :param upstream_ref: git ref to upstream commit
-        :param list_on_homepage: if set, created copr project will be visible on copr's home-page
-        :param preserve_project: if set, project will not be created as temporary
-        :param list additional_packages: buildroot packages for the chroot [DOES NOT WORK YET]
-        :param list additional_repos: buildroot additional additional_repos
-        :param bool request_admin_if_needed: if we can't change the settings
-                                             and are not allowed to do so
-        :return: id of the created build and url to the build web page
+        Args:
+            project: Name of the copr project to build inside
+
+                Defaults to something long and ugly.
+            chroots: List of Copr chroots (targets), e.g. `fedora-rawhide-x86_64`.
+            owner: Defaults to username from copr config file.
+            description: Description of the Copr project.
+            instructions: Installation instructions for the Copr project.
+            upstream_ref: Git ref to upstream commit.
+            list_on_homepage: Specifies whether created Copr project will be
+                visible on Copr's homepage.
+            preserve_project: Specifies whether created Copr project should be
+                automatically deleted after specific period.
+            additional_packages: Buildroot packages for the chroot [DOES NOT WORK YET].
+            additional_repos: Buildroot additional additional_repos.
+            request_admin_if_needed: Specifies whether to ask for admin privileges,
+                if changes to configuration of Copr project are required.
+            enable_net: Specifies whether created Copr build should have access
+                to network during its build.
+
+        Returns:
+            ID of the created build and URL to the build web page.
         """
         srpm_path = self.create_srpm(
             upstream_ref=upstream_ref, srpm_dir=self.up.local_project.working_dir
@@ -1297,7 +1306,10 @@ class PackitAPI:
         )
 
         build = self.copr_helper.copr_client.build_proxy.create_from_file(
-            ownername=owner, projectname=project, path=srpm_path
+            ownername=owner,
+            projectname=project,
+            path=srpm_path,
+            buildopts={"enable_net": enable_net},
         )
         return build.id, self.copr_helper.copr_web_build_url(build)
 

--- a/packit/cli/copr_build.py
+++ b/packit/cli/copr_build.py
@@ -75,6 +75,12 @@ logger = logging.getLogger(__name__)
     default=False,
     is_flag=True,
 )
+@click.option(
+    "--enable-net/--disable-net",
+    help="Copr build is built with explicitly enabled network access or disabled",
+    default=True,
+    is_flag=True,
+)
 @click.argument("path_or_url", type=LocalProjectParameter(), default=os.path.curdir)
 @pass_config
 @cover_packit_exception
@@ -91,6 +97,7 @@ def copr_build(
     upstream_ref,
     additional_repos,
     request_admin_if_needed,
+    enable_net,
     path_or_url,
 ):
     """
@@ -146,6 +153,7 @@ def copr_build(
         preserve_project=preserve_project,
         additional_repos=additional_repos_list,
         request_admin_if_needed=request_admin_if_needed,
+        enable_net=enable_net,
     )
     click.echo(f"Build id: {build_id}, repo url: {repo_url}")
     if not nowait:

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -55,6 +55,7 @@ class JobMetadataConfig:
         use_internal_tf: bool = False,
         skip_build: bool = False,
         env: Dict[str, Any] = None,
+        enable_net: bool = True,
     ):
         """
         Args:
@@ -77,6 +78,7 @@ class JobMetadataConfig:
             use_internal_tf: if we want to use internal instance of Testing Farm
             skip_build: if we want to skip build phase for Testing Farm job
             env: environment variables
+            enable_net: if set to False, Copr builds have network disabled
         """
         self._targets: Dict[str, Dict[str, Any]]
         if isinstance(_targets, list):
@@ -100,6 +102,7 @@ class JobMetadataConfig:
         self.use_internal_tf: bool = use_internal_tf
         self.skip_build: bool = skip_build
         self.env: Dict[str, Any] = env or {}
+        self.enable_net = enable_net
 
     def __repr__(self):
         return (
@@ -119,7 +122,8 @@ class JobMetadataConfig:
             f"fmf_ref={self.fmf_ref}, "
             f"use_internal_tf={self.use_internal_tf}, "
             f"skip_build={self.skip_build},"
-            f"env={self.env})"
+            f"env={self.env},"
+            f"enable_net={self.enable_net})"
         )
 
     def __eq__(self, other: object):
@@ -144,6 +148,7 @@ class JobMetadataConfig:
             and self.use_internal_tf == other.use_internal_tf
             and self.skip_build == other.skip_build
             and self.env == other.env
+            and self.enable_net == other.enable_net
         )
 
     @property

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -235,6 +235,7 @@ class JobMetadataSchema(Schema):
     fmf_ref = fields.String(missing=None)
     skip_build = fields.Boolean()
     env = fields.Dict(keys=fields.String(), missing=None)
+    enable_net = fields.Boolean(missing=True)
 
     @pre_load
     def ordered_preprocess(self, data, **_):

--- a/tests/integration/test_copr_build.py
+++ b/tests/integration/test_copr_build.py
@@ -570,6 +570,7 @@ def test_copr_build_cli_no_project_configured(upstream_and_remote, copr_client_m
         preserve_project=False,
         additional_repos=None,
         request_admin_if_needed=False,
+        enable_net=True,
     ).and_return(("id", "url")).once()
 
     flexmock(packit.copr_helper.CoprClient).should_receive(
@@ -593,6 +594,7 @@ def test_copr_build_cli_project_set_via_cli(upstream_and_remote, copr_client_moc
         preserve_project=False,
         additional_repos=None,
         request_admin_if_needed=False,
+        enable_net=True,
     ).and_return(("id", "url")).once()
 
     flexmock(packit.copr_helper.CoprClient).should_receive(
@@ -627,6 +629,7 @@ def test_copr_build_cli_project_set_from_config(upstream_and_remote, copr_client
         preserve_project=False,
         additional_repos=None,
         request_admin_if_needed=False,
+        enable_net=True,
     ).and_return(("id", "url")).once()
 
     run_packit(["copr-build", "--nowait"], working_dir=upstream)


### PR DESCRIPTION
- Add `enable_net` to configuration
- Add `--enable-net/--disable-net` to Copr build CLI
- Extend API to allow disabling of network during Copr build

Signed-off-by: Matej Focko <mfocko@redhat.com>

Fixes #1386

RELEASE NOTES BEGIN

We have added a new configuration option for Copr builds `enable_net` that allows you to disable network access during Copr builds. It is also complemented by `--enable-net/--disable-net` CLI options if you use Packit locally.

RELEASE NOTES END
