### PR TITLE
fix: do not error out when app is not installed

### DIFF
--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Optional, List, Dict, Union, Set
 
 from ogr.abstract import GitProject
+from ogr.exceptions import GithubAppNotInstalledError
 from yaml import safe_load
 
 from packit.actions import ActionName
@@ -335,7 +336,7 @@ def get_package_config_from_repo(
             config_file_content = project.get_file_content(
                 path=config_file_name, ref=ref
             )
-        except FileNotFoundError:
+        except (FileNotFoundError, GithubAppNotInstalledError):
             # do nothing
             pass
         else:


### PR DESCRIPTION
When we cannot fetch the config file, because the GitHub App is not
installed on the repository, do not error out, just silently fail.

Signed-off-by: Matej Focko <mfocko@redhat.com>

Fixes packit/packit-service#1462

Merge after packit/ogr#706