### PR TITLE
fix(tests): Try the latest python3-flexmock

### DIFF
--- a/files/tasks/rpm-test-deps.yaml
+++ b/files/tasks/rpm-test-deps.yaml
@@ -2,7 +2,7 @@
 - name: Install test rpm dependencies
   dnf:
     name:
-      - python3-flexmock-0.10.4
+      - python3-flexmock
       - python3-setuptools_scm_git_archive
       - python3-setuptools_scm
       - python3-distro


### PR DESCRIPTION
In the test image python3-flexmock was pinned to 0.10.4, "due to 0.10.5
causing some regression".

Being unable to tell what that regression was, let's try if things work
with the latest version (0.10.10).

Do this, b/c version 0.10.4 is no longer available from the Fedora
repositories.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>

RELEASE NOTES BEGIN
RELEASE NOTES END
