### PR TITLE
Fix checking for dict type during validation

### DIFF
--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -284,7 +284,9 @@ def load_packit_yaml(config_file_path: Path) -> Dict:
     :return: Dict with the file content
     """
     try:
-        return safe_load(config_file_path.read_text())
+        # safe_load() returns None when the file is empty, but this needs
+        # to return a dict.
+        return safe_load(config_file_path.read_text()) or {}
     except Exception as ex:
         logger.error(f"Cannot load package config {config_file_path}.")
         raise PackitConfigException(f"Cannot load package config: {ex!r}.")

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -430,10 +430,9 @@ class JobConfigSchema(CommonConfigSchema):
                 )
 
         for key in ("targets", "dist_git_branches"):
-            if data is dict:
-                if isinstance(data.get(key), str):
-                    # allow key value being specified as string, convert to list
-                    data[key] = [data.pop(key)]
+            if isinstance(data, dict) and isinstance(data.get(key), str):
+                # allow key value being specified as string, convert to list
+                data[key] = [data.pop(key)]
 
         return data
 

--- a/tests/integration/test_validate_config.py
+++ b/tests/integration/test_validate_config.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path
+from textwrap import dedent
 
 import pytest
 
@@ -13,171 +14,170 @@ from packit.utils.commands import cwd
     "raw_package_config,expected_output",
     [
         (
+            dedent(
+                """\
+                dist_git_base_url: https://packit.dev/
+                downstream_package_name: packit
+                upstream_ref: last_commit
+                upstream_package_name: packit_upstream
+                allowed_gpg_keys: [gpg]
+                dist_git_namespace: awesome
+                notifications:
+                    pull_request:
+                        successful_build: true
             """
-            {
-                "config_file_path": "packit.json",
-                "dist_git_base_url": "https://packit.dev/",
-                "downstream_package_name": "packit",
-                "upstream_ref": "last_commit",
-                "upstream_package_name": "packit_upstream",
-                "allowed_gpg_keys": ["gpg"],
-                "dist_git_namespace": "awesome",
-                "notifications": {
-                    "pull_request": {
-                        "successful_build": True
-                    }
-                }
-            }
-            """,
-            "packit.json is valid and ready to be used",
+            ),
+            "packit.yaml is valid and ready to be used",
         ),
         (
+            dedent(
+                """\
+                dist_git_base_url: https://packit.dev/
+                downstream_package_name: packit
+                upstream_ref: last_commit
+                upstream_package_name: packit_upstream
+                allowed_gpg_keys: [gpg]
+                dist_git_namespace: awesome
+                notifications:
+                    pull_request:
+                        successful_build: 55
             """
-            {
-                "config_file_path": "packit.json",
-                "dist_git_base_url": "https://packit.dev/",
-                "downstream_package_name": "packit",
-                "upstream_ref": "last_commit",
-                "upstream_package_name": "packit_upstream",
-                "allowed_gpg_keys": ["gpg"],
-                "dist_git_namespace": "awesome",
-                "notifications": {
-                    "pull_request": {
-                        "successful_build": 55
-                    }
-                }
-            }
-            """,
+            ),
             "* field notifications has an incorrect value:\n"
             "** field pull_request has an incorrect value:\n"
             "*** value at index successful_build: Not a valid boolean.",
         ),
-        ("{}", "packit.json is valid and ready to be used"),
+        ("", "packit.yaml is valid and ready to be used"),
         (
+            dedent(
+                """\
+                dist_git_base_url: https://packit.dev/
+                downstream_package_name: packit
+                upstream_ref: last_commit
+                upstream_package_name: packit_upstream
+                allowed_gpg_keys: [gpg]
+                dist_git_namespace: awesome
+                synced_files:
+                - a.md
+                - b.md
+                - c.txt
             """
-            {
-                "config_file_path": "packit.json",
-                "dist_git_base_url": "https://packit.dev/",
-                "downstream_package_name": "packit",
-                "upstream_ref": "last_commit",
-                "upstream_package_name": "packit_upstream",
-                "allowed_gpg_keys": ["gpg"],
-                "dist_git_namespace": "awesome",
-                "synced_files": ["a.md", "b.md", "c.txt"]
-            }
-            """,
-            "packit.json is valid and ready to be used",
+            ),
+            "packit.yaml is valid and ready to be used",
         ),
         (
+            dedent(
+                """\
+                dist_git_base_url: https://packit.dev/
+                downstream_package_name: packit
+                upstream_ref: last_commit
+                upstream_package_name: packit_upstream
+                allowed_gpg_keys: [gpg]
+                dist_git_namespace: awesome
+                synced_files:
+                - src: 55
+                  dest: a.md
+                - b.md
+                - c.txt
             """
-                {
-                    "config_file_path": "packit.json",
-                    "dist_git_base_url": "https://packit.dev/",
-                    "downstream_package_name": "packit",
-                    "upstream_ref": "last_commit",
-                    "upstream_package_name": "packit_upstream",
-                    "allowed_gpg_keys": ["gpg"],
-                    "dist_git_namespace": "awesome",
-                    "synced_files": [{ "src": 55, "dest": "a.md" }, "b.md", "c.txt"]
-                }
-                """,
+            ),
             "Expected 'list[str]' or 'str', got <class 'int'>.",
         ),
         (
+            dedent(
+                """\
+                dist_git_base_url: https://packit.dev/
+                downstream_package_name: packit
+                upstream_ref: last_commit
+                upstream_package_name: packit_upstream
+                allowed_gpg_keys: [gpg]
+                dist_git_namespace: awesome
+                synced_files:
+                - a.md
+                - b.md
+                - src: c.txt
+                  dest: True
             """
-                {
-                    "config_file_path": "packit.json",
-                    "dist_git_base_url": "https://packit.dev/",
-                    "downstream_package_name": "packit",
-                    "upstream_ref": "last_commit",
-                    "upstream_package_name": "packit_upstream",
-                    "allowed_gpg_keys": ["gpg"],
-                    "dist_git_namespace": "awesome",
-                    "synced_files": ["a.md", "b.md", { "src": "c.txt", "dest": True }]
-                }
-                """,
+            ),
             "dest: Not a valid string.",
         ),
         (
+            dedent(
+                """\
+                dist_git_base_url: https://packit.dev/
+                downstream_package_name: packit
+                upstream_ref: last_commit
+                upstream_package_name: packit_upstream
+                allowed_gpg_keys: [gpg]
+                dist_git_namespace: awesome
             """
-                {
-                    "dist_git_base_url": "https://packit.dev/",
-                    "downstream_package_name": "packit",
-                    "upstream_ref": "last_commit",
-                    "upstream_package_name": "packit_upstream",
-                    "allowed_gpg_keys": ["gpg"],
-                    "dist_git_namespace": "awesome"
-                }
-                """,
-            "packit.json is valid and ready to be used",
+            ),
+            "packit.yaml is valid and ready to be used",
         ),
         (
+            dedent(
+                """\
+                dist_git_base_url: https://packit.dev/
+                downstream_package_name: 23
+                upstream_ref: last_commit
+                upstream_package_name: packit_upstream
+                allowed_gpg_keys: [gpg]
+                dist_git_namespace: awesome
             """
-                {
-                    "dist_git_base_url": "https://packit.dev/",
-                    "downstream_package_name": 23,
-                    "upstream_ref": "last_commit",
-                    "upstream_package_name": "packit_upstream",
-                    "allowed_gpg_keys": ["gpg"],
-                    "dist_git_namespace": "awesome"
-                }
-                """,
+            ),
             "* field downstream_package_name: Not a valid string.",
         ),
         (
+            dedent(
+                """\
+                dist_git_base_url: https://packit.dev/
+                downstream_package_name: packit
+                upstream_ref: last_commit
+                upstream_package_name: packit_upstream
+                allowed_gpg_keys: [gpg]
+                dist_git_namespace: awesome
+                create_pr: ""
             """
-                {
-                    "dist_git_base_url": "https://packit.dev/",
-                    "downstream_package_name": "packit",
-                    "upstream_ref": "last_commit",
-                    "upstream_package_name": "packit_upstream",
-                    "allowed_gpg_keys": ["gpg"],
-                    "dist_git_namespace": "awesome",
-                    create_pr: ""
-                }
-                """,
+            ),
             "* field create_pr: Not a valid boolean.",
         ),
         (
+            dedent(
+                """\
+                dist_git_base_url: https://packit.dev/
+                downstream_package_name: packit
+                upstream_ref: last_commit
+                upstream_package_name: packit_upstream
+                allowed_gpg_keys: [gpg]
+                dist_git_namespace: awesome
             """
-                {
-                    "config_file_path": "packit.json",
-                    "dist_git_base_url": "https: //packit.dev/",
-                    "downstream_package_name": "packit",
-                    "upstream_ref": "last_commit",
-                    "upstream_package_name": "packit_upstream",
-                    "allowed_gpg_keys": ["gpg"],
-                    "dist_git_namespace": "awesome"
-                }
-                """,
-            "packit.json is valid and ready to be used",
+            ),
+            "packit.yaml is valid and ready to be used",
         ),
         (
+            dedent(
+                """\
+                dist_git_base_url: https://packit.dev/
+                downstream_package_name: packit
+                upstream_ref: last_commit
+                upstream_package_name: packit_upstream
+                allowed_gpg_keys: gpg
+                dist_git_namespace: awesome
             """
-                {
-                    "config_file_path": "packit.json",
-                    "dist_git_base_url": "https: //packit.dev/",
-                    "downstream_package_name": "packit",
-                    "upstream_ref": "last_commit",
-                    "upstream_package_name": "packit_upstream",
-                    "allowed_gpg_keys": "gpg",
-                    "dist_git_namespace": "awesome"
-                }
-                """,
+            ),
             "* field allowed_gpg_keys: Not a valid list.",
         ),
         (
+            dedent(
+                """\
+                dist_git_base_url: https://packit.dev/
+                downstream_package_name: packit
+                upstream_ref: last_commit
+                upstream_package_name: packit/upstream
+                allowed_gpg_keys: [gpg]
+                dist_git_namespace: awesome
             """
-                {
-                    "config_file_path": "packit.json",
-                    "dist_git_base_url": "https: //packit.dev/",
-                    "downstream_package_name": "packit",
-                    "upstream_ref": "last_commit",
-                    "upstream_package_name": "packit/upstream",
-                    "allowed_gpg_keys": ["gpg"],
-                    "dist_git_namespace": "awesome"
-                }
-                """,
+            ),
             " Repository name must be a valid filename.",
         ),
     ],
@@ -199,7 +199,7 @@ from packit.utils.commands import cwd
 def test_schema_validation(tmpdir, raw_package_config, expected_output):
     with cwd(tmpdir):
         Path("test_dir").mkdir()
-        Path("test_dir/packit.json").write_text(raw_package_config)
+        Path("test_dir/packit.yaml").write_text(raw_package_config)
         Path("test_dir/packit.spec").write_text("hello")
         Path("test_dir/a.md").write_text("a")
         Path("test_dir/b.md").write_text("b")

--- a/tests/integration/test_validate_config.py
+++ b/tests/integration/test_validate_config.py
@@ -25,6 +25,10 @@ from packit.utils.commands import cwd
                 notifications:
                     pull_request:
                         successful_build: true
+                jobs:
+                - job: copr_build
+                  trigger: pull_request
+                  targets: fedora-stable
             """
             ),
             "packit.yaml is valid and ready to be used",
@@ -61,6 +65,10 @@ from packit.utils.commands import cwd
                 - a.md
                 - b.md
                 - c.txt
+                jobs:
+                - job: propose_downstream
+                  trigger: release
+                  dist_git_branches: fedora-latest
             """
             ),
             "packit.yaml is valid and ready to be used",
@@ -110,6 +118,12 @@ from packit.utils.commands import cwd
                 upstream_package_name: packit_upstream
                 allowed_gpg_keys: [gpg]
                 dist_git_namespace: awesome
+                jobs:
+                - job: tests
+                  trigger: pull_request
+                  targets:
+                  - fedora-stable
+                  - centos-stream-9
             """
             ),
             "packit.yaml is valid and ready to be used",
@@ -150,6 +164,12 @@ from packit.utils.commands import cwd
                 upstream_package_name: packit_upstream
                 allowed_gpg_keys: [gpg]
                 dist_git_namespace: awesome
+                jobs:
+                - job: bodhi_update
+                  trigger: commit
+                  dist_git_branches:
+                  - f35
+                  - f36
             """
             ),
             "packit.yaml is valid and ready to be used",


### PR DESCRIPTION
This was causing the 'targets' and 'dist_git_branches' fields to be
considered invalid if their values were strings instead of lists.

Fixes #1605.

RELEASE NOTES BEGIN
Fixed a regression where string values for the 'targets' and 'dist_git_branches' configuration keys was not accepted.
RELEASE NOTES END
