### PR TITLE
De-duplicate Git-trailers

### DIFF
--- a/_packitpatch
+++ b/_packitpatch
@@ -56,35 +56,22 @@ fi
 # Let's go back to the ref we were before starting all this.
 git checkout -
 
-trailers="Patch-name: ${patch_name}"
-# when patches are applied with -p0, we need to strip the prefix
-# in packit when creating the patch files
-if echo ${@:3} | grep -E "[-]p0|[-]p 0"; then
-  trailers="$trailers
-No-prefix: true
-"
-fi
-
 # Cherry-pick commits from the temp branch, one-by-one, and amend them
 # to include Git-trailers with patch-metadata.
 for commit in $(git rev-list ${base_commit}..${temp_branch} | tac); do
-    commit_message=$(git show -s --format=%B $commit)
-    has_trailers=$(echo "$commit_message" | git interpret-trailers --parse)
-    # Make sure there is an empty line to separate the trailer block
-    # from the commit message if the commit message has no trailers so far.
-    if [[ -z "$has_trailers" ]]; then
-        # Watch out for the correct indentation!
-        # This seems to be the easiest way to add a newline
-        # at the end of the message.
-        commit_message="$commit_message
-"
+    commit_message_file=$(mktemp)
+    git show -s --format=%B $commit > $commit_message_file
+    git interpret-trailers --in-place --if-exists replace \
+        --trailer "Patch-name=${patch_name}" "$commit_message_file"
+    # when patches are applied with -p0, we need to strip the prefix
+    # in packit when creating the patch files
+    if echo ${@:3} | grep -E "[-]p0|[-]p 0"; then
+        git interpret-trailers --in-place --if-exists replace \
+            --trailer "No-prefix=true" "$commit_message_file"
     fi
-    # Watch out for the correct indentation!
-    commit_message="$commit_message
-$trailers
-"
     git cherry-pick --allow-empty $commit
-    git commit --allow-empty --amend -m"$commit_message"
+    git commit --allow-empty --amend --file "$commit_message_file"
+    rm "$commit_message_file"
 done
 
 # Clean up the temporary branch.

--- a/packit/utils/__init__.py
+++ b/packit/utils/__init__.py
@@ -10,6 +10,7 @@ from packit.utils.logging import (
     commits_to_nice_str,
 )
 from packit.utils.repo import (
+    commit_message_file,
     get_default_branch,
     get_file_author,
     get_namespace_and_repo_name,
@@ -22,6 +23,7 @@ from packit.utils.repo import (
 
 __all__ = [
     assert_existence.__name__,
+    commit_message_file.__name__,
     commits_to_nice_str.__name__,
     cwd.__name__,
     get_default_branch.__name__,

--- a/tests/data/rpms/hello/from-git.patch
+++ b/tests/data/rpms/hello/from-git.patch
@@ -6,6 +6,7 @@ MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
 
+Patch-name: from-another-git.patch
 Signed-off-by: A U Thor <thor@redhat.com>
 ---
  hello.rs | 2 +-

--- a/tests/integration/test_source_git_init.py
+++ b/tests/integration/test_source_git_init.py
@@ -296,6 +296,7 @@ def test_create_from_upstream_not_require_autosetup(
     commit = hello_source_git_repo.commit("HEAD")
     commit_messsage_lines = commit.message.splitlines()
     assert "Patch-name: from-git.patch" in commit_messsage_lines
+    assert "Patch-name: from-another-git.patch" not in commit_messsage_lines
     assert "Patch-id: 2" in commit_messsage_lines
     assert "Patch-status: |" in commit_messsage_lines
     assert (

--- a/tests/integration/test_source_git_update_source_git.py
+++ b/tests/integration/test_source_git_update_source_git.py
@@ -187,11 +187,13 @@ def test_update_source_git(
 
     # Delete a file
     (distgit / new_name).unlink()
-    api_instance_update_source_git.dg.commit("Delete", "")
+    api_instance_update_source_git.dg.commit("Delete", "Some file")
     api_instance_update_source_git.update_source_git(revision_range)
     assert not (sourcegit / DISTRO_DIR / new_name).exists()
     assert (
-        "Delete"
+        """Delete
+
+Some file"""
         in api_instance_update_source_git.up.local_project.git_repo.head.commit.message
     )
     assert (


### PR DESCRIPTION
TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.

Fixes #1491.

RELEASE NOTES BEGIN
`packit source-git` commands learnt to replace [Git-trailers in commit messages](https://packit.dev/source-git/work-with-source-git/control-patch-generation/) if they already exist.
RELEASE NOTES END
