### PR TITLE
FAS authentication for Bodhi

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -52,6 +52,7 @@ from packit.status import Status
 from packit.sync import sync_files, SyncFilesItem
 from packit.upstream import Upstream
 from packit.utils import commands
+from packit.utils.bodhi import get_bodhi_client
 from packit.utils.changelog_helper import ChangelogHelper
 from packit.utils.extensions import assert_existence
 from packit.utils.repo import (
@@ -1329,11 +1330,11 @@ class PackitAPI:
 
     @staticmethod
     def push_bodhi_update(update_alias: str):
-        from bodhi.client.bindings import BodhiClient, UpdateNotFound
+        from bodhi.client.bindings import UpdateNotFound
 
-        b = BodhiClient()
+        bodhi_client = get_bodhi_client()
         try:
-            response = b.request(update=update_alias, request="stable")
+            response = bodhi_client.request(update=update_alias, request="stable")
             logger.debug(f"Bodhi response:\n{response}")
             response = response["update"]
             logger.info(
@@ -1346,10 +1347,8 @@ class PackitAPI:
             logger.error("Update was not found.")
 
     def get_testing_updates(self, update_alias: Optional[str]) -> List:
-        from bodhi.client.bindings import BodhiClient
-
-        b = BodhiClient()
-        results = b.query(
+        bodhi_client = get_bodhi_client()
+        results = bodhi_client.query(
             alias=update_alias,
             packages=self.dg.package_config.downstream_package_name,
             status="testing",

--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -6,11 +6,11 @@ from collections import defaultdict
 from datetime import timedelta
 from typing import Dict, List, Set
 
-from bodhi.client.bindings import BodhiClient
 from cachetools.func import ttl_cache
 
 from packit.copr_helper import CoprHelper
 from packit.exceptions import PackitException
+from packit.utils.bodhi import get_bodhi_client
 from packit.utils.commands import run_command
 from packit.utils.decorators import fallback_return_value
 
@@ -239,7 +239,7 @@ def get_aliases() -> Dict[str, List[str]]:
         Dictionary containing aliases.
     """
 
-    bodhi_client = BodhiClient()
+    bodhi_client = get_bodhi_client()
     releases = bodhi_client.get_releases(exclude_archived=True)
     aliases = defaultdict(list)
     for release in releases.releases:

--- a/packit/config/config.py
+++ b/packit/config/config.py
@@ -35,6 +35,7 @@ class Config:
         self,
         debug: bool = False,
         fas_user: Optional[str] = None,
+        fas_password: Optional[str] = None,
         keytab_path: Optional[str] = None,
         upstream_git_remote: Optional[str] = None,
         kerberos_realm: Optional[str] = "FEDORAPROJECT.ORG",
@@ -53,6 +54,7 @@ class Config:
     ):
         self.debug: bool = debug
         self.fas_user: Optional[str] = fas_user
+        self.fas_password: Optional[str] = fas_password
         self.keytab_path: Optional[str] = keytab_path
         self.kerberos_realm = kerberos_realm
         self.koji_build_command = koji_build_command

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -416,8 +416,15 @@ class DistGit(PackitRepositoryBase):
             f"About to create a Bodhi update of type {update_type!r} from {dist_git_branch!r}"
         )
 
-        # bodhi will likely prompt for username and password if kerb ticket is not up
-        b = BodhiClient()
+        if self.config.fas_user and self.config.fas_password:
+            b = BodhiClient(
+                username=self.config.fas_user, password=self.config.fas_password
+            )
+        else:
+            # Bodhi will prompt for username and password if the session is not cached.
+            # (It is stored as `~/.fedora/openidbaseclient-sessions.cache`.)
+            b = BodhiClient()
+
         if not koji_builds:
             # alternatively we can call something like `koji latest-build rawhide sen`
             builds_d = b.latest_builds(self.package_config.downstream_package_name)

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -416,6 +416,7 @@ class UserConfigSchema(Schema):
 
     debug = fields.Bool()
     fas_user = fields.String()
+    fas_password = fields.String()
     keytab_path = fields.String()
     upstream_git_remote = fields.String()
     github_token = fields.String()

--- a/packit/status.py
+++ b/packit/status.py
@@ -3,10 +3,9 @@
 
 import logging
 from datetime import datetime, timedelta
-from typing import List, Tuple, Dict, Set
+from typing import Dict, List, Set, Tuple
 
-from bodhi.client.bindings import BodhiClient
-from koji import ClientSession, BUILD_STATES
+from koji import BUILD_STATES, ClientSession
 
 from ogr.abstract import Release
 from packit.config import Config
@@ -15,6 +14,7 @@ from packit.copr_helper import CoprHelper
 from packit.distgit import DistGit
 from packit.exceptions import PackitException
 from packit.upstream import Upstream
+from packit.utils.bodhi import get_bodhi_client
 
 logger = logging.getLogger(__name__)
 
@@ -130,10 +130,10 @@ class Status:
         :param number_of_updates: int
         :return: None
         """
-        b = BodhiClient()
-        results = b.query(packages=self.dg.package_config.downstream_package_name)[
-            "updates"
-        ]
+        bodhi_client = get_bodhi_client()
+        results = bodhi_client.query(
+            packages=self.dg.package_config.downstream_package_name
+        )["updates"]
         logger.debug("Bodhi updates fetched.")
 
         stable_branches: Set[str] = set()

--- a/packit/utils/bodhi.py
+++ b/packit/utils/bodhi.py
@@ -1,0 +1,23 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+
+from bodhi.client.bindings import BodhiClient
+
+logger = logging.getLogger(__name__)
+
+
+def get_bodhi_client(fas_username: str = None, fas_password: str = None) -> BodhiClient:
+    """
+    Initialise the Bodhi client.
+
+    Bodhi will prompt for username and password
+    if the values are not set and the session is not cached.
+    (The session is stored as `~/.fedora/openidbaseclient-sessions.cache`.)
+    """
+    logger.debug(
+        f'Initialisation of the Bodhi client: FAS user {fas_username or "not configured"}; '
+        f'password {"provided" if fas_password else "not configured"}'
+    )
+    return BodhiClient(username=fas_username, password=fas_password)

--- a/packit/utils/bodhi.py
+++ b/packit/utils/bodhi.py
@@ -15,6 +15,13 @@ def get_bodhi_client(fas_username: str = None, fas_password: str = None) -> Bodh
     Bodhi will prompt for username and password
     if the values are not set and the session is not cached.
     (The session is stored as `~/.fedora/openidbaseclient-sessions.cache`.)
+
+    Note for tests:
+    * Don't mock the Bodhi instantiation via
+      `flexmock(bodhi.client.bindings.BodhiClient).new_instances(bodhi_instance_mock)`
+      what can affect other tests.
+    * Mock this function instead -- for example:
+      `flexmock(aliases).should_receive("get_bodhi_client").and_return(bodhi_instance_mock)`
     """
     logger.debug(
         f'Initialisation of the Bodhi client: FAS user {fas_username or "not configured"}; '

--- a/tests/unit/test_config_aliases.py
+++ b/tests/unit/test_config_aliases.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MIT
 from collections import Counter
 
-import bodhi
 import pytest
 from flexmock import flexmock
 
 import packit
+from packit.config import aliases
 from packit.config.aliases import (
     get_versions,
     get_build_targets,
@@ -284,22 +284,28 @@ class TestGetAliases:
         bodhi_instance_mock.should_receive("get_releases").and_return(
             bodhi_client_response(releases_list)
         )
-        flexmock(bodhi.client.bindings.BodhiClient).new_instances(bodhi_instance_mock)
+        flexmock(aliases).should_receive("get_bodhi_client").and_return(
+            bodhi_instance_mock
+        ).once()
 
         get_aliases.cache_clear()
-        aliases = get_aliases()
+        aliases_result = get_aliases()
 
-        assert Counter(aliases["fedora-stable"]) == Counter(
+        assert Counter(aliases_result["fedora-stable"]) == Counter(
             expected_return["fedora-stable"]
         )
-        assert Counter(aliases["fedora-development"]) == Counter(
+        assert Counter(aliases_result["fedora-development"]) == Counter(
             expected_return["fedora-development"]
         )
-        assert Counter(aliases["fedora-all"]) == Counter(expected_return["fedora-all"])
-        assert Counter(aliases["fedora-latest"]) == Counter(
+        assert Counter(aliases_result["fedora-all"]) == Counter(
+            expected_return["fedora-all"]
+        )
+        assert Counter(aliases_result["fedora-latest"]) == Counter(
             expected_return["fedora-latest"]
         )
-        assert Counter(aliases["epel-all"]) == Counter(expected_return["epel-all"])
+        assert Counter(aliases_result["epel-all"]) == Counter(
+            expected_return["epel-all"]
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes: #1516 

RELEASE NOTES BEGIN

When using Packit CLI for creating Bodhi updates, you can now set `fas_username` and `fas_password` in your Packit user config to not be asked about that when the command is executed.

RELEASE NOTES END
