### PR TITLE
Introduce job config fields for allowed accounts for Koji builds

### DIFF
--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -61,6 +61,10 @@ class CommonPackageConfig:
         skip_build: if we want to skip build phase for Testing Farm job
         env: environment variables
         enable_net: if set to False, Copr builds have network disabled
+        allowed_pr_authors: list of Fedora accounts for which distgit PRs we
+                        will run koji builds
+        allowed_committers: list of Fedora accounts for which distgit pushes we
+                        will run koji builds
     """
 
     def __init__(
@@ -113,6 +117,8 @@ class CommonPackageConfig:
         skip_build: bool = False,
         env: Optional[Dict[str, Any]] = None,
         enable_net: bool = True,
+        allowed_pr_authors: Optional[List[str]] = None,
+        allowed_committers: Optional[List[str]] = None,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -193,6 +199,10 @@ class CommonPackageConfig:
         self.skip_build: bool = skip_build
         self.env: Dict[str, Any] = env or {}
         self.enable_net = enable_net
+        self.allowed_pr_authors = (
+            allowed_pr_authors if allowed_pr_authors is not None else ["packit"]
+        )
+        self.allowed_committers = allowed_committers or []
 
     @property
     def targets_dict(self):
@@ -283,7 +293,9 @@ class CommonPackageConfig:
             f"use_internal_tf={self.use_internal_tf}, "
             f"skip_build={self.skip_build},"
             f"env={self.env},"
-            f"enable_net={self.enable_net})"
+            f"enable_net={self.enable_net},"
+            f"allowed_pr_authors={self.allowed_pr_authors},"
+            f"allowed_committers={self.allowed_committers})"
         )
 
     @property

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -96,6 +96,8 @@ class JobConfig(CommonPackageConfig):
         skip_build: bool = False,
         env: Optional[Dict[str, Any]] = None,
         enable_net: bool = True,
+        allowed_pr_authors: Optional[List[str]] = None,
+        allowed_committers: Optional[List[str]] = None,
     ):
         super().__init__(
             config_file_path=config_file_path,
@@ -146,6 +148,8 @@ class JobConfig(CommonPackageConfig):
             skip_build=skip_build,
             env=env,
             enable_net=enable_net,
+            allowed_pr_authors=allowed_pr_authors,
+            allowed_committers=allowed_committers,
         )
         self.type: JobType = type
         self.trigger: JobConfigTriggerType = trigger
@@ -197,7 +201,9 @@ class JobConfig(CommonPackageConfig):
             f"use_internal_tf={self.use_internal_tf}, "
             f"skip_build={self.skip_build},"
             f"env={self.env},"
-            f"enable_net={self.enable_net})"
+            f"enable_net={self.enable_net},"
+            f"allowed_pr_authors={self.allowed_pr_authors},"
+            f"allowed_commiters={self.allowed_committers})"
         )
 
     @classmethod

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -386,6 +386,8 @@ class JobConfigSchema(CommonConfigSchema):
     skip_build = fields.Boolean()
     env = fields.Dict(keys=fields.String(), missing=None)
     enable_net = fields.Boolean(missing=True)
+    allowed_pr_authors = fields.List(fields.String(), missing=None)
+    allowed_committers = fields.List(fields.String(), missing=None)
 
     metadata = fields.Nested(JobMetadataSchema)
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -160,6 +160,60 @@ def test_job_config_parse(raw, expected_config):
     assert job_config == expected_config
 
 
+@pytest.mark.parametrize(
+    "raw,expected,allowed_pr_authors,allowed_committers",
+    [
+        pytest.param(
+            {
+                "job": "koji_build",
+                "trigger": "commit",
+            },
+            JobConfig(
+                type=JobType.koji_build,
+                trigger=JobConfigTriggerType.commit,
+            ),
+            ["packit"],
+            [],
+        ),
+        pytest.param(
+            {
+                "job": "koji_build",
+                "trigger": "commit",
+                "allowed_committers": ["me"],
+            },
+            JobConfig(
+                type=JobType.koji_build,
+                trigger=JobConfigTriggerType.commit,
+                allowed_committers=["me"],
+            ),
+            ["packit"],
+            ["me"],
+        ),
+        pytest.param(
+            {
+                "job": "koji_build",
+                "trigger": "commit",
+                "allowed_committers": ["me"],
+                "allowed_pr_authors": [],
+            },
+            JobConfig(
+                type=JobType.koji_build,
+                trigger=JobConfigTriggerType.commit,
+                allowed_committers=["me"],
+                allowed_pr_authors=[],
+            ),
+            [],
+            ["me"],
+        ),
+    ],
+)
+def test_koji_build_allowlist(raw, expected, allowed_pr_authors, allowed_committers):
+    job_config = JobConfig.get_from_dict(raw_dict=raw)
+    assert job_config == expected
+    assert job_config.allowed_pr_authors == allowed_pr_authors
+    assert job_config.allowed_committers == allowed_committers
+
+
 def test_get_user_config(tmp_path):
     user_config_file_path = tmp_path / ".packit.yaml"
     user_config_file_path.write_text(


### PR DESCRIPTION
Introduce 2 new job config fields - allowed_pr_authors - list of Fedora accounts for which distgit PRs we
will run koji builds, allowed_committers - list of Fedora accounts for which distgit pushes we
will run koji builds.

TODO:
- [ ] Update or write new documentation in `packit/packit.dev`.


Related to packit/packit-service#1490


RELEASE NOTES BEGIN
TODO

RELEASE NOTES END
