### PR TITLE
feat: Add new 'fedora-*' aliases

### DIFF
--- a/tests/unit/test_config_aliases.py
+++ b/tests/unit/test_config_aliases.py
@@ -249,9 +249,38 @@ class TestGetAliases:
                     "fedora-stable": ["fedora-32", "fedora-33"],
                     "fedora-development": ["fedora-34", "fedora-rawhide"],
                     "fedora-latest": ["fedora-34"],
+                    "fedora-latest-stable": ["fedora-33"],
+                    "fedora-branched": ["fedora-32", "fedora-33", "fedora-34"],
                     "epel-all": ["epel-8"],
                 },
-                id="valid_bodhi_response",
+                id="after_branching",
+            ),
+            pytest.param(
+                [
+                    ("F30", "Fedora 30", "FEDORA", "archived"),
+                    ("F31", "Fedora 31", "FEDORA", "archived"),
+                    ("F32", "Fedora 32", "FEDORA", "current"),
+                    ("F33", "Fedora 33", "FEDORA", "current"),
+                    ("F34", "Fedora 34", "FEDORA", "current"),
+                    ("F35", "Fedora 35", "FEDORA", "pending"),
+                    ("F31F", "Fedora 31 Flatpaks", "FEDORA-FLATPAK", "current"),
+                    ("EPEL-8", "Fedora EPEL 8", "FEDORA-EPEL", "current"),
+                ],
+                {
+                    "fedora-all": [
+                        "fedora-32",
+                        "fedora-33",
+                        "fedora-34",
+                        "fedora-rawhide",
+                    ],
+                    "fedora-stable": ["fedora-32", "fedora-33", "fedora-34"],
+                    "fedora-development": ["fedora-rawhide"],
+                    "fedora-latest": ["fedora-34"],
+                    "fedora-latest-stable": ["fedora-34"],
+                    "fedora-branched": ["fedora-32", "fedora-33", "fedora-34"],
+                    "epel-all": ["epel-8"],
+                },
+                id="after_release",
             ),
             pytest.param(
                 [
@@ -273,9 +302,11 @@ class TestGetAliases:
                     "fedora-stable": ["fedora-33", "fedora-34"],
                     "fedora-development": ["fedora-rawhide"],
                     "fedora-latest": ["fedora-34"],
+                    "fedora-latest-stable": ["fedora-34"],
+                    "fedora-branched": ["fedora-33", "fedora-34"],
                     "epel-all": ["epel-8"],
                 },
-                id="valid_bodhi_response",
+                id="after_eol",
             ),
         ],
     )
@@ -302,6 +333,12 @@ class TestGetAliases:
         )
         assert Counter(aliases_result["fedora-latest"]) == Counter(
             expected_return["fedora-latest"]
+        )
+        assert Counter(aliases_result["fedora-latest-stable"]) == Counter(
+            expected_return["fedora-latest-stable"]
+        )
+        assert Counter(aliases_result["fedora-branched"]) == Counter(
+            expected_return["fedora-branched"]
         )
         assert Counter(aliases_result["epel-all"]) == Counter(
             expected_return["epel-all"]


### PR DESCRIPTION
Add a new alias, 'fedora-latest-stable', in order to be able to
reference the latest stable Fedora Linux release.

Add a new alias, 'fedora-branched', in order to be able to reference all
Fedora Linux releases, except 'rawhide'.

Fixes #1510.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>

RELEASE NOTES BEGIN
Introduced two new build and test target aliases: 'fedora-latest-stable' resolves to the latest stable Fedora Linux release, while 'fedora-branched' resolves to all branched releases (all Fedora Linux release, except 'rawhide').
RELEASE NOTES END
