### PR TITLE
Remove the usage of git wrappers

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -357,7 +357,9 @@ class PackitAPI:
         diffs: List[List[git.Diff]] = []
         patch_suffix = ".patch"
         distro_path = self.up.local_project.working_dir / DISTRO_DIR
-        for commit in self.dg.local_project.get_commits(revision_range, reverse=True):
+        for commit in self.dg.local_project.git_repo.iter_commits(
+            revision_range, reverse=True
+        ):
             commits.append(commit)
             diffs.append(get_commit_diff(commit))
             for diff in diffs[-1]:
@@ -466,7 +468,7 @@ class PackitAPI:
                     re.MULTILINE,
                 ).group(1),
             )
-            for c in self.up.local_project.get_commits(
+            for c in self.up.local_project.git_repo.iter_commits(
                 max_count=1, grep=rf"^{re.escape(FROM_DIST_GIT_TOKEN)}: .\+$"
             )
         ]
@@ -479,7 +481,7 @@ class PackitAPI:
                 ).group(1),
                 c.hexsha,
             )
-            for c in self.dg.local_project.get_commits(
+            for c in self.dg.local_project.git_repo.iter_commits(
                 max_count=1, grep=rf"^{re.escape(FROM_SOURCE_GIT_TOKEN)}: .\+$"
             )
         ]

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -394,9 +394,9 @@ class PackitRepositoryBase:
         logger.info(
             f"Pushing changes to remote {remote_name!r} using refspec {refspec!r}."
         )
-        push_infos_list: Iterable[PushInfo] = self.local_project.push(
-            refspec, remote_name=remote_name, force=force
-        )
+        push_infos_list: Iterable[PushInfo] = self.local_project.git_repo.remote(
+            name=remote_name
+        ).push(refspec=refspec, force=force)
         for pi in push_infos_list:
             logger.info(f"Push summary: {pi.summary}")
             push_failed = [

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -4,7 +4,7 @@
 import logging
 import shutil
 from pathlib import Path
-from typing import Optional, Union, Iterable, Iterator
+from typing import Optional, Union
 
 import git
 from git.exc import GitCommandError
@@ -542,45 +542,6 @@ class LocalProject:
         except Exception as ex:
             raise PackitException(f"Cannot checkout release tag: {ex!r}.")
 
-    def push(
-        self, refspec: str, remote_name: str = "origin", force: bool = False
-    ) -> Iterable[git.PushInfo]:
-        """
-        push changes to a remote using provided refspec
-
-        :param refspec: e.g. "main", "HEAD:f30"
-        :param remote_name: name of the remote where we push
-        :param force: force push: yes or no?
-        :return: a list of git.remote.PushInfo objects - have fun
-        """
-        return self.git_repo.remote(name=remote_name).push(refspec=refspec, force=force)
-
-    def stage(self, path: str = ".", force: bool = True):
-        """
-        stage provided path from working tree to index
-
-        force: bypass gitignore
-        """
-        self.git_repo.git.add(path, force=force)
-
-    def commit(
-        self,
-        message: str,
-        body: Optional[str] = None,
-        allow_empty: bool = True,
-        amend: bool = False,
-    ):
-        """Commit staged changes"""
-        other_message_kwargs = {"message": body} if body else {}
-        # some of the commits may be empty and it's not an error,
-        # e.g. extra source files
-        self.git_repo.git.commit(
-            allow_empty=allow_empty, m=message, amend=amend, **other_message_kwargs
-        )
-
-    def get_commits(self, ref: str = "HEAD", **kwargs) -> Iterator[git.Commit]:
-        return self.git_repo.iter_commits(ref, **kwargs)
-
     def fetch(self, remote: str, refspec: Optional[str] = None):
         """
         fetch refs from a remote to this repo
@@ -592,13 +553,6 @@ class LocalProject:
             self.git_repo.git.fetch(remote, refspec)
         else:
             self.git_repo.git.fetch(remote, "--tags")
-
-    def rebase(self, ref: str):
-        self.git_repo.git.rebase(ref)
-
-    def reset(self, ref: str):
-        """git reset --hard $ref"""
-        self.git_repo.head.reset(ref, index=True, working_tree=True)
 
     def __del__(self):
         self.clean()

--- a/tests/integration/test_base_git.py
+++ b/tests/integration/test_base_git.py
@@ -78,11 +78,17 @@ def test_base_push_bad(distgit_and_remote):
     b.local_project = LocalProject(
         working_dir=distgit, git_url="https://github.com/packit/lol"
     )
-    flexmock(
-        LocalProject,
-        push=lambda *args, **kwargs: [
-            PushInfo(PushInfo.REMOTE_REJECTED, None, None, None, None)
-        ],
+    flexmock(LocalProject).should_receive("git_repo").and_return(
+        flexmock()
+        .should_receive("remote")
+        .and_return(
+            flexmock(
+                push=lambda *args, **kwargs: [
+                    PushInfo(PushInfo.REMOTE_REJECTED, None, None, None, None)
+                ]
+            )
+        )
+        .mock()
     )
     with pytest.raises(PackitException) as e:
         b.push("master")
@@ -96,10 +102,16 @@ def test_base_push_good(distgit_and_remote):
     b.local_project = LocalProject(
         working_dir=distgit, git_url="https://github.com/packit/lol"
     )
-    flexmock(
-        LocalProject,
-        push=lambda *args, **kwargs: [
-            PushInfo(PushInfo.FAST_FORWARD, None, None, None, None)
-        ],
+    flexmock(LocalProject).should_receive("git_repo").and_return(
+        flexmock()
+        .should_receive("remote")
+        .and_return(
+            flexmock(
+                push=lambda *args, **kwargs: [
+                    PushInfo(PushInfo.FAST_FORWARD, None, None, None, None)
+                ]
+            )
+        )
+        .mock()
     )
     b.push("master")


### PR DESCRIPTION
These were mostly unused aside from a few mocks so no point in keeping these oneline wrappers.

Related to #343 