### PR TITLE
fix(local_project): check forge against project

### DIFF
--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -10,6 +10,7 @@ import git
 from git.exc import GitCommandError
 from ogr import GitlabService
 from ogr.abstract import GitProject, GitService
+from ogr.factory import get_service_class
 from ogr.parsing import parse_git_repo
 
 from packit.constants import LP_TEMP_PR_CHECKOUT_NAME
@@ -468,7 +469,9 @@ class LocalProject:
             pr_id: ID of the PR we are merging.
         """
         logger.info(f"Checking out PR {pr_id}.")
-        is_gitlab = isinstance(self.git_service, GitlabService)
+        is_gitlab = isinstance(self.git_service, GitlabService) or (
+            not self.git_service and get_service_class(self.git_url) == GitlabService
+        )
         remote_ref = "+refs/{}/{}/head".format(
             "merge-requests" if is_gitlab else "pull", pr_id
         )


### PR DESCRIPTION
When checking out PR during preparation of sources (in Sandcastle or Copr),
we use `git_service` to correctly determine remote git reference. When
running in Copr, we have neither git project or git service, therefore in
such case, fall back to the ogr's parsing of git URL to acquire expected
service class.

Signed-off-by: Matej Focko <mfocko@redhat.com>

TODO:

- [X] Write new tests or update the old ones to cover new functionality.
- [X] Update doc-strings where appropriate.
- [X] Update or write new documentation in `packit/packit.dev`.
