### PR TITLE
feat(aliases,copr): switch to TTL cache

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,7 @@ repos:
             types-tabulate,
             types-Deprecated,
             types-PyYAML,
+            types-cachetools,
           ]
   - repo: https://github.com/packit/pre-commit-hooks
     rev: 1da916777f5cc26ecf221b15e58ca51891d26d94

--- a/files/install-requirements-pip.yaml
+++ b/files/install-requirements-pip.yaml
@@ -12,5 +12,6 @@
         - rebasehelper
         - sandcastle
         - requre
+        - cachetools
       become: true
     - include_tasks: tasks/requre.yaml

--- a/packit.spec
+++ b/packit.spec
@@ -29,6 +29,7 @@ BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(setuptools-scm)
 BuildRequires:  python3dist(setuptools-scm-git-archive)
 BuildRequires:  python3-bodhi-client
+BuildRequires:  python3-cachetools
 Requires:       python3-%{real_name} = %{version}-%{release}
 
 %description

--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -1,12 +1,13 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-import functools
 import logging
 from collections import defaultdict
+from datetime import timedelta
 from typing import Dict, List, Set
 
 from bodhi.client.bindings import BodhiClient
+from cachetools.func import ttl_cache
 
 from packit.copr_helper import CoprHelper
 from packit.exceptions import PackitException
@@ -212,7 +213,7 @@ def get_all_koji_targets() -> List[str]:
     return run_command(["koji", "list-targets", "--quiet"], output=True).split()
 
 
-@functools.lru_cache(maxsize=1)
+@ttl_cache(maxsize=1, ttl=timedelta(hours=12).seconds)
 @fallback_return_value(ALIASES)
 def get_aliases() -> Dict[str, List[str]]:
     """
@@ -221,7 +222,8 @@ def get_aliases() -> Dict[str, List[str]]:
     Current data are fetched via bodhi client, with default base url
     `https://bodhi.fedoraproject.org/'.
 
-    :return: dictionary containing aliases
+    Returns:
+        Dictionary containing aliases.
     """
 
     bodhi_client = BodhiClient()

--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -1,12 +1,12 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-import functools
 import logging
 import time
 from datetime import datetime, timedelta
 from typing import Callable, List, Optional, Dict, Tuple, Any
 
+from cachetools.func import ttl_cache
 from copr.v3 import Client as CoprClient
 from copr.v3.exceptions import (
     CoprNoResultException,
@@ -351,12 +351,13 @@ class CoprHelper:
         ]
 
     @staticmethod
-    @functools.lru_cache(maxsize=1)
+    @ttl_cache(maxsize=1, ttl=timedelta(hours=12).seconds)
     def get_available_chroots() -> list:
         """
         Gets available copr chroots. Uses cache to avoid repetitive url fetching.
 
-        :return: list of valid chroots
+        Returns:
+            List of valid chroots.
         """
 
         client = CoprClient.create_from_config_file()

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     tabulate
     bodhi-client
     koji
+    cachetools
 python_requires = >=3.6
 include_package_data = True
 setup_requires =


### PR DESCRIPTION
When using LRU cache in service, we can encounter situations such as
deprecation of chroots and dist-git branches or their introduction
before release. In these cases it is required to redeploy the service,
since the targets/branches are cached. Switch to TTL cache with 12-hour
long expiration, so that the targets and branches are fetched once in 12
hours.

Signed-off-by: Matej Focko <mfocko@redhat.com>

TODO:

- [x] fix tests if necessary - _trivially done_ (they passed)
- [x] make sure `cachetools` are added as dependency at all places where required

Fixes #1303

RELEASE NOTES BEGIN

We have switched the cache for dist-git branches and Copr targets to TTL cache that gets discarded once in 12 hours, in case there is a change in targets, the changes shall propagate to both of our deployments without the need to redeploy within 12 hours.

RELEASE NOTES END
