### PR TITLE
Use Koji instead of Bodhi to get the tag latest build

### DIFF
--- a/packit/constants.py
+++ b/packit/constants.py
@@ -159,3 +159,5 @@ REPO_NOT_PRISTINE_HINT = (
     "Use 'git reset --hard HEAD' to reset changed files and "
     "'git clean -xdff' to delete untracked files and directories."
 )
+
+KOJI_BASEURL = "https://koji.fedoraproject.org/kojihub"

--- a/packit/status.py
+++ b/packit/status.py
@@ -15,6 +15,7 @@ from packit.distgit import DistGit
 from packit.exceptions import PackitException
 from packit.upstream import Upstream
 from packit.utils.bodhi import get_bodhi_client
+from packit.constants import KOJI_BASEURL
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +106,7 @@ class Status:
         """
         Get latest koji builds as a dict of branch: latest build in that branch.
         """
-        session = ClientSession(baseurl="https://koji.fedoraproject.org/kojihub")
+        session = ClientSession(baseurl=KOJI_BASEURL)
         package_id = session.getPackageID(
             self.dg.package_config.downstream_package_name
         )


### PR DESCRIPTION
Fixes packit#1475

RELEASE NOTES BEGIN

Creation of a Bodhi update will no more timeout.

RELEASE NOTES END
