### PR TITLE
Do not raise an exception if symlink is broken

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1094,7 +1094,9 @@ The first dist-git commit to be synced is '{short_hash}'.
             result_dir: directory where the specfile directory content should be copied
         """
         logger.debug(f"Copying {self.up.absolute_specfile_dir} -> {result_dir}")
-        copy_tree(str(self.up.absolute_specfile_dir), str(result_dir))
+        copy_tree(
+            str(self.up.absolute_specfile_dir), str(result_dir), preserve_symlinks=True
+        )
 
     def create_srpm(
         self,


### PR DESCRIPTION
If 'preserve_symlinks' is true, symlinks will be copied as symlinks.
Otherwise (the default), the destination of the symlink will be copied,
and it will raise an exception if the symlink is dangling.


Fixes packit/packit#1560


RELEASE NOTES BEGIN

Packit will no raise Exceptions anymore when creating a SRPM with dangling symlinks. 

RELEASE NOTES END
