### PR TITLE
Fix removal of specfile patches

### DIFF
--- a/packit/specfile.py
+++ b/packit/specfile.py
@@ -334,15 +334,19 @@ class Specfile(SpecFile):
     def remove_patches(self):
         """Remove all patch-lines from the spec file"""
         content = []
+        # The stretch gathers patch + the associated comments
         stretch = []
         for line in self.spec_content.section("%package"):
             stretch.append(line)
-            # Empty lines save the current stretch into content.
-            if not line.strip():
+            # Non-patch lines without comment save the current stretch
+            stripped = line.strip()
+            if not stripped.startswith("#") and not stripped.lower().startswith(
+                "patch"
+            ):
                 content += stretch
                 stretch = []
             # Patch-lines throw away the current stretch.
-            if line.lower().startswith("patch"):
+            if stripped.lower().startswith("patch"):
                 stretch = []
                 # If there is an empty line at the end of content
                 # throw it away, to avoid duplicate lines.

--- a/tests/integration/test_spec.py
+++ b/tests/integration/test_spec.py
@@ -194,3 +194,23 @@ Patch : dark.patch
     spec = Specfile(specfile, sources_dir=specfile.parent)
     spec.remove_patches()
     assert specfile.read_text() == no_patches
+
+
+def test_remove_patches_no_blanklines(specfile):
+    no_blanks = specfile.read_text().replace("\n\n", "\n")
+    no_patches = no_blanks.replace("\n### patches ###\n", "\n")
+    patches = no_blanks.replace(
+        "### patches ###\n",
+        """\
+# Some comment line to be removed
+Patch1: yellow.patch
+Patch2: blue.patch
+# One
+# Or more lines
+Patch : dark.patch
+""",
+    )
+    specfile.write_text(patches)
+    spec = Specfile(specfile, sources_dir=specfile.parent)
+    spec.remove_patches()
+    assert specfile.read_text() == no_patches


### PR DESCRIPTION
We need to keep track of the stretch with patch + its associated
comments correctly. Previously, the stretch was added to the new section
content when a blank line was hit, however this does not work when the
patches are not separated by blank lines in the preamble. Add the stretch
when a non-patch and non-comment line is found.

TODO:

- [x] Write new tests or update the old ones to cover new functionality.

<!-- notes for reviewers -->

The example given in the original issue still does not work correctly but this is caused by an unrelated rebase-helper bug. The rpm.spec is not parsed correctly and does not contain the patch application, hence a `KeyError` occurs in packit. However, the parsing works correctly with then new specfile library so I am not sure if it's worth fixing. Anyway, I will take a look in rebase-helper and try to find the root cause there if it is simple enough.

Fixes #1571 

RELEASE NOTES BEGIN
Packit now correctly removes patches during `packit source-git init` when the preamble does not contain blank lines.
RELEASE NOTES END
