### PR TITLE
Don't search for the spec file path when loading a remote config

### DIFF
--- a/packit/config/package_config_validator.py
+++ b/packit/config/package_config_validator.py
@@ -7,7 +7,7 @@ import logging
 
 from marshmallow import ValidationError
 
-from packit.config.package_config import PackageConfig, get_local_specfile_path
+from packit.config.package_config import PackageConfig
 from packit.exceptions import PackitConfigException
 from packit.sync import iter_srcs
 
@@ -29,9 +29,6 @@ class PackageConfigValidator:
             config = PackageConfig.get_from_dict(
                 self.content,
                 config_file_path=str(self.config_file_path),
-                spec_file_path=str(
-                    get_local_specfile_path(self.config_file_path.parent)
-                ),
             )
         except ValidationError as e:
             schema_errors = e.messages


### PR DESCRIPTION
Don't perform a recursive search for a spec file when loading the
package configuration remotely, from a forge with
`get_package_config_from_repo()`.

This will decrease the number of API calls to the forge, and speed up
things in general.

Loading a package config from the forge is used by Packit Service in
order to be able to figure out what jobs need to be executed for a given
event. But this activity does not require knowing the spec file. When
knowing the spec file is important, Packit Service always clones the
whole repository and uses the local project.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>
