### PR TITLE
Implement LocalProjectBuilder class

### DIFF
--- a/packit/cli/source_git_status.py
+++ b/packit/cli/source_git_status.py
@@ -11,7 +11,7 @@ from packit.config import pass_config
 from packit.config import Config, get_local_package_config
 from packit.constants import DISTRO_DIR, SRC_GIT_CONFIG
 from packit.api import PackitAPI
-from packit.local_project import LocalProject
+from packit.local_project import LocalProjectBuilder, CALCULATE
 from packit.cli.utils import cover_packit_exception
 
 
@@ -36,10 +36,15 @@ def source_git_status(config: Config, source_git: str, dist_git: str):
     package_config = get_local_package_config(
         package_config_path=source_git_path / DISTRO_DIR / SRC_GIT_CONFIG
     )
+    builder = LocalProjectBuilder(offline=True)
     api = PackitAPI(
         config=config,
         package_config=package_config,
-        upstream_local_project=LocalProject(working_dir=source_git_path, offline=True),
-        downstream_local_project=LocalProject(working_dir=dist_git_path, offline=True),
+        upstream_local_project=builder.build(
+            working_dir=source_git_path, git_repo=CALCULATE
+        ),
+        downstream_local_project=builder.build(
+            working_dir=dist_git_path, git_repo=CALCULATE
+        ),
     )
     click.echo(api.sync_status_string(source_git=source_git, dist_git=dist_git))

--- a/packit/cli/types.py
+++ b/packit/cli/types.py
@@ -8,7 +8,7 @@ from typing import Optional
 import click
 import git
 
-from packit.local_project import LocalProject
+from packit.local_project import LocalProject, LocalProjectBuilder, CALCULATE
 from packit.utils.repo import git_remote_url_to_https_url
 
 logger = logging.getLogger(__name__)
@@ -66,25 +66,41 @@ class LocalProjectParameter(click.ParamType):
             if self.target_branch_param_name:
                 target_branch = self.get_param(self.target_branch_param_name, ctx)
 
+            # General use-case, create fully featured project
+            builder = LocalProjectBuilder()
             if os.path.isdir(value):
                 absolute_path = os.path.abspath(value)
                 logger.debug(f"Input is a directory: {absolute_path}")
-                local_project = LocalProject(
+                local_project = builder.build(
                     working_dir=absolute_path,
                     ref=ref,
                     remote=ctx.obj.upstream_git_remote,
                     merge_pr=merge_pr,
                     target_branch=target_branch,
+                    git_repo=CALCULATE,
+                    git_project=CALCULATE,
+                    git_service=CALCULATE,
+                    full_name=CALCULATE,
+                    namespace=CALCULATE,
+                    repo_name=CALCULATE,
+                    git_url=CALCULATE,
                 )
             elif git_remote_url_to_https_url(value):
                 logger.debug(f"Input is a URL to a git repo: {value}")
-                local_project = LocalProject(
+                local_project = builder.build(
                     git_url=value,
                     ref=ref,
                     remote=ctx.obj.upstream_git_remote,
                     pr_id=pr_id,
                     merge_pr=merge_pr,
                     target_branch=target_branch,
+                    git_repo=CALCULATE,
+                    working_dir=CALCULATE,
+                    git_project=CALCULATE,
+                    git_service=CALCULATE,
+                    full_name=CALCULATE,
+                    namespace=CALCULATE,
+                    repo_name=CALCULATE,
                 )
             else:
                 self.fail(

--- a/packit/cli/update_dist_git.py
+++ b/packit/cli/update_dist_git.py
@@ -17,7 +17,7 @@ from packit.config import pass_config
 from packit.config import Config, get_local_package_config
 from packit.constants import DISTRO_DIR, SRC_GIT_CONFIG
 from packit.api import PackitAPI
-from packit.local_project import LocalProject
+from packit.local_project import LocalProjectBuilder, CALCULATE
 
 
 @click.command("update-dist-git")
@@ -127,11 +127,16 @@ def update_dist_git(
     package_config = get_local_package_config(
         package_config_path=source_git_path / DISTRO_DIR / SRC_GIT_CONFIG
     )
+    builder = LocalProjectBuilder(offline=True)
     api = PackitAPI(
         config=config,
         package_config=package_config,
-        upstream_local_project=LocalProject(working_dir=source_git_path, offline=True),
-        downstream_local_project=LocalProject(working_dir=dist_git_path, offline=True),
+        upstream_local_project=builder.build(
+            working_dir=source_git_path, git_repo=CALCULATE
+        ),
+        downstream_local_project=builder.build(
+            working_dir=dist_git_path, git_repo=CALCULATE
+        ),
     )
 
     title, _, message = message.partition("\n\n") if message else (None, None, None)

--- a/packit/cli/update_source_git.py
+++ b/packit/cli/update_source_git.py
@@ -14,7 +14,7 @@ from packit.config import pass_config
 from packit.config import Config, get_local_package_config
 from packit.constants import DISTRO_DIR, SRC_GIT_CONFIG
 from packit.api import PackitAPI
-from packit.local_project import LocalProject
+from packit.local_project import LocalProjectBuilder, CALCULATE
 from packit.cli.utils import cover_packit_exception
 
 
@@ -94,11 +94,16 @@ def update_source_git(
     package_config = get_local_package_config(
         package_config_path=source_git_path / DISTRO_DIR / SRC_GIT_CONFIG
     )
+    builder = LocalProjectBuilder(offline=True)
     api = PackitAPI(
         config=config,
         package_config=package_config,
-        upstream_local_project=LocalProject(working_dir=source_git_path, offline=True),
-        downstream_local_project=LocalProject(working_dir=dist_git_path, offline=True),
+        upstream_local_project=builder.build(
+            working_dir=source_git_path, git_repo=CALCULATE
+        ),
+        downstream_local_project=builder.build(
+            working_dir=dist_git_path, git_repo=CALCULATE
+        ),
     )
 
     api.update_source_git(

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -26,7 +26,7 @@ from packit.exceptions import (
     PackitConfigException,
     PackitBodhiException,
 )
-from packit.local_project import LocalProject
+from packit.local_project import LocalProject, LocalProjectBuilder, CALCULATE
 from packit.pkgtool import PkgTool
 from packit.utils.bodhi import get_bodhi_client
 from packit.utils.koji_helper import KojiHelper
@@ -109,7 +109,9 @@ class DistGit(PackitRepositoryBase):
         """
         dg = cls(config, package_config)
         dg.clone_package(target_path=path, branch=branch)
-        dg._local_project = LocalProject(working_dir=path)
+        dg._local_project = LocalProjectBuilder().build(
+            working_dir=path, git_repo=CALCULATE
+        )
         return dg
 
     @property
@@ -135,11 +137,22 @@ class DistGit(PackitRepositoryBase):
             )
             self._local_project.working_dir_temporary = not self._clone_path
             self._local_project.refresh_the_arguments()
+            # TODO: Turn this on once p-s mocks are updated
+            # builder = LocalProjectBuilder(cache=self.repository_cache)
+            # self._local_project = builder.build(
+            #    working_dir=working_dir,
+            #    git_url=self.package_config.dist_git_package_url,
+            #    namespace=self.package_config.dist_git_namespace,
+            #    repo_name=self.package_config.downstream_package_name,
+            #    git_project=self.config.get_project(
+            #        url=self.package_config.dist_git_package_url
+            #    ),
+            #    git_repo=CALCULATE,
+            # )
         elif not self._local_project.git_project:
             self._local_project.git_project = self.config.get_project(
                 url=self.package_config.dist_git_package_url
             )
-            self._local_project.refresh_the_arguments()
 
         return self._local_project
 

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -78,6 +78,17 @@ class Upstream(PackitRepositoryBase):
                 cache=self.repository_cache,
                 merge_pr=self.package_config.merge_pr_in_ci,
             )
+            # TODO: Turn this on once p-s mocks are updated
+            # builder = LocalProjectBuilder(cache=self.repository_cache)
+            # self._local_project = builder.build(
+            #    git_url=self.package_config.upstream_project_url,
+            #    repo_name=self.package_config.upstream_package_name,
+            #    merge_pr=self.package_config.merge_pr_in_ci,
+            #    git_repo=CALCULATE,
+            #    working_dir=CALCULATE,
+            #    ref=CALCULATE,
+            #    git_project=CALCULATE,
+            # )
         if self._local_project.git_project is None:
             if not self.package_config.upstream_project_url:
                 self.package_config.upstream_project_url = git_remote_url_to_https_url(
@@ -87,7 +98,6 @@ class Upstream(PackitRepositoryBase):
             self._local_project.git_project = self.config.get_project(
                 url=self.package_config.upstream_project_url
             )
-            # self._local_project.refresh_the_arguments()
         return self._local_project
 
     @property

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -137,8 +137,9 @@ def mock_remote_functionality(distgit: Path, upstream: Path):
     )
     flexmock(PagureUser, get_username=lambda: "packito")
 
-    dglp = LocalProject(
+    dglp = LocalProjectBuilder().build(
         working_dir=distgit,
+        git_repo=CALCULATE,
         git_url="https://packit.dev/rpms/beer",
         git_service=PagureService(),
     )
@@ -252,7 +253,7 @@ def upstream_instance(upstream_and_remote, tmp_path):
 
         pc = get_local_package_config(str(u))
         pc.upstream_project_url = str(u)
-        lp = LocalProject(working_dir=u)
+        lp = LocalProjectBuilder().build(working_dir=u, git_repo=CALCULATE)
 
         ups = Upstream(c, pc, lp)
         yield u, ups
@@ -301,7 +302,12 @@ def api_instance(upstream_and_remote, distgit_and_remote):
     d, _ = distgit_and_remote
 
     c = get_test_config()
-    api = get_packit_api(config=c, local_project=LocalProject(working_dir=Path.cwd()))
+    api = get_packit_api(
+        config=c,
+        local_project=LocalProjectBuilder().build(
+            working_dir=Path.cwd(), git_repo=CALCULATE
+        ),
+    )
     return u, d, api
 
 
@@ -357,8 +363,9 @@ def api_instance_sync_push(sourcegit_and_remote, distgit_and_remote):
         default_branch="main", get_pulls=lambda state, sort, direction: [], fork="fork"
     )
     service = flexmock(user=flexmock(get_username=lambda: "packit"))
-    up_lp = LocalProject(
+    up_lp = LocalProjectBuilder().build(
         working_dir=sourcegit,
+        git_repo=CALCULATE,
         git_project=GithubProject(
             repo="beer", service=service, namespace="packit.dev", github_repo=repo
         ),

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,7 +26,7 @@ from packit.constants import FROM_SOURCE_GIT_TOKEN
 from packit.distgit import DistGit
 from packit.upstream import Upstream
 from packit.pkgtool import PkgTool
-from packit.local_project import LocalProject
+from packit.local_project import LocalProject, LocalProjectBuilder, CALCULATE
 from packit.utils.commands import cwd
 from packit.utils.repo import create_new_repo
 
@@ -321,7 +321,8 @@ def mock_api_for_source_git(
 def api_instance_source_git(sourcegit_and_remote, distgit_and_remote):
     sourcegit, _ = sourcegit_and_remote
     distgit, _ = distgit_and_remote
-    up_lp = LocalProject(working_dir=sourcegit)
+    builder = LocalProjectBuilder()
+    up_lp = builder.build(working_dir=sourcegit, git_repo=CALCULATE)
     return mock_api_for_source_git(sourcegit, distgit, up_lp)
 
 

--- a/tests/integration/test_base_git.py
+++ b/tests/integration/test_base_git.py
@@ -9,7 +9,7 @@ from packit.actions import ActionName
 from packit.base_git import PackitRepositoryBase
 from packit.exceptions import PackitException
 from packit.config import CommonPackageConfig, Config, PackageConfig, RunCommandType
-from packit.local_project import LocalProject
+from packit.local_project import LocalProject, LocalProjectBuilder
 from tests.spellbook import can_a_module_be_imported
 
 
@@ -60,7 +60,9 @@ def test_get_output_from_action_defined_in_sandcastle():
             }
         ),
     )
-    packit_repository_base.local_project = LocalProject(working_dir="/tmp")
+    packit_repository_base.local_project = LocalProjectBuilder().build(
+        working_dir="/tmp"
+    )
 
     flexmock(Sandcastle).should_receive("run")
     flexmock(Sandcastle).should_receive("exec").and_return(echo_cmd)
@@ -95,7 +97,7 @@ def test_base_push_bad(distgit_and_remote):
         config=Config(),
         package_config=PackageConfig(packages={"package": CommonPackageConfig()}),
     )
-    b.local_project = LocalProject(
+    b.local_project = LocalProjectBuilder().build(
         working_dir=distgit, git_url="https://github.com/packit/lol"
     )
     flexmock(LocalProject).should_receive("git_repo").and_return(
@@ -122,7 +124,7 @@ def test_base_push_good(distgit_and_remote):
         config=Config(),
         package_config=PackageConfig(packages={"package": CommonPackageConfig()}),
     )
-    b.local_project = LocalProject(
+    b.local_project = LocalProjectBuilder().build(
         working_dir=distgit, git_url="https://github.com/packit/lol"
     )
     flexmock(LocalProject).should_receive("git_repo").and_return(

--- a/tests/integration/test_get_api.py
+++ b/tests/integration/test_get_api.py
@@ -9,14 +9,19 @@ from packit.cli import utils
 from packit.cli.utils import get_packit_api
 from packit.config import CommonPackageConfig, JobConfig
 from packit.config.job_config import JobType, JobConfigTriggerType
-from packit.local_project import LocalProject
+from packit.local_project import LocalProjectBuilder, CALCULATE
 from tests.spellbook import get_test_config, initiate_git_repo
 
 
 def test_is_upstream(upstream_and_remote):
     upstream, _ = upstream_and_remote
     c = get_test_config()
-    api = get_packit_api(config=c, local_project=LocalProject(working_dir=upstream))
+    api = get_packit_api(
+        config=c,
+        local_project=LocalProjectBuilder().build(
+            working_dir=upstream, git_repo=CALCULATE
+        ),
+    )
     assert api.upstream_local_project
     assert not api.downstream_local_project
     assert api.upstream_local_project.working_dir == upstream
@@ -25,7 +30,12 @@ def test_is_upstream(upstream_and_remote):
 def test_is_downstream(distgit_and_remote):
     downstream, _ = distgit_and_remote
     c = get_test_config()
-    api = get_packit_api(config=c, local_project=LocalProject(working_dir=downstream))
+    api = get_packit_api(
+        config=c,
+        local_project=LocalProjectBuilder().build(
+            working_dir=downstream, git_repo=CALCULATE
+        ),
+    )
     assert api.downstream_local_project
     assert not api.upstream_local_project
     assert api.downstream_local_project.working_dir == downstream
@@ -35,7 +45,9 @@ def test_url_is_downstream():
     c = get_test_config()
     api = get_packit_api(
         config=c,
-        local_project=LocalProject(git_url="https://src.fedoraproject.org/rpms/packit"),
+        local_project=LocalProjectBuilder().build(
+            git_url="https://src.fedoraproject.org/rpms/packit", git_repo=CALCULATE
+        ),
     )
     assert api.downstream_local_project
     assert not api.upstream_local_project
@@ -45,7 +57,9 @@ def test_url_is_upstream():
     c = get_test_config()
     api = get_packit_api(
         config=c,
-        local_project=LocalProject(git_url="https://github.com/packit/ogr"),
+        local_project=LocalProjectBuilder().build(
+            git_url="https://github.com/packit/ogr", git_repo=CALCULATE
+        ),
     )
     assert api.upstream_local_project
     assert not api.downstream_local_project
@@ -186,7 +200,12 @@ def test_get_api(tmp_path, remotes, package_config, is_upstream):
     )
 
     c = get_test_config()
-    api = get_packit_api(config=c, local_project=LocalProject(working_dir=str(repo)))
+    api = get_packit_api(
+        config=c,
+        local_project=LocalProjectBuilder().build(
+            working_dir=str(repo), git_repo=CALCULATE
+        ),
+    )
 
     if is_upstream:
         assert api.upstream_local_project

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -19,7 +19,7 @@ import packit
 from packit.actions import ActionName
 from packit.config import Config, get_local_package_config
 from packit.exceptions import PackitSRPMException
-from packit.local_project import LocalProject
+from packit.local_project import LocalProjectBuilder
 from packit.upstream import Archive, Upstream, SRPMBuilder
 from packit.utils.commands import cwd
 from packit.utils.repo import create_new_repo
@@ -129,7 +129,7 @@ def test_set_spec_macro_source(tmp_path):
 
         pc = get_local_package_config(str(u))
         pc.upstream_project_url = str(u)
-        lp = LocalProject(working_dir=u)
+        lp = LocalProjectBuilder().build(working_dir=u)
 
         ups = Upstream(c, pc, lp)
 
@@ -164,7 +164,7 @@ def test_set_spec_ver_empty_changelog(tmp_path):
 
         pc = get_local_package_config(str(u))
         pc.upstream_project_url = str(u)
-        lp = LocalProject(working_dir=u)
+        lp = LocalProjectBuilder().build(working_dir=u)
 
         ups = Upstream(c, pc, lp)
 

--- a/tests/integration/test_using_cockpit.py
+++ b/tests/integration/test_using_cockpit.py
@@ -14,7 +14,7 @@ from packit.api import PackitAPI
 from packit.config import get_local_package_config
 from packit.distgit import DistGit
 from packit.pkgtool import PkgTool
-from packit.local_project import LocalProject
+from packit.local_project import LocalProjectBuilder, CALCULATE
 from packit.utils import repo
 from packit.utils.commands import cwd
 from tests.spellbook import UP_COCKPIT_OSTREE, initiate_git_repo, get_test_config
@@ -62,11 +62,13 @@ def test_update_on_cockpit_ostree(cockpit_ostree):
     )
 
     pc = get_local_package_config(str(upstream_path))
-    up_lp = LocalProject(working_dir=upstream_path)
+    up_lp = LocalProjectBuilder().build(working_dir=upstream_path, git_repo=CALCULATE)
     c = get_test_config()
     api = PackitAPI(c, pc, up_lp)
     api._dg = DistGit(c, pc)
-    api._dg._local_project = LocalProject(working_dir=dist_git_path)
+    api._dg._local_project = LocalProjectBuilder().build(
+        working_dir=dist_git_path, git_repo=CALCULATE
+    )
 
     with cwd(upstream_path):
         api.sync_release(
@@ -100,11 +102,13 @@ def test_update_on_cockpit_ostree_pr_exists(cockpit_ostree):
     flexmock(DistGit).should_receive("existing_pr").and_return(pr)
 
     pc = get_local_package_config(str(upstream_path))
-    up_lp = LocalProject(working_dir=upstream_path)
+    up_lp = LocalProjectBuilder().build(working_dir=upstream_path, git_repo=CALCULATE)
     c = get_test_config()
     api = PackitAPI(c, pc, up_lp)
     api._dg = DistGit(c, pc)
-    api._dg._local_project = LocalProject(working_dir=dist_git_path)
+    api._dg._local_project = LocalProjectBuilder().build(
+        working_dir=dist_git_path, git_repo=CALCULATE
+    )
 
     with cwd(upstream_path):
         assert pr == api.sync_release(
@@ -120,7 +124,7 @@ def test_srpm_on_cockpit_ostree(cockpit_ostree):
     upstream_path, dist_git_path = cockpit_ostree
 
     pc = get_local_package_config(str(upstream_path))
-    up_lp = LocalProject(working_dir=upstream_path)
+    up_lp = LocalProjectBuilder().build(working_dir=upstream_path, git_repo=CALCULATE)
     c = get_test_config()
     api = PackitAPI(c, pc, up_lp)
 

--- a/tests/integration/test_using_examples.py
+++ b/tests/integration/test_using_examples.py
@@ -8,7 +8,7 @@ E2E tests which utilize cockpit projects
 import pytest
 
 from packit.cli.utils import get_packit_api
-from packit.local_project import LocalProject
+from packit.local_project import LocalProjectBuilder, CALCULATE
 from packit.utils.commands import cwd
 from tests.spellbook import (
     initiate_git_repo,
@@ -44,7 +44,12 @@ def example_repo(request, tmp_path):
 
 def test_srpm_on_example(example_repo):
     c = get_test_config()
-    api = get_packit_api(config=c, local_project=LocalProject(working_dir=example_repo))
+    api = get_packit_api(
+        config=c,
+        local_project=LocalProjectBuilder().build(
+            working_dir=example_repo, git_repo=CALCULATE
+        ),
+    )
     with cwd(example_repo):
         path = api.create_srpm()
     assert path.exists()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -10,7 +10,7 @@ from munch import munchify
 import packit
 from packit.config import Config
 from packit.distgit import DistGit
-from packit.local_project import LocalProject
+from packit.local_project import LocalProjectBuilder
 from packit.upstream import Upstream
 from tests.spellbook import get_test_config, CRONIE, initiate_git_repo
 
@@ -107,7 +107,7 @@ def upstream_mock(local_project_mock, package_config_mock):
     upstream = Upstream(
         config=get_test_config(),
         package_config=package_config_mock,
-        local_project=LocalProject(working_dir="test"),
+        local_project=LocalProjectBuilder().build(working_dir="test"),
     )
     flexmock(upstream)
     upstream.should_receive("local_project").and_return(local_project_mock)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -11,7 +11,7 @@ from flexmock import flexmock
 from packit.api import PackitAPI
 from packit.copr_helper import CoprHelper
 from packit.exceptions import PackitException
-from packit.local_project import LocalProject
+from packit.local_project import LocalProjectBuilder
 from packit.patches import PatchGenerator
 
 
@@ -192,5 +192,5 @@ def test_dg_downstream_package_name_is_set(
 ):
     api_mock._dg = None
     api_mock.package_config.downstream_package_name = downstream_package_name
-    api_mock.downstream_local_project = LocalProject(working_dir=path)
+    api_mock.downstream_local_project = LocalProjectBuilder().build(working_dir=path)
     assert api_mock.dg.package_config.downstream_package_name == expectation

--- a/tests/unit/test_base_git.py
+++ b/tests/unit/test_base_git.py
@@ -15,7 +15,7 @@ from packit.command_handler import LocalCommandHandler
 from packit.config import Config, CommonPackageConfig, RunCommandType, PackageConfig
 from packit.config.sources import SourcesItem
 from packit.distgit import DistGit
-from packit.local_project import LocalProject
+from packit.local_project import LocalProjectBuilder
 from packit.upstream import Upstream
 from packit.utils import commands
 from tests.spellbook import can_a_module_be_imported
@@ -117,7 +117,7 @@ def packit_repository_base_with_sandcastle_object(tmp_path):
             }
         ),
     )
-    b.local_project = LocalProject(working_dir=tmp_path)
+    b.local_project = LocalProjectBuilder().build(working_dir=tmp_path)
     return b
 
 

--- a/tests/unit/test_dg.py
+++ b/tests/unit/test_dg.py
@@ -6,7 +6,7 @@ from flexmock import flexmock
 
 from packit.config import CommonPackageConfig, Config, PackageConfig
 from packit.distgit import DistGit
-from packit.local_project import LocalProject
+from packit.local_project import LocalProjectBuilder
 
 
 @pytest.mark.parametrize(
@@ -96,9 +96,8 @@ from packit.local_project import LocalProject
 )
 def test_existing_pr(title, description, branch, source_branch, prs, exists):
     user_mock = flexmock().should_receive("get_username").and_return("packit").mock()
-    local_project = LocalProject(
+    local_project = LocalProjectBuilder().build(
         git_project=flexmock(service="something", get_pr_list=lambda: prs),
-        refresh=False,
         git_service=flexmock(user=user_mock),
     )
     distgit = DistGit(

--- a/tests/unit/test_local_project.py
+++ b/tests/unit/test_local_project.py
@@ -8,7 +8,12 @@ import git
 from flexmock import flexmock
 
 from packit import local_project
-from packit.local_project import LocalProject
+from packit.local_project import (
+    LocalProject,
+    LocalProjectBuilder,
+    CALCULATE,
+    LocalProjectCalculationState,
+)
 from packit.utils import repo
 from packit.utils.repo import RepositoryCache
 
@@ -113,11 +118,6 @@ def test_parse_ref_from_git_repo_detached():
     assert project._ref == "sha"
 
 
-def test_parse_working_dir_from_git_repo():
-    # TODO
-    pass
-
-
 def test_parse_git_repo_from_git_url():
     flexmock(local_project).should_receive("get_repo").with_args(
         url="http://some.example/url/reponame", directory=None
@@ -148,11 +148,6 @@ def test_parse_git_url_from_git_project():
     assert changed
     assert project.git_project
     assert project.git_url == "http://some.example/namespace/reponame"
-
-
-def test_parse_repo_name_from_git_project():
-    # TODO
-    pass
 
 
 def test_parse_namespace_from_git_project():
@@ -553,6 +548,465 @@ def test_clone_and_add_to_cache():
         .and_return(flexmock())
         .mock(),
         cache=repo_cache,
+    )
+
+    assert project
+    assert project.working_dir == Path("some/temp/dir")
+    assert project.git_url == "https://server.git/my_namespace/package_name"
+    assert project.namespace == "my_namespace"
+    assert project.repo_name == "package_name"
+    assert project.git_service
+    assert project.git_project
+    assert project.git_repo
+    assert project.ref == "branch"
+
+
+def test_builder_parse_repo_name_and_namespace_from_namespace():
+    builder = LocalProjectBuilder()
+    state = LocalProjectCalculationState(full_name="namespace/repository_name")
+    changed = builder._parse_repo_name_full_name_and_namespace(state)
+
+    assert changed
+    assert state.repo_name == "repository_name"
+    assert state.namespace == "namespace"
+    assert state.full_name == "namespace/repository_name"
+
+
+def test_builder_parse_full_name_from_repo_and_namespace():
+    builder = LocalProjectBuilder()
+    state = LocalProjectCalculationState(
+        repo_name="repository_name", namespace="namespace"
+    )
+    changed = builder._parse_repo_name_full_name_and_namespace(state)
+
+    assert changed
+    assert state.repo_name == "repository_name"
+    assert state.namespace == "namespace"
+    assert state.full_name == "namespace/repository_name"
+
+
+def test_builder_parse_git_repo_from_working_dir():
+    path = Path("some/example/path")
+    flexmock(local_project).should_receive("is_git_repo").with_args(path).and_return(
+        True
+    )
+    flexmock(
+        git, Repo=flexmock(active_branch="branch", head=flexmock(is_detached=False))
+    )
+    state = LocalProjectCalculationState(working_dir=path)
+    builder = LocalProjectBuilder()
+    changed = builder._parse_git_repo_from_working_dir(state)
+
+    assert changed
+    assert state.git_repo
+    assert state.git_repo.active_branch == "branch"
+    assert not state.working_dir_temporary
+
+
+def test_builder_parse_git_project_from_repo_namespace_and_git_service():
+    service_mock = (
+        flexmock()
+        .should_receive("get_project")
+        .with_args(repo="repo", namespace="namespace")
+        .replace_with(lambda repo, namespace: flexmock())
+        .mock()
+    )
+
+    state = LocalProjectCalculationState(
+        git_service=service_mock, repo_name="repo", namespace="namespace"
+    )
+    builder = LocalProjectBuilder()
+    changed = builder._parse_git_project_from_repo_namespace_and_git_service(state)
+
+    assert changed
+    assert state.git_service
+    assert state.git_project
+
+
+def test_builder_parse_git_service_from_git_project():
+    """Get git_url, namespace/repo and service from git_project"""
+    project_mock = flexmock(service=flexmock())
+
+    state = LocalProjectCalculationState(git_project=project_mock)
+    changed = LocalProjectBuilder()._parse_git_service_from_git_project(state)
+
+    assert changed
+    assert state.git_service
+    assert state.git_project
+
+
+def test_builder_parse_ref_from_git_repo():
+    """Get ref from git_repo"""
+    state = LocalProjectCalculationState(
+        git_repo=flexmock(
+            active_branch=flexmock(name="branch"), head=flexmock(is_detached=False)
+        ),
+    )
+    changed = LocalProjectBuilder()._parse_ref_from_git_repo(state)
+
+    assert changed
+    assert state.git_repo
+    assert state.ref == "branch"
+
+
+def test_builder_parse_ref_from_git_repo_detached():
+    state = LocalProjectCalculationState(
+        git_repo=flexmock(
+            active_branch="branch",
+            head=flexmock(is_detached=True, commit=flexmock(hexsha="sha")),
+        ),
+    )
+    changed = LocalProjectBuilder()._parse_ref_from_git_repo(state)
+
+    assert changed
+    assert state.git_repo
+    assert state.ref == "sha"
+
+
+def test_builder_parse_working_dir_from_git_repo():
+    state = LocalProjectCalculationState(git_repo=flexmock(working_dir="foo"))
+    changed = LocalProjectBuilder()._parse_working_dir_from_git_repo(state)
+    assert changed
+    assert state.git_repo
+    assert str(state.working_dir) == "foo"
+
+
+def test_builder_parse_git_repo_from_git_url():
+    flexmock(local_project).should_receive("get_repo").with_args(
+        url="http://some.example/url/reponame", directory=None
+    ).and_return(flexmock())
+    state = LocalProjectCalculationState(git_url="http://some.example/url/reponame")
+    changed = LocalProjectBuilder()._parse_git_repo_from_git_url(state)
+
+    assert changed
+    assert state.git_url
+    assert state.git_repo
+    assert state.working_dir_temporary
+
+
+def test_builder_parse_git_url_from_git_project():
+    state = LocalProjectCalculationState(
+        git_project=flexmock()
+        .should_receive("get_git_urls")
+        .and_return({"git": "http://some.example/namespace/reponame"})
+        .once()
+        .mock(),
+    )
+
+    changed = LocalProjectBuilder()._parse_git_url_from_git_project(state)
+
+    assert changed
+    assert state.git_project
+    assert state.git_url == "http://some.example/namespace/reponame"
+
+
+def test_builder_parse_repo_name_from_git_project():
+    state = LocalProjectCalculationState(git_project=flexmock(repo="foo"))
+    changed = LocalProjectBuilder()._parse_repo_name_from_git_project(state)
+
+    assert changed
+    assert state.git_project
+    assert str(state.repo_name) == "foo"
+
+
+def test_builder_parse_namespace_from_git_project():
+    project = LocalProject(git_project=flexmock(namespace="namespace"), refresh=False)
+
+    changed = project._parse_namespace_from_git_project()
+
+    assert changed
+    assert project.git_project
+    assert project.namespace
+    assert project.namespace == "namespace"
+
+
+def test_builder_parse_git_url_from_git_repo():
+    state = LocalProjectCalculationState(
+        git_repo=flexmock(
+            remotes=[flexmock(name="origin", url="git@github.com:org/name")]
+        ),
+    )
+
+    changed = LocalProjectBuilder()._parse_git_url_from_git_repo(state)
+
+    assert changed
+    assert state.git_repo
+    assert state.git_url == "git@github.com:org/name"
+
+
+def test_builder_parse_namespace_from_git_url():
+    state = LocalProjectCalculationState(
+        git_url="https://github.com/namespace/reponame"
+    )
+    changed = LocalProjectBuilder()._parse_namespace_from_git_url(state)
+
+    assert changed
+    assert state.namespace
+    assert state.namespace == "namespace"
+    assert state.repo_name == "reponame"
+    assert state.git_url == "https://github.com/namespace/reponame"
+
+
+def test_builder_offline_git_project():
+    """No get_project on offline"""
+
+    builder = LocalProjectBuilder(offline=True)
+    project = builder.build(
+        repo_name="repo_name",
+        namespace="namespace",
+        git_service=flexmock().should_receive("get_project").times(0).mock(),
+        git_project=CALCULATE,
+    )
+    assert project.repo_name == "repo_name"
+    assert project.namespace == "namespace"
+    assert project.git_service
+    assert not project.git_project
+
+
+def test_builder_offline_git_service():
+    """No git service on on offline"""
+
+    builder = LocalProjectBuilder(offline=True)
+    project = builder.build(
+        repo_name="repo_name",
+        namespace="namespace",
+        git_project=flexmock(service="something")
+        .should_receive("get_git_urls")
+        .times(0)
+        .mock(),
+        git_service=CALCULATE,
+    )
+    assert project.repo_name == "repo_name"
+    assert project.namespace == "namespace"
+    assert project.git_project
+    assert not project.git_service
+    assert not project.git_url
+
+
+def test_builder_offline_no_clone():
+    """No clone on offline"""
+    flexmock(repo).should_receive("get_repo").times(0)
+    flexmock(tempfile).should_receive("mkdtemp").times(0)
+    flexmock(git.Repo).should_receive("clone_from").times(0)
+
+    builder = LocalProjectBuilder(offline=True)
+    project = builder.build(
+        working_dir="some/example/path",
+        git_url="http://some.example/url/reponame",
+    )
+    assert project.working_dir == Path("some/example/path")
+    assert project.git_url == "http://some.example/url/reponame"
+    assert not project.git_repo
+
+
+def test_builder_offline_no_clone_no_temp_dir():
+    """No clone on offline, no temp dir"""
+    flexmock(repo).should_receive("get_repo").times(0)
+    flexmock(tempfile).should_receive("mkdtemp").times(0)
+    flexmock(git.Repo).should_receive("clone_from").times(0)
+    project = LocalProject(git_url="http://some.example/url/reponame", offline=True)
+
+    assert project.git_url == "http://some.example/url/reponame"
+    assert not project.git_repo
+    assert not project.working_dir
+
+
+def test_builder_clone_using_empty_cache():
+    cache_path_mock = flexmock(
+        is_dir=lambda: True,
+        iterdir=lambda: [],
+        joinpath=lambda x: "/reference/repo/package_name",
+    )
+    repo_cache = RepositoryCache(cache_path=cache_path_mock, add_new=False)
+
+    flexmock(git.Repo).should_receive("clone_from").with_args(
+        url="https://server.git/my_namespace/package_name",
+        to_path="some/temp/dir",
+        tags=True,
+    ).and_return(
+        flexmock(
+            active_branch=flexmock(name="branch"),
+            working_dir="some/temp/dir",
+            head=flexmock(is_detached=False),
+        )
+    )
+
+    flexmock(tempfile).should_receive("mkdtemp").and_return("some/temp/dir")
+
+    builder = LocalProjectBuilder(cache=repo_cache)
+    project = builder.build(
+        git_url="https://server.git/my_namespace/package_name",
+        repo_name="package_name",
+        git_service=flexmock()
+        .should_receive("get_project")
+        .and_return(flexmock())
+        .mock(),
+        working_dir=CALCULATE,
+        namespace=CALCULATE,
+        git_project=CALCULATE,
+        git_repo=CALCULATE,
+    )
+
+    assert project
+    assert project.working_dir == Path("some/temp/dir")
+    assert project.git_url == "https://server.git/my_namespace/package_name"
+    assert project.namespace == "my_namespace"
+    assert project.repo_name == "package_name"
+    assert project.git_service
+    assert project.git_project
+    assert project.git_repo
+    assert project.ref == "branch"
+
+
+def test_builder_clone_using_cache_present():
+    reference_repo = flexmock(
+        is_dir=lambda: True, __str__="/reference/repo/package_name", name="package_name"
+    )
+    cache_path_mock = flexmock(
+        is_dir=lambda: True,
+        iterdir=lambda: [reference_repo],
+        joinpath=lambda x: "/reference/repo/package_name",
+    )
+    repo_cache = RepositoryCache(cache_path=cache_path_mock, add_new=False)
+
+    flexmock(git.Repo).should_receive("clone_from").with_args(
+        url="https://server.git/my_namespace/package_name",
+        reference="/reference/repo/package_name",
+        to_path="some/temp/dir",
+        tags=True,
+    ).and_return(
+        flexmock(
+            active_branch=flexmock(name="branch"),
+            working_dir="some/temp/dir",
+            head=flexmock(is_detached=False),
+        )
+    )
+
+    flexmock(tempfile).should_receive("mkdtemp").and_return("some/temp/dir")
+
+    builder = LocalProjectBuilder(cache=repo_cache)
+    project = builder.build(
+        git_url="https://server.git/my_namespace/package_name",
+        repo_name="package_name",
+        git_service=flexmock()
+        .should_receive("get_project")
+        .and_return(flexmock())
+        .mock(),
+        working_dir=CALCULATE,
+        namespace=CALCULATE,
+        git_project=CALCULATE,
+        git_repo=CALCULATE,
+    )
+
+    assert project
+    assert project.working_dir == Path("some/temp/dir")
+    assert project.git_url == "https://server.git/my_namespace/package_name"
+    assert project.namespace == "my_namespace"
+    assert project.repo_name == "package_name"
+    assert project.git_service
+    assert project.git_project
+    assert project.git_repo
+    assert project.ref == "branch"
+
+
+def test_builder_clone_using_cache_not_present():
+    reference_repo = flexmock(
+        is_dir=lambda: True,
+        __str__="/reference/repo/different_package",
+        name="different_package",
+    )
+    cache_path_mock = flexmock(
+        is_dir=lambda: True,
+        iterdir=lambda: [reference_repo],
+        joinpath=lambda x: "/reference/repo/package_name",
+    )
+    repo_cache = RepositoryCache(cache_path=cache_path_mock, add_new=False)
+
+    flexmock(git.Repo).should_receive("clone_from").with_args(
+        url="https://server.git/my_namespace/package_name",
+        to_path="some/temp/dir",
+        tags=True,
+    ).and_return(
+        flexmock(
+            active_branch=flexmock(name="branch"),
+            working_dir="some/temp/dir",
+            head=flexmock(is_detached=False),
+        )
+    )
+
+    flexmock(tempfile).should_receive("mkdtemp").and_return("some/temp/dir")
+
+    builder = LocalProjectBuilder(cache=repo_cache)
+    project = builder.build(
+        git_url="https://server.git/my_namespace/package_name",
+        repo_name="package_name",
+        git_service=flexmock()
+        .should_receive("get_project")
+        .and_return(flexmock())
+        .mock(),
+        working_dir=CALCULATE,
+        namespace=CALCULATE,
+        git_project=CALCULATE,
+        git_repo=CALCULATE,
+    )
+
+    assert project
+    assert project.working_dir == Path("some/temp/dir")
+    assert project.git_url == "https://server.git/my_namespace/package_name"
+    assert project.namespace == "my_namespace"
+    assert project.repo_name == "package_name"
+    assert project.git_service
+    assert project.git_project
+    assert project.git_repo
+    assert project.ref == "branch"
+
+
+def test_builder_clone_and_add_to_cache():
+    cache_path_mock = flexmock(
+        is_dir=lambda: True,
+        iterdir=lambda: [],
+        joinpath=lambda x: "/reference/repo/package_name",
+    )
+    repo_cache = RepositoryCache(cache_path=cache_path_mock, add_new=True)
+
+    flexmock(git.Repo).should_receive("clone_from").with_args(
+        url="https://server.git/my_namespace/package_name",
+        to_path="/reference/repo/package_name",
+        tags=True,
+    ).and_return(
+        flexmock(
+            active_branch=flexmock(name="branch"),
+            working_dir="some/temp/dir",
+            head=flexmock(is_detached=False),
+        )
+    )
+    flexmock(git.Repo).should_receive("clone_from").with_args(
+        url="https://server.git/my_namespace/package_name",
+        reference="/reference/repo/package_name",
+        to_path="some/temp/dir",
+        tags=True,
+    ).and_return(
+        flexmock(
+            active_branch=flexmock(name="branch"),
+            working_dir="some/temp/dir",
+            head=flexmock(is_detached=False),
+        )
+    )
+
+    flexmock(tempfile).should_receive("mkdtemp").and_return("some/temp/dir")
+
+    builder = LocalProjectBuilder(cache=repo_cache)
+    project = builder.build(
+        git_url="https://server.git/my_namespace/package_name",
+        repo_name="package_name",
+        git_service=flexmock()
+        .should_receive("get_project")
+        .and_return(flexmock())
+        .mock(),
+        working_dir=CALCULATE,
+        namespace=CALCULATE,
+        git_project=CALCULATE,
+        git_repo=CALCULATE,
     )
 
     assert project

--- a/tests_recording/testbase.py
+++ b/tests_recording/testbase.py
@@ -10,7 +10,7 @@ import packit.distgit
 import packit.upstream
 from packit.config import Config, get_package_config_from_repo
 from packit.exceptions import PackitException
-from packit.local_project import LocalProject
+from packit.local_project import LocalProjectBuilder, CALCULATE
 
 
 def socket_guard(*args, **kwargs):
@@ -74,7 +74,19 @@ class PackitTest(unittest.TestCase):
     @property
     def lp(self):
         if not self._lp:
-            self._lp = LocalProject(git_project=self.project)
+            # Fully construct LocalProject, the tests may need anything
+            builder = LocalProjectBuilder()
+            self._lp = builder.build(
+                working_dir=CALCULATE,
+                ref=CALCULATE,
+                git_repo=CALCULATE,
+                git_project=self.project,
+                git_service=CALCULATE,
+                full_name=CALCULATE,
+                namespace=CALCULATE,
+                repo_name=CALCULATE,
+                git_url=CALCULATE,
+            )
         return self._lp
 
     @property


### PR DESCRIPTION
Opening a pull request even though the work is not completely done yet (though fairly close) to allow for some early feedback + see if the changes don't somehow break packit-service based on reverse-dep tests.

The plan is to transition gradually, so I haven't removed the old `LocalProject` construction just yet, once this PR is merged, I will update p-s and hardly to use the builder and only then drop the parsing/refreshing from `LocalProject`

TODO:

- [x] Update tests inside packit to build using this new method (non-test usages have been replaced already)
- [x] Transition `LocalProject` test coverage to `LocalProjectBuilder`
- [x] Add tests for the calculation logic.
- [ ] Update packit-service and then drop the old API (needs new pull requests once this one is merged)

