### PR TITLE
fix(copr): do not error out for already created repo

### DIFF
--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -282,6 +282,13 @@ class CoprHelper:
             )
             # TODO: additional_packages
         except CoprException as ex:
+            # TODO: Remove once Copr doesn't throw for existing projects or new
+            # API endpoint is established.
+            if "You already have a project named" in ex.result.error:
+                # race condition between workers
+                logger.debug(f"Copr project ({owner}/{project}) is already present.")
+                return
+
             error = (
                 f"Cannot create a new Copr project "
                 f"(owner={owner} project={project} chroots={chroots}): {ex}"

--- a/tests/integration/test_copr_build.py
+++ b/tests/integration/test_copr_build.py
@@ -633,3 +633,23 @@ def test_copr_build_cli_project_set_from_config(upstream_and_remote, copr_client
     ).and_return(("id", "url")).once()
 
     run_packit(["copr-build", "--nowait"], working_dir=upstream)
+
+
+def test_create_copr_project(copr_client_mock):
+    copr_helper = CoprHelper(flexmock(git_url="https://gitlab.com/"))
+    flexmock(packit.copr_helper.CoprClient).should_receive(
+        "create_from_config_file"
+    ).and_return(copr_client_mock)
+
+    copr_client_mock.project_proxy = flexmock()
+    flexmock(copr_client_mock.project_proxy).should_receive("add").and_raise(
+        CoprRequestException, "You already have a project named 'already-present'."
+    )
+
+    copr_helper.create_copr_project(
+        chroots=["centos-stream-8-x86_64"],
+        description="my fabulous test",
+        instructions=None,
+        owner="me",
+        project="already-present",
+    )


### PR DESCRIPTION
When creating a Copr repository, if necessary, check for already created
repository when creation fails. Should prevent premature failing due to
a race condition.

Signed-off-by: Matej Focko <mfocko@redhat.com>

Fixes packit/packit-service#1403

RELEASE NOTES BEGIN

Packit will no longer error out when trying to create a new Copr repository when it is already present (caused by a race condition).

RELEASE NOTES END
