### PR TITLE
Check the paths in the package config relative to the project path

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1521,7 +1521,7 @@ The first dist-git commit to be synced is '{short_hash}'.
             try_local_dir_last=True,
         )
         config_content = load_packit_yaml(config_path)
-        v = PackageConfigValidator(config_path, config_content)
+        v = PackageConfigValidator(config_path, config_content, working_dir)
         return v.validate()
 
     def init_source_git(

--- a/tests/integration/test_validate_config.py
+++ b/tests/integration/test_validate_config.py
@@ -198,11 +198,12 @@ from packit.utils.commands import cwd
 )
 def test_schema_validation(tmpdir, raw_package_config, expected_output):
     with cwd(tmpdir):
-        Path("packit.json").write_text(raw_package_config)
-        Path("packit.spec").write_text("hello")
-        Path("a.md").write_text("a")
-        Path("b.md").write_text("b")
-        Path("c.txt").write_text("c")
+        Path("test_dir").mkdir()
+        Path("test_dir/packit.json").write_text(raw_package_config)
+        Path("test_dir/packit.spec").write_text("hello")
+        Path("test_dir/a.md").write_text("a")
+        Path("test_dir/b.md").write_text("b")
+        Path("test_dir/c.txt").write_text("c")
 
-        output = PackitAPI.validate_package_config(Path("."))
+        output = PackitAPI.validate_package_config(Path("test_dir"))
         assert expected_output in output

--- a/tests/integration/test_validate_synced_files.py
+++ b/tests/integration/test_validate_synced_files.py
@@ -44,7 +44,8 @@ from packit.utils.commands import cwd
                 "synced_files": ["a.md", "b.md", "c.txt", "a_dir"]
             }
             """,
-            "The following path is configured to be synced but does not exist: c.txt",
+            "The following path is configured to be synced but is not present "
+            "in the repository: c.txt",
         ),
         (
             ["a.md"],
@@ -61,7 +62,8 @@ from packit.utils.commands import cwd
                  "synced_files": ["a.md", "b.md", "c.txt"]
              }
              """,
-            "The following paths are configured to be synced but do not exist: b.md, c.txt",
+            "The following paths are configured to be synced but are not present "
+            "in the repository: b.md, c.txt",
         ),
     ],
     ids=[


### PR DESCRIPTION
When checking if the paths referenced in a package configuration file
(path of the specfile, paths of the files to be synced), make these
paths relative to the path of the project.

This fixes an issue, where

    packit validate-config src/systemd

was reporting the specfile and the files to be synced as missing,
although all of them were to be found in 'src/systemd/.distro'.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.