### PR TITLE
Build refactor

### DIFF
--- a/packit/cli/build.py
+++ b/packit/cli/build.py
@@ -1,132 +1,32 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+"""The 'build' subcommand for Packit"""
+
 import logging
-from os import getcwd
 
 import click
 
-from packit.cli.types import LocalProjectParameter
-from packit.cli.utils import cover_packit_exception, get_packit_api
-from packit.config import pass_config, get_context_settings
-from packit.config.aliases import get_branches, get_koji_targets
-from packit.exceptions import PackitCommandFailedError, ensure_str
-from packit.exceptions import PackitConfigException
-from packit.utils.changelog_helper import ChangelogHelper
+from packit.cli.builds.copr_build import copr
+from packit.cli.builds.koji_build import koji
+from packit.cli.builds.local_build import local
 
 logger = logging.getLogger(__name__)
 
 
-@click.command("build", context_settings=get_context_settings())
+@click.group("build")
 @click.option(
-    "--dist-git-branch",
-    help="Comma separated list of target branches in dist-git to release into. "
-    "(defaults to repo's default branch)",
-)
-@click.option(
-    "--dist-git-path",
-    help="Path to dist-git repo to work in. "
-    "Otherwise clone the repo in a temporary directory.",
-)
-@click.option(
-    "--from-upstream",
-    help="Build the project in koji directly from the upstream repository",
-    is_flag=True,
-    default=False,
-)
-@click.option(
-    "--koji-target", help="Koji target to build inside (see `koji list-targets`)."
-)
-@click.option(
-    "--scratch", is_flag=True, default=False, help="Submit a scratch koji build"
-)
-@click.option("--nowait", is_flag=True, default=False, help="Don't wait on build")
-@click.option(
-    "--release-suffix",
+    "--srpm",
+    help="Build the SRPM from FILE instead of implicit SRPM build.",
+    type=click.Path(exists=True, dir_okay=False),
     default=None,
-    type=click.STRING,
-    help="Specifies release suffix. Allows to override default generated:"
-    "{current_time}.{sanitized_current_branch}{git_desc_suffix}",
 )
-@click.option(
-    "--default-release-suffix",
-    default=False,
-    is_flag=True,
-    help=(
-        "Allows to use default, packit-generated, release suffix when some "
-        "release_suffix is specified in the configuration."
-    ),
-)
-@click.argument("path_or_url", type=LocalProjectParameter(), default=getcwd())
-@pass_config
-@cover_packit_exception
-def build(
-    config,
-    dist_git_path,
-    dist_git_branch,
-    from_upstream,
-    koji_target,
-    scratch,
-    nowait,
-    release_suffix,
-    default_release_suffix,
-    path_or_url,
-):
-    """
-    Build selected upstream project in Fedora.
+@click.pass_context
+def build(ctx, srpm):
+    """Subcommand to collect build related functionality"""
+    ctx.obj.srpm_path = srpm
 
-    By default, packit checks out the respective dist-git repository and performs
-    `fedpkg build` for the selected branch. With `--from-upstream`, packit creates a SRPM
-    out of the current checkout and sends it to koji.
 
-    PATH_OR_URL argument is a local path or a URL to the upstream git repository,
-    it defaults to the current working directory
-    """
-    api = get_packit_api(
-        config=config, dist_git_path=dist_git_path, local_project=path_or_url
-    )
-    release_suffix = ChangelogHelper.resolve_release_suffix(
-        api.package_config, release_suffix, default_release_suffix
-    )
-
-    default_dg_branch = api.dg.local_project.git_project.default_branch
-    dist_git_branch = dist_git_branch or default_dg_branch
-    branches_to_build = get_branches(
-        *dist_git_branch.split(","), default_dg_branch=default_dg_branch
-    )
-    click.echo(f"Building from the following branches: {', '.join(branches_to_build)}")
-
-    if koji_target is None:
-        targets_to_build = {None}
-    else:
-        targets_to_build = get_koji_targets(koji_target)
-
-    if len(targets_to_build) > 1 and len(branches_to_build) > 1:
-        raise PackitConfigException(
-            "Parameters --dist-git-branch and --koji-target cannot have "
-            "multiple values at the same time."
-        )
-
-    for target in targets_to_build:
-        for branch in branches_to_build:
-            try:
-                out = api.build(
-                    dist_git_branch=branch,
-                    scratch=scratch,
-                    nowait=nowait,
-                    koji_target=target,
-                    from_upstream=from_upstream,
-                    release_suffix=release_suffix,
-                )
-            except PackitCommandFailedError as ex:
-                logs_stdout = "\n>>> ".join(ex.stdout_output.strip().split("\n"))
-                logs_stderr = "\n!!! ".join(ex.stderr_output.strip().split("\n"))
-                click.echo(
-                    f"Build for branch '{branch}' failed. \n"
-                    f">>> {logs_stdout}\n"
-                    f"!!! {logs_stderr}\n",
-                    err=True,
-                )
-            else:
-                if out:
-                    print(ensure_str(out))
+build.add_command(copr)
+build.add_command(koji)
+build.add_command(local)

--- a/packit/cli/builds/__init__.py
+++ b/packit/cli/builds/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT

--- a/packit/cli/builds/copr_build.py
+++ b/packit/cli/builds/copr_build.py
@@ -121,7 +121,7 @@ def copr(
     path_or_url,
 ):
     """
-    Build selected upstream project in COPR.
+    Build selected upstream project in Copr.
 
     PATH_OR_URL argument is a local path or a URL to the upstream git repository,
     it defaults to the current working directory.
@@ -132,22 +132,22 @@ def copr(
     )
 
     if not project:
-        logger.debug("COPR project name was not passed via CLI.")
+        logger.debug("Copr project name was not passed via CLI.")
 
         if isinstance(api.package_config, PackageConfig):
             project = api.package_config.get_copr_build_project_value()
 
         if project:
-            logger.debug("Using a first COPR project found in the job configuration.")
+            logger.debug("Using a first Copr project found in the job configuration.")
         else:
             logger.debug(
-                "COPR project not found in the job configuration. "
+                "Copr project not found in the job configuration. "
                 "Using the default one."
             )
             sanitized_ref = sanitize_branch_name(path_or_url.ref)
             project = f"packit-cli-{path_or_url.repo_name}-{sanitized_ref}"
 
-    logger.info(f"Using COPR project name = {project}")
+    logger.info(f"Using Copr project name = {project}")
 
     targets_list = targets.split(",")
     for target in targets_list:

--- a/packit/cli/builds/copr_build.py
+++ b/packit/cli/builds/copr_build.py
@@ -17,7 +17,7 @@ from packit.utils.changelog_helper import ChangelogHelper
 logger = logging.getLogger(__name__)
 
 
-@click.command("copr", context_settings=get_context_settings())
+@click.command("in-copr", context_settings=get_context_settings())
 @click.option("--nowait", is_flag=True, default=False, help="Don't wait for build")
 @click.option(
     "--owner",

--- a/packit/cli/builds/copr_build.py
+++ b/packit/cli/builds/copr_build.py
@@ -1,5 +1,6 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
+
 import logging
 import os
 from typing import Optional, List
@@ -16,7 +17,7 @@ from packit.utils.changelog_helper import ChangelogHelper
 logger = logging.getLogger(__name__)
 
 
-@click.command("copr-build", context_settings=get_context_settings())
+@click.command("copr", context_settings=get_context_settings())
 @click.option("--nowait", is_flag=True, default=False, help="Don't wait for build")
 @click.option(
     "--owner",
@@ -101,7 +102,7 @@ logger = logging.getLogger(__name__)
 @click.argument("path_or_url", type=LocalProjectParameter(), default=os.path.curdir)
 @pass_config
 @cover_packit_exception
-def copr_build(
+def copr(
     config,
     nowait,
     owner,
@@ -178,6 +179,7 @@ def copr_build(
         request_admin_if_needed=request_admin_if_needed,
         enable_net=enable_net,
         release_suffix=release_suffix,
+        srpm_path=config.srpm_path,
     )
     click.echo(f"Build id: {build_id}, repo url: {repo_url}")
     if not nowait:

--- a/packit/cli/builds/koji_build.py
+++ b/packit/cli/builds/koji_build.py
@@ -17,7 +17,7 @@ from packit.utils.changelog_helper import ChangelogHelper
 logger = logging.getLogger(__name__)
 
 
-@click.command("koji", context_settings=get_context_settings())
+@click.command("in-koji", context_settings=get_context_settings())
 @click.option(
     "--dist-git-branch",
     help="Comma separated list of target branches in dist-git to release into. "

--- a/packit/cli/builds/koji_build.py
+++ b/packit/cli/builds/koji_build.py
@@ -1,0 +1,133 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+from os import getcwd
+
+import click
+
+from packit.cli.types import LocalProjectParameter
+from packit.cli.utils import cover_packit_exception, get_packit_api
+from packit.config import pass_config, get_context_settings
+from packit.config.aliases import get_branches, get_koji_targets
+from packit.exceptions import PackitCommandFailedError, ensure_str
+from packit.exceptions import PackitConfigException
+from packit.utils.changelog_helper import ChangelogHelper
+
+logger = logging.getLogger(__name__)
+
+
+@click.command("koji", context_settings=get_context_settings())
+@click.option(
+    "--dist-git-branch",
+    help="Comma separated list of target branches in dist-git to release into. "
+    "(defaults to repo's default branch)",
+)
+@click.option(
+    "--dist-git-path",
+    help="Path to dist-git repo to work in. "
+    "Otherwise clone the repo in a temporary directory.",
+)
+@click.option(
+    "--from-upstream",
+    help="Build the project in koji directly from the upstream repository",
+    is_flag=True,
+    default=False,
+)
+@click.option(
+    "--koji-target", help="Koji target to build inside (see `koji list-targets`)."
+)
+@click.option(
+    "--scratch", is_flag=True, default=False, help="Submit a scratch koji build"
+)
+@click.option("--nowait", is_flag=True, default=False, help="Don't wait on build")
+@click.option(
+    "--release-suffix",
+    default=None,
+    type=click.STRING,
+    help="Specifies release suffix. Allows to override default generated:"
+    "{current_time}.{sanitized_current_branch}{git_desc_suffix}",
+)
+@click.option(
+    "--default-release-suffix",
+    default=False,
+    is_flag=True,
+    help=(
+        "Allows to use default, packit-generated, release suffix when some "
+        "release_suffix is specified in the configuration."
+    ),
+)
+@click.argument("path_or_url", type=LocalProjectParameter(), default=getcwd())
+@pass_config
+@cover_packit_exception
+def koji(
+    config,
+    dist_git_path,
+    dist_git_branch,
+    from_upstream,
+    koji_target,
+    scratch,
+    nowait,
+    release_suffix,
+    default_release_suffix,
+    path_or_url,
+):
+    """
+    Build selected upstream project in Fedora.
+
+    By default, packit checks out the respective dist-git repository and performs
+    `fedpkg build` for the selected branch. With `--from-upstream`, packit creates a SRPM
+    out of the current checkout and sends it to koji.
+
+    PATH_OR_URL argument is a local path or a URL to the upstream git repository,
+    it defaults to the current working directory
+    """
+    api = get_packit_api(
+        config=config, dist_git_path=dist_git_path, local_project=path_or_url
+    )
+    release_suffix = ChangelogHelper.resolve_release_suffix(
+        api.package_config, release_suffix, default_release_suffix
+    )
+
+    default_dg_branch = api.dg.local_project.git_project.default_branch
+    dist_git_branch = dist_git_branch or default_dg_branch
+    branches_to_build = get_branches(
+        *dist_git_branch.split(","), default_dg_branch=default_dg_branch
+    )
+    click.echo(f"Building from the following branches: {', '.join(branches_to_build)}")
+
+    if koji_target is None:
+        targets_to_build = {None}
+    else:
+        targets_to_build = get_koji_targets(koji_target)
+
+    if len(targets_to_build) > 1 and len(branches_to_build) > 1:
+        raise PackitConfigException(
+            "Parameters --dist-git-branch and --koji-target cannot have "
+            "multiple values at the same time."
+        )
+
+    for target in targets_to_build:
+        for branch in branches_to_build:
+            try:
+                out = api.build(
+                    dist_git_branch=branch,
+                    scratch=scratch,
+                    nowait=nowait,
+                    koji_target=target,
+                    from_upstream=from_upstream,
+                    release_suffix=release_suffix,
+                    srpm_path=config.srpm_path,
+                )
+            except PackitCommandFailedError as ex:
+                logs_stdout = "\n>>> ".join(ex.stdout_output.strip().split("\n"))
+                logs_stderr = "\n!!! ".join(ex.stderr_output.strip().split("\n"))
+                click.echo(
+                    f"Build for branch '{branch}' failed. \n"
+                    f">>> {logs_stdout}\n"
+                    f"!!! {logs_stderr}\n",
+                    err=True,
+                )
+            else:
+                if out:
+                    print(ensure_str(out))

--- a/packit/cli/builds/local_build.py
+++ b/packit/cli/builds/local_build.py
@@ -14,7 +14,7 @@ from packit.utils.changelog_helper import ChangelogHelper
 logger = logging.getLogger("packit")
 
 
-@click.command("local", context_settings=get_context_settings())
+@click.command("locally", context_settings=get_context_settings())
 @click.option(
     "--upstream-ref",
     default=None,

--- a/packit/cli/builds/local_build.py
+++ b/packit/cli/builds/local_build.py
@@ -14,7 +14,7 @@ from packit.utils.changelog_helper import ChangelogHelper
 logger = logging.getLogger("packit")
 
 
-@click.command("local-build", context_settings=get_context_settings())
+@click.command("local", context_settings=get_context_settings())
 @click.option(
     "--upstream-ref",
     default=None,
@@ -45,9 +45,7 @@ logger = logging.getLogger("packit")
 )
 @pass_config
 @cover_packit_exception
-def local_build(
-    config, upstream_ref, release_suffix, default_release_suffix, path_or_url
-):
+def local(config, upstream_ref, release_suffix, default_release_suffix, path_or_url):
     """
     Create RPMs using content of the upstream repository.
 
@@ -60,7 +58,9 @@ def local_build(
     )
 
     rpm_paths = api.create_rpms(
-        upstream_ref=upstream_ref, release_suffix=release_suffix
+        upstream_ref=upstream_ref,
+        release_suffix=release_suffix,
+        # srpm_path=config.srpm_path,
     )
     logger.info("RPMs:")
     for path in rpm_paths:

--- a/packit/cli/packit_base.py
+++ b/packit/cli/packit_base.py
@@ -7,10 +7,8 @@ import click
 from pkg_resources import get_distribution
 
 from packit.cli.build import build
-from packit.cli.copr_build import copr_build
 from packit.cli.create_update import create_update
 from packit.cli.init import init
-from packit.cli.local_build import local_build
 from packit.cli.push_updates import push_updates
 from packit.cli.srpm import srpm
 from packit.cli.status import status
@@ -91,13 +89,11 @@ def packit_base(ctx, debug, fas_user, keytab, remote, package_config_path):
 packit_base.add_command(propose_downstream)
 packit_base.add_command(sync_from_downstream)
 packit_base.add_command(build)
-packit_base.add_command(copr_build)
 packit_base.add_command(create_update)
 packit_base.add_command(push_updates)
 packit_base.add_command(srpm)
 packit_base.add_command(status)
 packit_base.add_command(init)
-packit_base.add_command(local_build)
 packit_base.add_command(validate_config)
 packit_base.add_command(source_git)
 packit_base.add_command(prepare_sources)

--- a/tests/functional/test_local_build.py
+++ b/tests/functional/test_local_build.py
@@ -15,7 +15,7 @@ from tests.functional.spellbook import call_real_packit
 
 def test_rpm_command(ogr_distgit_and_remote):
     call_real_packit(
-        parameters=["--debug", "build", "local"], cwd=ogr_distgit_and_remote[0]
+        parameters=["--debug", "build", "locally"], cwd=ogr_distgit_and_remote[0]
     )
     rpm_paths = ogr_distgit_and_remote[0].glob("noarch/*.rpm")
 
@@ -24,7 +24,7 @@ def test_rpm_command(ogr_distgit_and_remote):
 
 def test_local_build_with_remote_good(ogr_distgit_and_remote):
     call_real_packit(
-        parameters=["--debug", "--remote", "origin", "build", "local"],
+        parameters=["--debug", "--remote", "origin", "build", "locally"],
         cwd=ogr_distgit_and_remote[0],
     )
     rpm_paths = ogr_distgit_and_remote[0].glob("noarch/*.rpm")
@@ -35,7 +35,7 @@ def test_local_build_with_remote_good(ogr_distgit_and_remote):
 def test_local_build_with_remote_bad(ogr_distgit_and_remote):
     with pytest.raises(CalledProcessError) as ex:
         call_real_packit(
-            parameters=["--debug", "--remote", "burcak", "build", "local"],
+            parameters=["--debug", "--remote", "burcak", "build", "locally"],
             cwd=ogr_distgit_and_remote[0],
             return_output=True,
         )
@@ -48,7 +48,7 @@ def test_local_build_with_remote_bad(ogr_distgit_and_remote):
 )
 def test_rpm_command_for_path(ogr_distgit_and_remote):
     call_real_packit(
-        parameters=["--debug", "build", "local", str(ogr_distgit_and_remote[0])]
+        parameters=["--debug", "build", "locally", str(ogr_distgit_and_remote[0])]
     )
     rpm_paths = Path.cwd().glob("noarch/*.rpm")
     assert all(rpm_path.exists() for rpm_path in rpm_paths)

--- a/tests/functional/test_local_build.py
+++ b/tests/functional/test_local_build.py
@@ -15,7 +15,7 @@ from tests.functional.spellbook import call_real_packit
 
 def test_rpm_command(ogr_distgit_and_remote):
     call_real_packit(
-        parameters=["--debug", "local-build"], cwd=ogr_distgit_and_remote[0]
+        parameters=["--debug", "build", "local"], cwd=ogr_distgit_and_remote[0]
     )
     rpm_paths = ogr_distgit_and_remote[0].glob("noarch/*.rpm")
 
@@ -24,7 +24,7 @@ def test_rpm_command(ogr_distgit_and_remote):
 
 def test_local_build_with_remote_good(ogr_distgit_and_remote):
     call_real_packit(
-        parameters=["--debug", "--remote", "origin", "local-build"],
+        parameters=["--debug", "--remote", "origin", "build", "local"],
         cwd=ogr_distgit_and_remote[0],
     )
     rpm_paths = ogr_distgit_and_remote[0].glob("noarch/*.rpm")
@@ -35,7 +35,7 @@ def test_local_build_with_remote_good(ogr_distgit_and_remote):
 def test_local_build_with_remote_bad(ogr_distgit_and_remote):
     with pytest.raises(CalledProcessError) as ex:
         call_real_packit(
-            parameters=["--debug", "--remote", "burcak", "local-build"],
+            parameters=["--debug", "--remote", "burcak", "build", "local"],
             cwd=ogr_distgit_and_remote[0],
             return_output=True,
         )
@@ -48,7 +48,7 @@ def test_local_build_with_remote_bad(ogr_distgit_and_remote):
 )
 def test_rpm_command_for_path(ogr_distgit_and_remote):
     call_real_packit(
-        parameters=["--debug", "local-build", str(ogr_distgit_and_remote[0])]
+        parameters=["--debug", "build", "local", str(ogr_distgit_and_remote[0])]
     )
     rpm_paths = Path.cwd().glob("noarch/*.rpm")
     assert all(rpm_path.exists() for rpm_path in rpm_paths)

--- a/tests/integration/test_copr_build.py
+++ b/tests/integration/test_copr_build.py
@@ -578,7 +578,7 @@ def test_copr_build_cli_no_project_configured(upstream_and_remote, copr_client_m
     ).and_return(copr_client_mock)
     CoprHelper.get_available_chroots.cache_clear()
 
-    run_packit(["build", "copr", "--nowait"], working_dir=upstream)
+    run_packit(["build", "in-copr", "--nowait"], working_dir=upstream)
 
 
 def test_copr_build_cli_project_set_via_cli(upstream_and_remote, copr_client_mock):
@@ -605,7 +605,8 @@ def test_copr_build_cli_project_set_via_cli(upstream_and_remote, copr_client_moc
     CoprHelper.get_available_chroots.cache_clear()
 
     run_packit(
-        ["build", "copr", "--nowait", "--project", "the-project"], working_dir=upstream
+        ["build", "in-copr", "--nowait", "--project", "the-project"],
+        working_dir=upstream,
     )
 
 
@@ -636,7 +637,7 @@ def test_copr_build_cli_project_set_from_config(upstream_and_remote, copr_client
         srpm_path=None,
     ).and_return(("id", "url")).once()
 
-    run_packit(["build", "copr", "--nowait"], working_dir=upstream)
+    run_packit(["build", "in-copr", "--nowait"], working_dir=upstream)
 
 
 def test_create_copr_project(copr_client_mock):

--- a/tests/integration/test_copr_build.py
+++ b/tests/integration/test_copr_build.py
@@ -570,6 +570,7 @@ def test_copr_build_cli_no_project_configured(upstream_and_remote, copr_client_m
         request_admin_if_needed=False,
         enable_net=True,
         release_suffix=None,
+        srpm_path=None,
     ).and_return(("id", "url")).once()
 
     flexmock(packit.copr_helper.CoprClient).should_receive(
@@ -577,7 +578,7 @@ def test_copr_build_cli_no_project_configured(upstream_and_remote, copr_client_m
     ).and_return(copr_client_mock)
     CoprHelper.get_available_chroots.cache_clear()
 
-    run_packit(["copr-build", "--nowait"], working_dir=upstream)
+    run_packit(["build", "copr", "--nowait"], working_dir=upstream)
 
 
 def test_copr_build_cli_project_set_via_cli(upstream_and_remote, copr_client_mock):
@@ -595,6 +596,7 @@ def test_copr_build_cli_project_set_via_cli(upstream_and_remote, copr_client_moc
         request_admin_if_needed=False,
         enable_net=True,
         release_suffix=None,
+        srpm_path=None,
     ).and_return(("id", "url")).once()
 
     flexmock(packit.copr_helper.CoprClient).should_receive(
@@ -603,7 +605,7 @@ def test_copr_build_cli_project_set_via_cli(upstream_and_remote, copr_client_moc
     CoprHelper.get_available_chroots.cache_clear()
 
     run_packit(
-        ["copr-build", "--nowait", "--project", "the-project"], working_dir=upstream
+        ["build", "copr", "--nowait", "--project", "the-project"], working_dir=upstream
     )
 
 
@@ -631,9 +633,10 @@ def test_copr_build_cli_project_set_from_config(upstream_and_remote, copr_client
         request_admin_if_needed=False,
         enable_net=True,
         release_suffix=None,
+        srpm_path=None,
     ).and_return(("id", "url")).once()
 
-    run_packit(["copr-build", "--nowait"], working_dir=upstream)
+    run_packit(["build", "copr", "--nowait"], working_dir=upstream)
 
 
 def test_create_copr_project(copr_client_mock):


### PR DESCRIPTION
TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.

RELEASE NOTES BEGIN

RPM build commands of Packit CLI have been merged into one `build` subcommand, for more information see the updated documentation at https://packit.dev/docs/cli/build/. We have also introduced a new `--srpm` option to the new `build` subcommand that can be used to trigger local, Copr or Koji build from an already built SRPM rather than implicitly created one by Packit.

RELEASE NOTES END
