### PR TITLE
Fix the files_to_sync field in the serialized object

### DIFF
--- a/packit/config/__init__.py
+++ b/packit/config/__init__.py
@@ -19,9 +19,15 @@ from packit.config.package_config import (
     get_local_package_config,
     parse_loaded_config,
 )
+from packit.config.common_package_config import (
+    CommonPackageConfig,
+    Deployment,
+)
 
 __all__ = [
+    CommonPackageConfig.__name__,
     Config.__name__,
+    Deployment.__name__,
     JobConfig.__name__,
     JobConfigTriggerType.__name__,
     JobType.__name__,

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -77,7 +77,7 @@ class CommonPackageConfig:
 
         self._files_to_sync: List[SyncFilesItem] = files_to_sync or []  # new option
         self._files_to_sync_used: bool = False if files_to_sync is None else True
-        self._synced_files: List[SyncFilesItem] = (
+        self.synced_files: List[SyncFilesItem] = (
             synced_files or []
         )  # old deprecated option
         if synced_files is not None:
@@ -155,8 +155,8 @@ class CommonPackageConfig:
 
         if self._files_to_sync_used:
             return self._files_to_sync
-        elif self._synced_files:
-            return self._synced_files
+        elif self.synced_files:
+            return self.synced_files
         else:
             return []
 

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -1346,6 +1346,25 @@ def test_serialize_and_deserialize(package_config):
     assert package_config == new_package_config
 
 
+@pytest.mark.parametrize(
+    "package_config",
+    [
+        PackageConfig(
+            specfile_path="fedora/package.spec",
+            config_file_path=".packit.yaml",
+            downstream_package_name="package",
+            upstream_package_name="package",
+        ),
+    ],
+)
+def test_files_to_sync_after_dump(package_config):
+    schema = PackageConfigSchema()
+    assert len(package_config.get_all_files_to_sync()) == 2
+    serialized = schema.dump(package_config)
+    new_package_config = schema.load(serialized)
+    assert len(new_package_config.get_all_files_to_sync()) == 2
+
+
 def test_get_specfile_sync_files_item():
     pc = PackageConfig(
         specfile_path="fedora/python-ogr.spec", downstream_package_name="python-ogr"


### PR DESCRIPTION
B/c CommonPackageConfig.files_to_sync is a derived value, the meaning of
the original configuration can be re-established only by checking the
'_files_to_sync_used' attribute, and removing the 'files_to_sync' field
from the serialized data if it's False.

Fixes #1525.