### PR TITLE
With the new `files_to_sync` key, the spec-file and Packit config needs to be set

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,5 +1,7 @@
 ---
 files_to_sync:
+  - packit.spec
+  - .packit.yaml
   - src: plans/
     dest: plans/
   - src: .fmf/


### PR DESCRIPTION
Signed-off-by: Frantisek Lachman <flachman@redhat.com>

Related to: #1490

RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
