### PR TITLE
Remove JobMetadataConfig class

### DIFF
--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -4,7 +4,7 @@
 from copy import deepcopy
 from enum import Enum
 from logging import getLogger
-from typing import List, Set, Dict, Optional, Union, Any
+from typing import List, Dict, Optional, Union, Any
 
 from packit.actions import ActionName
 from packit.config.aliases import DEFAULT_VERSION
@@ -36,131 +36,6 @@ class JobConfigTriggerType(Enum):
     commit = "commit"
 
 
-class JobMetadataConfig:
-    def __init__(
-        self,
-        _targets: Union[List[str], Dict[str, Dict[str, Any]], None] = None,
-        timeout: int = 7200,
-        owner: Optional[str] = None,
-        project: Optional[str] = None,
-        dist_git_branches: Optional[List[str]] = None,
-        branch: Optional[str] = None,
-        scratch: bool = False,
-        list_on_homepage: bool = False,
-        preserve_project: bool = False,
-        additional_packages: Optional[List[str]] = None,
-        additional_repos: Optional[List[str]] = None,
-        fmf_url: Optional[str] = None,
-        fmf_ref: Optional[str] = None,
-        use_internal_tf: bool = False,
-        skip_build: bool = False,
-        env: Optional[Dict[str, Any]] = None,
-        enable_net: bool = True,
-    ):
-        """
-        Args:
-            _targets: copr_build, mock chroots where to build
-                      tests, builds to test
-                      The _ prefix is used because 'targets' without it
-                      is now used for backward compatibility.
-            timeout: copr_build, give up watching a build after timeout, defaults to 7200s
-            owner: copr_build, a namespace in COPR where the build should happen
-            project: copr_build, a name of the copr project
-            dist_git_branches: propose_downstream, branches in dist-git where packit should work
-            branch: for `commit` trigger to specify the branch name
-            scratch: if we want to run scratch build in koji
-            list_on_homepage: if set, created copr project will be visible on copr's home-page
-            preserve_project: if set, project will not be created as temporary
-            additional_packages: buildroot packages for the chroot [DOES NOT WORK YET]
-            additional_repos: buildroot additional additional_repos
-            fmf_url: - git repository containing the metadata (FMF) tree
-            fmf_ref: - branch, tag or commit specifying the desired git revision
-            use_internal_tf: if we want to use internal instance of Testing Farm
-            skip_build: if we want to skip build phase for Testing Farm job
-            env: environment variables
-            enable_net: if set to False, Copr builds have network disabled
-        """
-        self._targets: Dict[str, Dict[str, Any]]
-        if isinstance(_targets, list):
-            self._targets = {key: {} for key in _targets}
-        else:
-            self._targets = _targets or {}
-        self.timeout: int = timeout
-        self.owner: str = owner
-        self.project: str = project
-        self.dist_git_branches: Set[str] = (
-            set(dist_git_branches) if dist_git_branches else set()
-        )
-        self.branch: str = branch
-        self.scratch: bool = scratch
-        self.list_on_homepage: bool = list_on_homepage
-        self.preserve_project: bool = preserve_project
-        self.additional_packages: List[str] = additional_packages or []
-        self.additional_repos: List[str] = additional_repos or []
-        self.fmf_url: str = fmf_url
-        self.fmf_ref: str = fmf_ref
-        self.use_internal_tf: bool = use_internal_tf
-        self.skip_build: bool = skip_build
-        self.env: Dict[str, Any] = env or {}
-        self.enable_net = enable_net
-
-    def __repr__(self):
-        return (
-            f"JobMetadataConfig("
-            f"targets={self._targets}, "
-            f"timeout={self.timeout}, "
-            f"owner={self.owner}, "
-            f"project={self.project}, "
-            f"dist_git_branches={self.dist_git_branches}, "
-            f"branch={self.branch}, "
-            f"scratch={self.scratch}, "
-            f"list_on_homepage={self.list_on_homepage}, "
-            f"preserve_project={self.preserve_project}, "
-            f"additional_packages={self.additional_packages}, "
-            f"additional_repos={self.additional_repos}, "
-            f"fmf_url={self.fmf_url}, "
-            f"fmf_ref={self.fmf_ref}, "
-            f"use_internal_tf={self.use_internal_tf}, "
-            f"skip_build={self.skip_build},"
-            f"env={self.env},"
-            f"enable_net={self.enable_net})"
-        )
-
-    def __eq__(self, other: object):
-        if not isinstance(other, JobMetadataConfig):
-            raise PackitConfigException(
-                "Provided object is not a JobMetadataConfig instance."
-            )
-        return (
-            self._targets == other._targets
-            and self.timeout == other.timeout
-            and self.owner == other.owner
-            and self.project == other.project
-            and self.dist_git_branches == other.dist_git_branches
-            and self.branch == other.branch
-            and self.scratch == other.scratch
-            and self.list_on_homepage == other.list_on_homepage
-            and self.preserve_project == other.preserve_project
-            and self.additional_packages == other.additional_packages
-            and self.additional_repos == other.additional_repos
-            and self.fmf_url == other.fmf_url
-            and self.fmf_ref == other.fmf_ref
-            and self.use_internal_tf == other.use_internal_tf
-            and self.skip_build == other.skip_build
-            and self.env == other.env
-            and self.enable_net == other.enable_net
-        )
-
-    @property
-    def targets_dict(self):
-        return self._targets
-
-    @property
-    def targets(self):
-        """For backward compatibility."""
-        return set(self._targets.keys())
-
-
 class JobConfig(CommonPackageConfig):
     """
     Definition of a job.
@@ -173,7 +48,6 @@ class JobConfig(CommonPackageConfig):
         self,
         type: JobType,
         trigger: JobConfigTriggerType,
-        metadata: Optional[JobMetadataConfig] = None,
         config_file_path: Optional[str] = None,
         specfile_path: Optional[str] = None,
         synced_files: Optional[List[SyncFilesItem]] = None,
@@ -204,6 +78,24 @@ class JobConfig(CommonPackageConfig):
         packit_instances: Optional[List[Deployment]] = None,
         issue_repository: Optional[str] = None,
         release_suffix: Optional[str] = None,
+        # from deprecated JobMetadataConfig
+        _targets: Union[List[str], Dict[str, Dict[str, Any]], None] = None,
+        timeout: int = 7200,
+        owner: Optional[str] = None,
+        project: Optional[str] = None,
+        dist_git_branches: Optional[List[str]] = None,
+        branch: Optional[str] = None,
+        scratch: bool = False,
+        list_on_homepage: bool = False,
+        preserve_project: bool = False,
+        additional_packages: Optional[List[str]] = None,
+        additional_repos: Optional[List[str]] = None,
+        fmf_url: Optional[str] = None,
+        fmf_ref: Optional[str] = None,
+        use_internal_tf: bool = False,
+        skip_build: bool = False,
+        env: Optional[Dict[str, Any]] = None,
+        enable_net: bool = True,
     ):
         super().__init__(
             config_file_path=config_file_path,
@@ -236,14 +128,31 @@ class JobConfig(CommonPackageConfig):
             packit_instances=packit_instances,
             issue_repository=issue_repository,
             release_suffix=release_suffix,
+            # from deprecated JobMetadataConfig
+            _targets=_targets,
+            timeout=timeout,
+            owner=owner,
+            project=project,
+            dist_git_branches=dist_git_branches,
+            branch=branch,
+            scratch=scratch,
+            list_on_homepage=list_on_homepage,
+            preserve_project=preserve_project,
+            additional_packages=additional_packages,
+            additional_repos=additional_repos,
+            fmf_url=fmf_url,
+            fmf_ref=fmf_ref,
+            use_internal_tf=use_internal_tf,
+            skip_build=skip_build,
+            env=env,
+            enable_net=enable_net,
         )
         self.type: JobType = type
         self.trigger: JobConfigTriggerType = trigger
-        self.metadata: JobMetadataConfig = metadata or JobMetadataConfig()
 
     def __repr__(self):
         return (
-            f"JobConfig(job={self.type}, trigger={self.trigger}, meta={self.metadata}, "
+            f"JobConfig(job={self.type}, trigger={self.trigger}, "
             f"config_file_path='{self.config_file_path}', "
             f"specfile_path='{self.specfile_path}', "
             f"files_to_sync='{self.files_to_sync}', "
@@ -270,7 +179,25 @@ class JobConfig(CommonPackageConfig):
             f"identifier='{self.identifier}', "
             f"packit_instances={self.packit_instances}, "
             f"issue_repository='{self.issue_repository}', "
-            f"release_suffix='{self.release_suffix}')"
+            f"release_suffix='{self.release_suffix}', "
+            # from deprecated JobMetadataConfig
+            f"targets={self._targets}, "
+            f"timeout={self.timeout}, "
+            f"owner={self.owner}, "
+            f"project={self.project}, "
+            f"dist_git_branches={self.dist_git_branches}, "
+            f"branch={self.branch}, "
+            f"scratch={self.scratch}, "
+            f"list_on_homepage={self.list_on_homepage}, "
+            f"preserve_project={self.preserve_project}, "
+            f"additional_packages={self.additional_packages}, "
+            f"additional_repos={self.additional_repos}, "
+            f"fmf_url={self.fmf_url}, "
+            f"fmf_ref={self.fmf_ref}, "
+            f"use_internal_tf={self.use_internal_tf}, "
+            f"skip_build={self.skip_build},"
+            f"env={self.env},"
+            f"enable_net={self.enable_net})"
         )
 
     @classmethod
@@ -289,7 +216,6 @@ class JobConfig(CommonPackageConfig):
         return (
             self.type == other.type
             and self.trigger == other.trigger
-            and self.metadata == other.metadata
             and self.specfile_path == other.specfile_path
             and self.files_to_sync == other.files_to_sync
             and self.dist_git_namespace == other.dist_git_namespace
@@ -314,6 +240,23 @@ class JobConfig(CommonPackageConfig):
             and self.packit_instances == other.packit_instances
             and self.issue_repository == other.issue_repository
             and self.release_suffix == other.release_suffix
+            and self._targets == other._targets
+            and self.timeout == other.timeout
+            and self.owner == other.owner
+            and self.project == other.project
+            and self.dist_git_branches == other.dist_git_branches
+            and self.branch == other.branch
+            and self.scratch == other.scratch
+            and self.list_on_homepage == other.list_on_homepage
+            and self.preserve_project == other.preserve_project
+            and self.additional_packages == other.additional_packages
+            and self.additional_repos == other.additional_repos
+            and self.fmf_url == other.fmf_url
+            and self.fmf_ref == other.fmf_ref
+            and self.use_internal_tf == other.use_internal_tf
+            and self.skip_build == other.skip_build
+            and self.env == other.env
+            and self.enable_net == other.enable_net
         )
 
 

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -170,8 +170,7 @@ class PackageConfig(CommonPackageConfig):
         package_config = PackageConfigSchema().load(raw_dict)
 
         if not package_config.specfile_path and not all(
-            job.type == JobType.tests and job.metadata.skip_build
-            for job in package_config.jobs
+            job.type == JobType.tests and job.skip_build for job in package_config.jobs
         ):
             raise PackitConfigException("Spec file was not found!")
 
@@ -183,9 +182,9 @@ class PackageConfig(CommonPackageConfig):
         this is only used when invoking copr builds from CLI
         """
         projects_list = [
-            job.metadata.project
+            job.project
             for job in self.jobs
-            if job.type == JobType.copr_build and job.metadata.project
+            if job.type == JobType.copr_build and job.project
         ]
         if not projects_list:
             return None
@@ -201,7 +200,7 @@ class PackageConfig(CommonPackageConfig):
     def get_propose_downstream_dg_branches_value(self) -> Optional[Set]:
         for job in self.jobs:
             if job.type == JobType.propose_downstream:
-                return job.metadata.dist_git_branches
+                return job.dist_git_branches
         return set()
 
     def __eq__(self, other: object):

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -396,6 +396,37 @@ class JobConfigSchema(CommonConfigSchema):
                 "The 'metadata' key in jobs is deprecated and can be removed."
                 "Nest config options from 'metadata' directly under the job object."
             )
+
+            not_nested_metadata_keys = [
+                k
+                for k in (
+                    "_targets",
+                    "timeout",
+                    "owner",
+                    "project",
+                    "dist_git_branches",
+                    "branch",
+                    "scratch",
+                    "list_on_homepage",
+                    "preserve_project",
+                    "use_internal_tf",
+                    "additional_packages",
+                    "additional_repos",
+                    "fmf_url",
+                    "fmf_ref",
+                    "skip_build",
+                    "env",
+                    "enable_net",
+                )
+                if k in data
+            ]
+            if not_nested_metadata_keys:
+                raise ValidationError(
+                    f"Keys: {not_nested_metadata_keys} are defined outside job metadata dictionary."
+                    "Mixing obsolete metadata dictionary and new job keys is not possible."
+                    "Remove obsolete nested job metadata dictionary."
+                )
+
         for key in ("targets", "dist_git_branches"):
             if data is dict:
                 if isinstance(data.get(key), str):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -240,6 +240,66 @@ def test_serialize_and_deserialize_job_config(config):
 
 
 @pytest.mark.parametrize(
+    "config_in,config_out,validation_error",
+    [
+        (
+            {
+                "job": "build",
+                "trigger": "release",
+                "enable_net": False,
+                "metadata": {"branch": "main"},
+            },
+            {
+                "job": "build",
+                "trigger": "release",
+                "enable_net": False,
+                "branch": "main",
+            },
+            True,
+        ),
+        (
+            {
+                "job": "build",
+                "trigger": "release",
+                "metadata": {"enable_net": False, "branch": "main"},
+            },
+            {
+                "job": "build",
+                "trigger": "release",
+                "enable_net": False,
+                "branch": "main",
+            },
+            False,
+        ),
+        (
+            {
+                "job": "build",
+                "trigger": "release",
+                "enable_net": False,
+                "branch": "main",
+            },
+            {
+                "job": "build",
+                "trigger": "release",
+                "enable_net": False,
+                "branch": "main",
+            },
+            False,
+        ),
+    ],
+)
+def test_deserialize_and_serialize_job_config(config_in, config_out, validation_error):
+    schema = JobConfigSchema()
+    if validation_error:
+        with pytest.raises(ValidationError):
+            schema.dump(schema.load(config_in))
+    else:
+        serialized_from_in = schema.dump(schema.load(config_in))
+        serialized_from_out = schema.dump(schema.load(config_out))
+        assert serialized_from_in == serialized_from_out
+
+
+@pytest.mark.parametrize(
     "config,is_valid",
     [
         ({}, True),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -15,7 +15,6 @@ from packit.config import (
     JobConfigTriggerType,
 )
 from packit.config.aliases import DEFAULT_VERSION
-from packit.config.job_config import JobMetadataConfig
 from packit.schema import JobConfigSchema, JobMetadataSchema
 
 
@@ -39,7 +38,7 @@ def get_job_config_dict_full():
     return {
         "job": "propose_downstream",
         "trigger": "pull_request",
-        "metadata": {"dist-git-branch": "master"},
+        "dist_git_branches": ["master"],
     }
 
 
@@ -48,7 +47,7 @@ def get_job_config_full(**kwargs):
     return JobConfig(
         type=JobType.propose_downstream,
         trigger=JobConfigTriggerType.pull_request,
-        metadata=JobMetadataConfig(dist_git_branches=["master"]),
+        dist_git_branches=["master"],
         **kwargs,
     )
 
@@ -62,7 +61,8 @@ def get_job_config_dict_build_for_branch():
     return {
         "job": "copr_build",
         "trigger": "commit",
-        "metadata": {"branch": "build-branch", "scratch": True},
+        "branch": "build-branch",
+        "scratch": True,
     }
 
 
@@ -71,7 +71,8 @@ def get_job_config_build_for_branch(**kwargs):
     return JobConfig(
         type=JobType.copr_build,
         trigger=JobConfigTriggerType.commit,
-        metadata=JobMetadataConfig(branch="build-branch", scratch=True),
+        branch="build-branch",
+        scratch=True,
         **kwargs,
     )
 
@@ -82,19 +83,19 @@ def get_default_job_config(**kwargs):
         JobConfig(
             type=JobType.copr_build,
             trigger=JobConfigTriggerType.pull_request,
-            metadata=JobMetadataConfig(_targets=[DEFAULT_VERSION]),
+            _targets=[DEFAULT_VERSION],
             **kwargs,
         ),
         JobConfig(
             type=JobType.tests,
             trigger=JobConfigTriggerType.pull_request,
-            metadata=JobMetadataConfig(_targets=[DEFAULT_VERSION]),
+            _targets=[DEFAULT_VERSION],
             **kwargs,
         ),
         JobConfig(
             type=JobType.propose_downstream,
             trigger=JobConfigTriggerType.release,
-            metadata=JobMetadataConfig(dist_git_branches=["fedora-all"]),
+            dist_git_branches=["fedora-all"],
             **kwargs,
         ),
     ]
@@ -142,15 +143,15 @@ def test_job_config_validate(raw, is_valid):
         (get_job_config_dict_full(), get_job_config_full()),
         (
             get_job_config_dict_simple(),
-            get_job_config_simple(metadata=JobMetadataConfig(preserve_project=False)),
+            get_job_config_simple(preserve_project=False),
         ),
         (
-            get_job_config_dict_simple(metadata={"preserve_project": False}),
-            get_job_config_simple(metadata=JobMetadataConfig(preserve_project=False)),
+            get_job_config_dict_simple(preserve_project=False),
+            get_job_config_simple(preserve_project=False),
         ),
         (
-            get_job_config_dict_simple(metadata={"preserve_project": True}),
-            get_job_config_simple(metadata=JobMetadataConfig(preserve_project=True)),
+            get_job_config_dict_simple(preserve_project=True),
+            get_job_config_simple(preserve_project=True),
         ),
     ],
 )

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -16,7 +16,6 @@ from packit.config import (
     JobConfig,
     get_package_config_from_repo,
 )
-from packit.config.job_config import JobMetadataConfig
 from packit.config.package_config import (
     get_specfile_path_from_repo,
     PackageConfig,
@@ -80,7 +79,7 @@ def test_get_specfile_path_from_repo(files, expected):
                     JobConfig(
                         type=JobType.copr_build,
                         trigger=JobConfigTriggerType.pull_request,
-                        metadata=JobMetadataConfig(project="example"),
+                        project="example",
                     )
                 ],
             ),
@@ -93,12 +92,12 @@ def test_get_specfile_path_from_repo(files, expected):
                     JobConfig(
                         type=JobType.copr_build,
                         trigger=JobConfigTriggerType.release,
-                        metadata=JobMetadataConfig(project="example1"),
+                        project="example1",
                     ),
                     JobConfig(
                         type=JobType.copr_build,
                         trigger=JobConfigTriggerType.pull_request,
-                        metadata=JobMetadataConfig(project="example2"),
+                        project="example2",
                     ),
                 ],
             ),
@@ -121,11 +120,9 @@ def test_project_from_copr_build_job(package_config, project):
                     JobConfig(
                         type=JobType.propose_downstream,
                         trigger=JobConfigTriggerType.pull_request,
-                        metadata=JobMetadataConfig(
-                            dist_git_branches=[
-                                "example",
-                            ]
-                        ),
+                        dist_git_branches=[
+                            "example",
+                        ],
                     )
                 ],
             ),
@@ -140,13 +137,11 @@ def test_project_from_copr_build_job(package_config, project):
                     JobConfig(
                         type=JobType.propose_downstream,
                         trigger=JobConfigTriggerType.pull_request,
-                        metadata=JobMetadataConfig(
-                            dist_git_branches=[
-                                "example1",
-                                "example2",
-                            ]
-                        ),
-                    )
+                        dist_git_branches=[
+                            "example1",
+                            "example2",
+                        ],
+                    ),
                 ],
             ),
             {"example1", "example2"},
@@ -266,7 +261,9 @@ def test_package_config_not_equal(not_equal_package_config):
                     {
                         "job": "propose_downstream",
                         "trigger": "release",
-                        "metadata": {"dist-git-branch": "fedora-all"},
+                        "dist_git_branches": [
+                            "fedora-all",
+                        ],
                     }
                 ],
             },
@@ -279,7 +276,7 @@ def test_package_config_not_equal(not_equal_package_config):
                     {
                         "job": "propose_downstream",
                         "trigger": "release",
-                        "metadata": {"dist_git_branches": ["fedora-all", "epel-8"]},
+                        "dist_git_branches": ["fedora-all", "epel-8"],
                     }
                 ],
             },
@@ -292,7 +289,9 @@ def test_package_config_not_equal(not_equal_package_config):
                     {
                         "job": "copr_build",
                         "trigger": "release",
-                        "metadata": {"targets": "fedora-stable"},
+                        "targets": [
+                            "fedora-stable",
+                        ],
                     }
                 ],
             },
@@ -305,9 +304,7 @@ def test_package_config_not_equal(not_equal_package_config):
                     {
                         "job": "copr_build",
                         "trigger": "release",
-                        "metadata": {
-                            "targets": ["fedora-stable", "fedora-development"]
-                        },
+                        "targets": ["fedora-stable", "fedora-development"],
                     }
                 ],
             },
@@ -320,12 +317,10 @@ def test_package_config_not_equal(not_equal_package_config):
                     {
                         "job": "propose_downstream",
                         "trigger": "release",
-                        "metadata": {
-                            "targets": ["f31", "f32"],
-                            "timeout": 123,
-                            "owner": "santa",
-                            "project": "gifts",
-                        },
+                        "targets": ["f31", "f32"],
+                        "timeout": 123,
+                        "owner": "santa",
+                        "project": "gifts",
                     }
                 ],
             },
@@ -338,12 +333,12 @@ def test_package_config_not_equal(not_equal_package_config):
                     {
                         "job": "tests",
                         "trigger": "pull_request",
-                        "metadata": {
-                            "targets": "fedora-all",
-                            "env": {
-                                "MYVAR1": 5,
-                                "MYVAR2": "foo",
-                            },
+                        "targets": [
+                            "fedora-all",
+                        ],
+                        "env": {
+                            "MYVAR1": 5,
+                            "MYVAR2": "foo",
                         },
                     }
                 ],
@@ -455,7 +450,7 @@ def test_package_config_validate(raw, is_valid):
                     {
                         "job": "propose_downstream",
                         "trigger": "release",
-                        "metadata": {"unknown": "key"},
+                        "unknown": "key",
                     }
                 ],
             },
@@ -835,10 +830,8 @@ def test_package_config_parse_error(raw):
                     {
                         "job": "copr_build",
                         "trigger": "release",
-                        "metadata": {
-                            "fmf_url": "https://example.com",
-                            "fmf_ref": "test_ref",
-                        },
+                        "fmf_url": "https://example.com",
+                        "fmf_ref": "test_ref",
                     },
                 ],
             },
@@ -850,9 +843,8 @@ def test_package_config_parse_error(raw):
                         type=JobType.copr_build,
                         specfile_path="fedora/package.spec",
                         trigger=JobConfigTriggerType.release,
-                        metadata=JobMetadataConfig(
-                            fmf_url="https://example.com", fmf_ref="test_ref"
-                        ),
+                        fmf_url="https://example.com",
+                        fmf_ref="test_ref",
                     ),
                 ],
             ),
@@ -1401,7 +1393,7 @@ def test_get_specfile_sync_files_nodownstreamname_item():
                 {
                     "job": "copr_build",
                     "trigger": "release",
-                    "metadata": {"targets": ["fedora-stable", "fedora-development"]},
+                    "targets": ["fedora-stable", "fedora-development"],
                 }
             ],
         },
@@ -1410,7 +1402,7 @@ def test_get_specfile_sync_files_nodownstreamname_item():
                 {
                     "job": "tests",
                     "trigger": "release",
-                    "metadata": {"targets": ["fedora-stable", "fedora-development"]},
+                    "targets": ["fedora-stable", "fedora-development"],
                 }
             ],
         },
@@ -1429,10 +1421,8 @@ def test_package_config_specfile_not_present_raise(raw):
                 {
                     "job": "tests",
                     "trigger": "commit",
-                    "metadata": {
-                        "targets": ["fedora-stable", "fedora-development"],
-                        "skip_build": True,
-                    },
+                    "targets": ["fedora-stable", "fedora-development"],
+                    "skip_build": True,
                 }
             ],
         },
@@ -1441,18 +1431,14 @@ def test_package_config_specfile_not_present_raise(raw):
                 {
                     "job": "tests",
                     "trigger": "commit",
-                    "metadata": {
-                        "targets": ["fedora-stable", "fedora-development"],
-                        "skip_build": True,
-                    },
+                    "targets": ["fedora-stable", "fedora-development"],
+                    "skip_build": True,
                 },
                 {
                     "job": "tests",
                     "trigger": "pull_request",
-                    "metadata": {
-                        "targets": ["fedora-stable", "fedora-development"],
-                        "skip_build": True,
-                    },
+                    "targets": ["fedora-stable", "fedora-development"],
+                    "skip_build": True,
                 },
             ],
         },

--- a/tests/unit/test_prepare_sources.py
+++ b/tests/unit/test_prepare_sources.py
@@ -5,7 +5,6 @@ import pytest
 
 from packit.cli.prepare_sources import load_job_config
 from packit.config import JobConfig, JobType, JobConfigTriggerType
-from packit.config.job_config import JobMetadataConfig
 
 
 @pytest.mark.parametrize(
@@ -18,11 +17,11 @@ from packit.config.job_config import JobMetadataConfig
             '"upstream_project_url": null, "sources": [], "create_pr": true, "merge_pr_in_ci": '
             'true, "job": "copr_build", "upstream_ref": null, "upstream_tag_template": '
             '"{version}", "config_file_path": null, "synced_files": [], "sync_changelog": false,'
-            ' "patch_generation_patch_id_digits": 4, "metadata": {"preserve_project": false, '
+            ' "patch_generation_patch_id_digits": 4, "preserve_project": false, '
             '"branch": null, "additional_repos": [], "env": {}, "additional_packages": [], '
             '"skip_build": false, "scratch": false, "targets": {}, "fmf_url": null, "fmf_ref":'
             ' null, "owner": null, "use_internal_tf": false, "list_on_homepage": false, '
-            '"project": "example1", "dist_git_branches": [], "timeout": 7200}, '
+            '"project": "example1", "dist_git_branches": [], "timeout": 7200, '
             '"notifications": {"pull_request": {"successful_build": false}}, '
             '"copy_upstream_release_description": false, "specfile_path": null, '
             '"dist_git_base_url": "https://src.fedoraproject.org/", "trigger": "release", '
@@ -30,7 +29,7 @@ from packit.config.job_config import JobMetadataConfig
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.release,
-                metadata=JobMetadataConfig(project="example1"),
+                project="example1",
             ),
             id="valid",
         ),

--- a/tests/unit/test_propose_downstream.py
+++ b/tests/unit/test_propose_downstream.py
@@ -13,7 +13,6 @@ from packit.config import (
     JobConfigTriggerType,
     JobConfig,
 )
-from packit.config.job_config import JobMetadataConfig
 
 
 @pytest.mark.parametrize(
@@ -41,7 +40,7 @@ from packit.config.job_config import JobMetadataConfig
                     JobConfig(
                         type=JobType.propose_downstream,
                         trigger=JobConfigTriggerType.pull_request,
-                        metadata=JobMetadataConfig(dist_git_branches=["file"]),
+                        dist_git_branches=["file"],
                     )
                 ],
             ),
@@ -72,7 +71,7 @@ from packit.config.job_config import JobMetadataConfig
                     JobConfig(
                         type=JobType.propose_downstream,
                         trigger=JobConfigTriggerType.pull_request,
-                        metadata=JobMetadataConfig(dist_git_branches=["file"]),
+                        dist_git_branches=["file"],
                     )
                 ],
             ),
@@ -88,9 +87,7 @@ from packit.config.job_config import JobMetadataConfig
                     JobConfig(
                         type=JobType.propose_downstream,
                         trigger=JobConfigTriggerType.pull_request,
-                        metadata=JobMetadataConfig(
-                            dist_git_branches=["file1", "file2"]
-                        ),
+                        dist_git_branches=["file1", "file2"],
                     )
                 ],
             ),
@@ -138,7 +135,7 @@ from packit.config.job_config import JobMetadataConfig
                     JobConfig(
                         type=JobType.propose_downstream,
                         trigger=JobConfigTriggerType.pull_request,
-                        metadata=JobMetadataConfig(dist_git_branches=["rawhide"]),
+                        dist_git_branches=["rawhide"],
                     )
                 ],
             ),
@@ -154,9 +151,7 @@ from packit.config.job_config import JobMetadataConfig
                     JobConfig(
                         type=JobType.propose_downstream,
                         trigger=JobConfigTriggerType.pull_request,
-                        metadata=JobMetadataConfig(
-                            dist_git_branches=["file1", "rawhide"]
-                        ),
+                        dist_git_branches=["file1", "rawhide"],
                     )
                 ],
             ),


### PR DESCRIPTION
Remove JobMetadataConfig from the code.

This PR removes also the support for the old osolete key dist-git-brach.

Usage of metadata key in the yaml files is still supported.
Mixing job->metadata->keys and job->keys it is not allowed.

Fixes packit#1515

Merge before packit/packit-service#1488

RELEASE NOTES BEGIN
Metadata dictionary is no longer required when specifying a job.
Keys which used to belong to the yaml metadata dictionary are now keys of the job dictionary itself.
RELEASE NOTES END
