### PR TITLE
feat(copr): add bump-version to script generator

### DIFF
--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -72,6 +72,7 @@ class CommonPackageConfig:
         identifier: Optional[str] = None,
         packit_instances: Optional[List[Deployment]] = None,
         issue_repository: Optional[str] = None,
+        release_suffix: Optional[str] = None,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -126,6 +127,7 @@ class CommonPackageConfig:
         self.merge_pr_in_ci = merge_pr_in_ci
         self.srpm_build_deps = srpm_build_deps
         self.issue_repository = issue_repository
+        self.release_suffix = release_suffix
 
     def _warn_user(self):
         logger = logging.getLogger(__name__)
@@ -188,7 +190,8 @@ class CommonPackageConfig:
             f"srpm_build_deps={self.srpm_build_deps}, "
             f"identifier={self.identifier}, "
             f"packit_instances={self.packit_instances}, "
-            f"issue_repository='{self.issue_repository}')"
+            f"issue_repository='{self.issue_repository}', "
+            f"release_suffix='{self.release_suffix}')"
         )
 
     @property

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -203,6 +203,7 @@ class JobConfig(CommonPackageConfig):
         identifier: Optional[str] = None,
         packit_instances: Optional[List[Deployment]] = None,
         issue_repository: Optional[str] = None,
+        release_suffix: Optional[str] = None,
     ):
         super().__init__(
             config_file_path=config_file_path,
@@ -234,6 +235,7 @@ class JobConfig(CommonPackageConfig):
             identifier=identifier,
             packit_instances=packit_instances,
             issue_repository=issue_repository,
+            release_suffix=release_suffix,
         )
         self.type: JobType = type
         self.trigger: JobConfigTriggerType = trigger
@@ -267,7 +269,8 @@ class JobConfig(CommonPackageConfig):
             f"srpm_build_deps={self.srpm_build_deps}, "
             f"identifier='{self.identifier}', "
             f"packit_instances={self.packit_instances}, "
-            f"issue_repository='{self.issue_repository}')"
+            f"issue_repository='{self.issue_repository}', "
+            f"release_suffix='{self.release_suffix}')"
         )
 
     @classmethod

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -59,6 +59,7 @@ class PackageConfig(CommonPackageConfig):
         identifier: Optional[str] = None,
         packit_instances: Optional[List[Deployment]] = None,
         issue_repository: Optional[str] = None,
+        release_suffix: Optional[str] = None,
     ):
         super().__init__(
             config_file_path=config_file_path,
@@ -90,6 +91,7 @@ class PackageConfig(CommonPackageConfig):
             identifier=identifier,
             packit_instances=packit_instances,
             issue_repository=issue_repository,
+            release_suffix=release_suffix,
         )
         self.jobs: List[JobConfig] = jobs or []
 
@@ -123,7 +125,8 @@ class PackageConfig(CommonPackageConfig):
             f"srpm_build_deps={self.srpm_build_deps}, "
             f"identifier='{self.identifier}', "
             f"packit_instances={self.packit_instances}, "
-            f"issue_repository='{self.issue_repository}')"
+            f"issue_repository='{self.issue_repository}', "
+            f"release_suffix='{self.release_suffix}')"
         )
 
     @classmethod

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -309,6 +309,7 @@ class CommonConfigSchema(Schema):
     identifier = fields.String(missing=None)
     packit_instances = fields.List(EnumField(Deployment), missing=[Deployment.prod])
     issue_repository = fields.String(missing=None)
+    release_suffix = fields.String(missing=None)
 
     @staticmethod
     def spec_source_id_serialize(value: PackageConfig):

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -928,7 +928,15 @@ class SRPMBuilder:
             "PACKIT_RPMSPEC_RELEASE": self.upstream.get_spec_release(),
             "PACKIT_PROJECT_COMMIT": current_commit,
             "PACKIT_PROJECT_ARCHIVE": archive,
+            "PACKIT_PROJECT_BRANCH": sanitize_branch_name_for_rpm(
+                self.upstream.local_project.ref
+            ),
         }
+
+        # in case we are given template as a release suffix
+        if release_suffix:
+            release_suffix = release_suffix.format(**env)
+
         if self.upstream.with_action(action=ActionName.fix_spec, env=env):
             self.upstream.fix_spec(
                 archive=archive,

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -370,8 +370,12 @@ class Upstream(PackitRepositoryBase):
             string which is meant to be put into a spec file %release field by packit
         """
         original_release_number = self.specfile.get_release_number().split(".", 1)[0]
-        if release_suffix:
-            return f"{original_release_number}.{release_suffix}"
+        if release_suffix is not None:
+            return (
+                f"{original_release_number}.{release_suffix}"
+                if release_suffix
+                else None
+            )
 
         if not bump_version:
             return None
@@ -925,7 +929,9 @@ class SRPMBuilder:
         env = {
             "PACKIT_PROJECT_VERSION": self.current_git_describe_version,
             # Spec file %release field which packit sets by default
-            "PACKIT_RPMSPEC_RELEASE": self.upstream.get_spec_release(),
+            "PACKIT_RPMSPEC_RELEASE": self.upstream.get_spec_release(
+                bump_version, release_suffix
+            ),
             "PACKIT_PROJECT_COMMIT": current_commit,
             "PACKIT_PROJECT_ARCHIVE": archive,
             "PACKIT_PROJECT_BRANCH": sanitize_branch_name_for_rpm(

--- a/packit/utils/source_script.py
+++ b/packit/utils/source_script.py
@@ -10,6 +10,7 @@ def create_source_script(
     merge_pr: Optional[bool] = True,
     target_branch: Optional[str] = None,
     job_config_index: Optional[int] = None,
+    bump_version: bool = True,
 ):
     options = []
     if ref:
@@ -20,6 +21,8 @@ def create_source_script(
             options += ["--target-branch", target_branch]
     if job_config_index is not None:
         options += ["--job-config-index", str(job_config_index)]
+    if not bump_version:
+        options += ["--no-bump"]
 
     options += [url]
     return COPR_SOURCE_SCRIPT.format(options=" ".join(options))

--- a/packit/utils/source_script.py
+++ b/packit/utils/source_script.py
@@ -11,6 +11,7 @@ def create_source_script(
     target_branch: Optional[str] = None,
     job_config_index: Optional[int] = None,
     bump_version: bool = True,
+    release_suffix: Optional[str] = None,
 ):
     options = []
     if ref:
@@ -23,6 +24,8 @@ def create_source_script(
         options += ["--job-config-index", str(job_config_index)]
     if not bump_version:
         options += ["--no-bump"]
+    if release_suffix:
+        options += ["--release-suffix", f"'{release_suffix}'"]
 
     options += [url]
     return COPR_SOURCE_SCRIPT.format(options=" ".join(options))


### PR DESCRIPTION
When submitting SRPM build to Copr, we should be able to disable bumping
of the version and release field.

Signed-off-by: Matej Focko <mfocko@redhat.com>

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Related to #1181

Merge before packit/packit-service#1478

RELEASE NOTES BEGIN

Packit now supports `release_suffix` configuration option that allows you to override the long release string provided by Packit that is used to ensure correct ordering and uniqueness of RPMs built in Copr.

RELEASE NOTES END
