### PR TITLE
source-git-init: Guess the author of non-git-am patches

### DIFF
--- a/_packitpatch
+++ b/_packitpatch
@@ -47,7 +47,9 @@ if ! cat "$patch_path" | git am; then
     git am --abort
     cat "$patch_path" | /usr/bin/patch ${patch_args}
     git add -f .
-    # patches can be empty, rpmbuild is fine with it
+    # Patches can be empty, rpmbuild is fine with it.
+    # The subject line is relied on when guessing the author
+    # of this patch!
     git commit -m"Apply patch ${patch_name}" --allow-empty
 fi
 

--- a/packit/source_git.py
+++ b/packit/source_git.py
@@ -248,7 +248,7 @@ class SourceGitGenerator:
             raise PackitException(
                 "Cannot initialize a source-git repo. "
                 "The corresponding dist-git repository at "
-                f"{self.dist_git.working_dir!r} is not pristine."
+                f"{self.dist_git.working_dir!r} is not pristine. "
                 f"{REPO_NOT_PRISTINE_HINT}"
             )
 

--- a/packit/utils/__init__.py
+++ b/packit/utils/__init__.py
@@ -11,6 +11,7 @@ from packit.utils.logging import (
 )
 from packit.utils.repo import (
     get_default_branch,
+    get_file_author,
     get_namespace_and_repo_name,
     get_repo,
     git_remote_url_to_https_url,
@@ -20,21 +21,22 @@ from packit.utils.repo import (
 
 
 __all__ = [
+    assert_existence.__name__,
+    commits_to_nice_str.__name__,
+    cwd.__name__,
+    get_default_branch.__name__,
+    get_file_author.__name__,
+    get_namespace_and_repo_name.__name__,
+    get_repo.__name__,
+    git_remote_url_to_https_url.__name__,
+    is_a_git_ref.__name__,
+    is_git_repo.__name__,
+    nested_get.__name__,
+    PackitFormatter.__name__,
     run_command.__name__,
     run_command_remote.__name__,
-    cwd.__name__,
-    assert_existence.__name__,
-    nested_get.__name__,
-    StreamLogger.__name__,
-    PackitFormatter.__name__,
     set_logging.__name__,
-    commits_to_nice_str.__name__,
-    is_git_repo.__name__,
-    get_repo.__name__,
-    get_namespace_and_repo_name.__name__,
-    is_a_git_ref.__name__,
-    git_remote_url_to_https_url.__name__,
-    get_default_branch.__name__,
+    StreamLogger.__name__,
 ]
 
 

--- a/packit/utils/repo.py
+++ b/packit/utils/repo.py
@@ -424,3 +424,27 @@ def is_the_repo_pristine(repo: git.Repo) -> bool:
         Whether the repo is pristine.
     """
     return not repo.git.diff() and not repo.git.clean("-xdn")
+
+
+def get_file_author(repo: git.Repo, filename: str) -> str:
+    """Get the original author of 'filename' in 'repo'
+
+    Args:
+        repo: Git-repo where the file is commited.
+        filename: Name of the file.
+
+    Returns:
+        The original (first) author of the file in the
+        "A U Thor <author@example.com>" format.
+    """
+    author, author_mail = "", ""
+    for line in repo.git.blame(filename, line_porcelain=True).splitlines():
+        token, _, value = line.partition(" ")
+        if token == "author":
+            author = value
+        elif token == "author-mail":
+            author_mail = value
+        elif token == "filename":
+            # End of the first blame-block
+            break
+    return f"{author} {author_mail}"

--- a/tests/data/rpms/hello/from-git.patch
+++ b/tests/data/rpms/hello/from-git.patch
@@ -1,12 +1,12 @@
 From 5691f2b93484dd9cebae5a9ca61e9de44e814d15 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Hunor=20Csomort=C3=A1ni?= <csomh@redhat.com>
+From: =?UTF-8?q?A=20U=20Thor?= <thor@redhat.com>
 Date: Wed, 8 Sep 2021 09:45:13 +0200
 Subject: [PATCH] Linux
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
-Signed-off-by: Hunor Csomortáni <csomh@redhat.com>
+Signed-off-by: A U Thor <thor@redhat.com>
 ---
  hello.rs | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -238,7 +238,7 @@ def hello_dist_git_repo(tmp_path):
     shutil.copytree(DATA_DIR / "rpms" / "hello", repo_dir)
     repo = git.Repo.init(repo_dir)
     repo.git.add(".")
-    repo.git.commit(message="Initial commit")
+    repo.git.commit(message="Initial commit", author="Engin Eer <eer@redhat.com>")
     return repo
 
 

--- a/tests/integration/test_source_git_init.py
+++ b/tests/integration/test_source_git_init.py
@@ -279,7 +279,8 @@ def test_create_from_upstream_not_require_autosetup(
         in Path(hello_source_git_repo.working_dir, "hello.rs").read_text()
     )
 
-    commit_messsage_lines = hello_source_git_repo.commit("HEAD~1").message.splitlines()
+    commit = hello_source_git_repo.commit("HEAD~1")
+    commit_messsage_lines = commit.message.splitlines()
     assert "Patch-name: turn-into-fedora.patch" in commit_messsage_lines
     assert "Patch-id: 1" in commit_messsage_lines
     assert "Patch-status: |" in commit_messsage_lines
@@ -287,8 +288,13 @@ def test_create_from_upstream_not_require_autosetup(
         f"From-dist-git-commit: {hello_dist_git_repo.head.commit.hexsha}"
         in commit_messsage_lines
     )
+    # Author of a non-git-am patch is the one who was the original author
+    # of the patch-file in dist-git.
+    assert commit.author.name == "Engin Eer"
+    assert commit.author.email == "eer@redhat.com"
 
-    commit_messsage_lines = hello_source_git_repo.commit("HEAD").message.splitlines()
+    commit = hello_source_git_repo.commit("HEAD")
+    commit_messsage_lines = commit.message.splitlines()
     assert "Patch-name: from-git.patch" in commit_messsage_lines
     assert "Patch-id: 2" in commit_messsage_lines
     assert "Patch-status: |" in commit_messsage_lines
@@ -296,3 +302,5 @@ def test_create_from_upstream_not_require_autosetup(
         f"From-dist-git-commit: {hello_dist_git_repo.head.commit.hexsha}"
         in commit_messsage_lines
     )
+    assert commit.author.name == "A U Thor"
+    assert commit.author.email == "thor@redhat.com"


### PR DESCRIPTION
TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.

RELEASE NOTES BEGIN

When initializing source-git repos, the author of downstream commits created from patch files which are not in a git-am format is set to the original author of the patch-file in dist-git, instead of using the locally configured Git author.

RELEASE NOTES END
