### PR TITLE
Add a new job config option for identifying the job

### DIFF
--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -62,6 +62,7 @@ class CommonPackageConfig:
         sources: Optional[List[SourcesItem]] = None,
         merge_pr_in_ci: bool = True,
         srpm_build_deps: Optional[List[str]] = None,
+        identifier: Optional[str] = None,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -99,6 +100,7 @@ class CommonPackageConfig:
         self.notifications = notifications or NotificationsConfig(
             pull_request=PullRequestNotificationsConfig()
         )
+        self.identifier = identifier
 
         # template to create an upstream tag name (upstream may use different tagging scheme)
         self.upstream_tag_template = upstream_tag_template

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -200,6 +200,7 @@ class JobConfig(CommonPackageConfig):
         sources: Optional[List[SourcesItem]] = None,
         merge_pr_in_ci: bool = True,
         srpm_build_deps: Optional[List[str]] = None,
+        identifier: Optional[str] = None,
     ):
         super().__init__(
             config_file_path=config_file_path,
@@ -228,6 +229,7 @@ class JobConfig(CommonPackageConfig):
             sources=sources,
             merge_pr_in_ci=merge_pr_in_ci,
             srpm_build_deps=srpm_build_deps,
+            identifier=identifier,
         )
         self.type: JobType = type
         self.trigger: JobConfigTriggerType = trigger
@@ -258,7 +260,8 @@ class JobConfig(CommonPackageConfig):
             f"copy_upstream_release_description='{self.copy_upstream_release_description}',"
             f"sources='{self.sources}', "
             f"merge_pr_in_ci={self.merge_pr_in_ci}, "
-            f"srpm_build_deps={self.srpm_build_deps})"
+            f"srpm_build_deps={self.srpm_build_deps}, "
+            f"identifier={self.identifier})"
         )
 
     @classmethod
@@ -298,6 +301,7 @@ class JobConfig(CommonPackageConfig):
             and self.sources == other.sources
             and self.merge_pr_in_ci == other.merge_pr_in_ci
             and self.srpm_build_deps == other.srpm_build_deps
+            and self.identifier == other.identifier
         )
 
 


### PR DESCRIPTION
It will be used to differentiate the results of two similar jobs.

So you can e.g. build two packages from one repository (aka monorepo)
and the commit statuses will not collide.

Required for packit/packit-service#1385

Do you have a better name for the config option?

Signed-off-by: Frantisek Lachman <flachman@redhat.com>

RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
