### PR TITLE
Use upstream for creating issues about downstream Packit failures

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,6 +11,7 @@ files_to_sync:
 upstream_package_name: packitos
 upstream_project_url: https://github.com/packit/packit
 copy_upstream_release_description: true
+issue_repository: https://github.com/packit/packit
 
 actions:
   create-archive:


### PR DESCRIPTION
Use upstream for creating issues about downstream Packit failures

See https://packit.dev/docs/configuration/#issue_repository