### PR TITLE
Adjust the expected error message for missing source archives

### DIFF
--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -264,7 +264,8 @@ def test_create_srpm(upstream_instance, tmp_path):
 
     with pytest.raises(PackitSRPMException) as exc:
         ups.create_srpm()
-    assert "Bad source" in str(exc.value)
+    # Creating an SRPM failes b/c the source archive is not present.
+    assert "tar.gz: No such file or directory" in str(exc.value)
 
     ups.create_archive()
     srpm = ups.create_srpm()

--- a/tests_recording/test_api.py
+++ b/tests_recording/test_api.py
@@ -45,7 +45,7 @@ class ProposeUpdate(PackitTest):
 
     def setUp(self):
         super().setUp()
-        self.set_git_user()
+        self.configure_git()
         self._api = None
 
     @property

--- a/tests_recording/testbase.py
+++ b/tests_recording/testbase.py
@@ -90,7 +90,7 @@ class PackitTest(unittest.TestCase):
         return self.lp.working_dir / self._project_specfile_path
 
     @staticmethod
-    def set_git_user():
+    def configure_git():
         try:
             check_output(["git", "config", "--global", "-l"])
         except CalledProcessError:
@@ -98,3 +98,4 @@ class PackitTest(unittest.TestCase):
                 ["git", "config", "--global", "user.email", "test@example.com"]
             )
             check_output(["git", "config", "--global", "user.name", "Tester"])
+            check_output(["git", "config", "--global", "safe.directory", "*"])


### PR DESCRIPTION
RPM 4.18.0-alpha1 and above checks for the source archive to be found on
disk only during build time, instead of parse time. This though also
changed the error message when the source archive is missing when
building an SRPM: "Bad source" becomes "Bad file". See

https://github.com/rpm-software-management/rpm/commit/cd5d667e99f931504a512b591fcde7ed92cee344

Instead of chasing the change in wording, check for the part of the
error message which seems more future proof: "No such file or
directory".

This fixes the failing Testing Farm tests in Rawhide.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>