### PR TITLE
feat: remove ‹create_pr› for service

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -711,7 +711,6 @@ The first dist-git commit to be synced is '{short_hash}'.
         upstream_ref = self.up._expand_git_ref(
             upstream_ref or self.package_config.upstream_ref
         )
-        create_pr = create_pr and self.package_config.create_pr
 
         current_up_branch = self.up.active_branch
         try:

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -60,10 +60,12 @@ def get_dg_branches(api, dist_git_branch):
     help="Upload the new sources also when the archive is already in the lookaside cache.",
 )
 @click.option(
-    "--no-pr",
-    is_flag=True,
-    default=False,
-    help="Do not create a pull request to downstream repository.",
+    "--pr/--no-pr",
+    default=None,
+    help=(
+        "Create a pull request to downstream repository or push directly. "
+        "If not set, defaults to value set in configuration."
+    ),
 )
 @click.option(
     "--upstream-ref",
@@ -92,7 +94,7 @@ def propose_downstream(
     dist_git_path,
     dist_git_branch,
     force_new_sources,
-    no_pr,
+    pr,
     local_content,
     path_or_url,
     upstream_ref,
@@ -112,6 +114,8 @@ def propose_downstream(
     api = get_packit_api(
         config=config, dist_git_path=dist_git_path, local_project=path_or_url
     )
+    if pr is None:
+        pr = api.package_config.create_pr
 
     branches_to_update = get_dg_branches(api, dist_git_branch)
 
@@ -126,6 +130,6 @@ def propose_downstream(
             version=version,
             force_new_sources=force_new_sources,
             upstream_ref=upstream_ref,
-            create_pr=not no_pr,
+            create_pr=pr,
             force=force,
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -162,6 +162,7 @@ def mock_remote_functionality(distgit: Path, upstream: Path):
         is_archive_in_lookaside_cache=lambda archive_path: False,
         local_project=dglp,
     )
+    flexmock(DistGit).should_receive("existing_pr").and_return(None)
 
     def mocked_new_sources(sources=None):
         if not Path(sources).is_file():

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -135,6 +135,7 @@ def distgit_mock(local_project_mock, config_mock, package_config_mock):
     distgit.should_receive("commit")
     distgit.should_receive("push")
     distgit.should_receive("absolute_specfile_dir").and_return(Path("/mock_path"))
+    distgit.should_receive("existing_pr").and_return(None)
     return distgit
 
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -155,6 +155,7 @@ def test_sync_release_version_tag_processing(
     api_mock.should_receive("_prepare_files_to_sync").with_args(
         synced_files=[], full_version=version, upstream_tag=tag
     )
+    api_mock.should_receive("push_and_create_pr").and_return(flexmock())
     flexmock(PatchGenerator).should_receive("undo_identical")
     with expectation:
         api_mock.sync_release(version=version, tag=tag, dist_git_branch="_")
@@ -165,6 +166,7 @@ def test_sync_release_do_not_create_sync_note(api_mock):
     flexmock(pathlib.Path).should_receive("write_text").never()
     api_mock.up.should_receive("get_specfile_version").and_return("some.version")
     api_mock.up.package_config.create_sync_note = False
+    api_mock.should_receive("push_and_create_pr").and_return(flexmock())
     api_mock.sync_release(version="1.1", dist_git_branch="_")
 
 
@@ -172,6 +174,7 @@ def test_sync_release_create_sync_note(api_mock):
     flexmock(PatchGenerator).should_receive("undo_identical")
     flexmock(pathlib.Path).should_receive("write_text").once()
     api_mock.up.should_receive("get_specfile_version").and_return("some.version")
+    api_mock.should_receive("push_and_create_pr").and_return(flexmock())
     api_mock.sync_release(version="1.1", dist_git_branch="_")
 
 


### PR DESCRIPTION
Signed-off-by: Matej Focko <mfocko@redhat.com>

TODO:

- [x] reach out to affected users
- [x] Do we want to drop the option completely or allow it for usage via CLI? (e.g. running `propose-downstream` without specifying `--no-pr`, but with the option in the config)

RELEASE NOTES BEGIN

From the security perspective, we have to decided to disable the `create_pr` option for our service, from now on Packit will unconditionally create PRs when running `propose-downstream`.

We have also updated the `propose-downstream` CLI such that it is possible to use `create_pr` from configuration **or** override it via `--pr/--no-pr` options.

RELEASE NOTES END
