### PR TITLE
0.51.0 upstream release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+# 0.51.0
+
+- We have decided to deprecate `metadata` section for job configurations. All
+  metadata-specific configuration values can be placed on the same level as the job
+  definition. For now we are in a backward-compatible period, please move your settings
+  from the `metadata` section. (#1569)
+- Packit now correctly removes patches during `packit source-git init` when the
+  preamble does not contain blank lines. (#1582)
+- `packit source-git` commands learnt to replace Git-trailers in commit
+  messages if they already exist. (#1577)
+- Packit now supports `--release-suffix` parameter in all of the related CLI
+  commands. Also we have added a support for the `release_suffix` option from
+  configuration to the CLI. With regards to that we have introduced a new CLI
+  switch `--default-release-suffix` that allows you to override the configuration
+  option to Packit-generated default option that ensures correct NVR ordering
+  of the RPMs. (#1586)
+
 # 0.50.0
 
 - When initializing source-git repos, the author of downstream commits created from patch files which are not in a git-am format is set to the original author of the patch-file in dist-git, instead of using the locally configured Git author. (#1575)

--- a/packit.spec
+++ b/packit.spec
@@ -2,7 +2,7 @@
 %global real_name packit
 
 Name:           %{real_name}
-Version:        0.50.0
+Version:        0.51.0
 Release:        1%{?dist}
 Summary:        A tool for integrating upstream projects with Fedora operating system
 
@@ -94,6 +94,9 @@ cp files/bash-completion/packit %{buildroot}%{_datadir}/bash-completion/completi
 %{python3_sitelib}/*
 
 %changelog
+* Thu May 12 2022 Tomas Tomecek <ttomecek@redhat.com> - 0.51.0-1
+- New upstream release 0.51.0
+
 * Thu May 05 2022 Matej Focko <mfocko@redhat.com> - 0.50.0-1
 - New upstream release 0.50.0
 


### PR DESCRIPTION
TODO:

- [x] Test out on stg the drop of the metadata key.
- [x] Then remove the commit that does that.
- [ ] rebase and pick up the release suffix change