### PR TITLE
fix(copr): do not overwrite chroots

### DIFF
--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -185,9 +185,7 @@ class CoprHelper:
             old_chroots = set(copr_proj.chroot_repos.keys())
 
             new_chroots = None
-            if copr_proj.ownername == "packit" and set(chroots) != old_chroots:
-                new_chroots = chroots
-            elif not set(chroots).issubset(old_chroots):
+            if not set(chroots).issubset(old_chroots):
                 new_chroots = list(set(chroots) | old_chroots)
 
             if new_chroots:

--- a/tests/integration/test_copr_build.py
+++ b/tests/integration/test_copr_build.py
@@ -381,8 +381,6 @@ def test_copr_build_existing_project_munch_do_not_update_booleans_by_default(
             ["fedora-rawhide-x86_64", "fedora-35-x86_64"],
             ["fedora-rawhide-x86_64", "fedora-35-x86_64", "epel-8-x86_64"],
         ),
-        # For Copr projects that are created by Packit we replace the chroots.
-        ("packit", ["fedora-rawhide-x86_64"], ["fedora-rawhide-x86_64"]),
         # For Copr projects that are not created by Packit we **do not** touch
         # chroots as long as the requirements for Copr build are satisfied.
         ("the-owner", ["fedora-rawhide-x86_64"], None),


### PR DESCRIPTION
Signed-off-by: Matej Focko <mfocko@redhat.com>

Fixes packit/packit-service#1425

RELEASE NOTES BEGIN

We have reverted functionality of Packit that allowed you to have set «only» specific targets for Copr repositories. This functionality was introduced a while ago and was found to be not very beneficial in case of differently configured Copr jobs building in parallel in the same Copr repository.

RELEASE NOTES END
