### PR TITLE
Support for packit instances

### DIFF
--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -6,6 +6,7 @@ Common package config attributes so they can be imported both in PackageConfig a
 """
 import warnings
 import logging
+from enum import Enum
 
 from os import getenv
 from os.path import basename
@@ -19,6 +20,12 @@ from packit.config.notifications import (
 from packit.config.sources import SourcesItem
 from packit.constants import PROD_DISTGIT_URL, DISTGIT_NAMESPACE
 from packit.sync import SyncFilesItem, iter_srcs
+
+
+class Deployment(Enum):
+    dev = "dev"
+    stg = "stg"
+    prod = "prod"
 
 
 class CommonPackageConfig:

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -70,6 +70,7 @@ class CommonPackageConfig:
         merge_pr_in_ci: bool = True,
         srpm_build_deps: Optional[List[str]] = None,
         identifier: Optional[str] = None,
+        packit_instances: Optional[List[Deployment]] = None,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -108,6 +109,13 @@ class CommonPackageConfig:
             pull_request=PullRequestNotificationsConfig()
         )
         self.identifier = identifier
+
+        # The default is set also on schema level,
+        # but for sake of code-generated configs,
+        # we want to react on prod events only by default.
+        self.packit_instances = (
+            packit_instances if packit_instances is not None else [Deployment.prod]
+        )
 
         # template to create an upstream tag name (upstream may use different tagging scheme)
         self.upstream_tag_template = upstream_tag_template
@@ -175,7 +183,9 @@ class CommonPackageConfig:
             f"copy_upstream_release_description='{self.copy_upstream_release_description}',"
             f"sources='{self.sources}', "
             f"merge_pr_in_ci={self.merge_pr_in_ci}, "
-            f"srpm_build_deps={self.srpm_build_deps})"
+            f"srpm_build_deps={self.srpm_build_deps}, "
+            f"identifier={self.identifier}, "
+            f"packit_instances={self.packit_instances})"
         )
 
     @property

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -8,7 +8,7 @@ from typing import List, Set, Dict, Optional, Union, Any
 
 from packit.actions import ActionName
 from packit.config.aliases import DEFAULT_VERSION
-from packit.config.common_package_config import CommonPackageConfig
+from packit.config.common_package_config import CommonPackageConfig, Deployment
 from packit.config.notifications import NotificationsConfig
 from packit.config.sources import SourcesItem
 from packit.sync import SyncFilesItem
@@ -201,6 +201,7 @@ class JobConfig(CommonPackageConfig):
         merge_pr_in_ci: bool = True,
         srpm_build_deps: Optional[List[str]] = None,
         identifier: Optional[str] = None,
+        packit_instances: Optional[List[Deployment]] = None,
     ):
         super().__init__(
             config_file_path=config_file_path,
@@ -230,6 +231,7 @@ class JobConfig(CommonPackageConfig):
             merge_pr_in_ci=merge_pr_in_ci,
             srpm_build_deps=srpm_build_deps,
             identifier=identifier,
+            packit_instances=packit_instances,
         )
         self.type: JobType = type
         self.trigger: JobConfigTriggerType = trigger
@@ -261,7 +263,8 @@ class JobConfig(CommonPackageConfig):
             f"sources='{self.sources}', "
             f"merge_pr_in_ci={self.merge_pr_in_ci}, "
             f"srpm_build_deps={self.srpm_build_deps}, "
-            f"identifier='{self.identifier}')"
+            f"identifier='{self.identifier}', "
+            f"packit_instances={self.packit_instances})"
         )
 
     @classmethod
@@ -302,6 +305,7 @@ class JobConfig(CommonPackageConfig):
             and self.merge_pr_in_ci == other.merge_pr_in_ci
             and self.srpm_build_deps == other.srpm_build_deps
             and self.identifier == other.identifier
+            and self.packit_instances == self.packit_instances
         )
 
 

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -10,7 +10,7 @@ from ogr.abstract import GitProject
 from yaml import safe_load
 
 from packit.actions import ActionName
-from packit.config.common_package_config import CommonPackageConfig
+from packit.config.common_package_config import CommonPackageConfig, Deployment
 from packit.config.job_config import JobConfig, get_default_jobs, JobType
 from packit.config.notifications import NotificationsConfig
 from packit.config.sources import SourcesItem
@@ -57,6 +57,7 @@ class PackageConfig(CommonPackageConfig):
         merge_pr_in_ci: bool = True,
         srpm_build_deps: Optional[List[str]] = None,
         identifier: Optional[str] = None,
+        packit_instances: Optional[List[Deployment]] = None,
     ):
         super().__init__(
             config_file_path=config_file_path,
@@ -86,6 +87,7 @@ class PackageConfig(CommonPackageConfig):
             merge_pr_in_ci=merge_pr_in_ci,
             srpm_build_deps=srpm_build_deps,
             identifier=identifier,
+            packit_instances=packit_instances,
         )
         self.jobs: List[JobConfig] = jobs or []
 
@@ -117,7 +119,8 @@ class PackageConfig(CommonPackageConfig):
             f"sources='{self.sources}', "
             f"merge_pr_in_ci={self.merge_pr_in_ci}, "
             f"srpm_build_deps={self.srpm_build_deps}, "
-            f"identifier='{self.identifier}')"
+            f"identifier='{self.identifier}', "
+            f"packit_instances={self.packit_instances})"
         )
 
     @classmethod

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -9,6 +9,7 @@ from marshmallow_enum import EnumField
 
 from packit.actions import ActionName
 from packit.config import PackageConfig, Config
+from packit.config.common_package_config import Deployment
 from packit.config.job_config import (
     JobType,
     JobConfig,
@@ -307,6 +308,7 @@ class CommonConfigSchema(Schema):
     merge_pr_in_ci = fields.Bool(default=True)
     srpm_build_deps = fields.List(fields.String(), missing=None)
     identifier = fields.String(missing=None)
+    packit_instances = fields.List(EnumField(Deployment), missing=[Deployment.prod])
 
     @staticmethod
     def spec_source_id_serialize(value: PackageConfig):


### PR DESCRIPTION
This will allow users to specify packit instances (=deployments) that will work on the service jobs.

(No release notes are needed. The feature will be documented in the service repo.)
RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
