### PR TITLE
Add packit to allowed_pr_authors for Koji builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -88,7 +88,7 @@ jobs:
   - job: koji_build
     trigger: commit
     packit_instances: ["stg"]
-    allowed_pr_authors: ["packit-stg"]
+    allowed_pr_authors: ["packit-stg", "packit"]
     dist_git_branches:
       - fedora-all
       - epel-8


### PR DESCRIPTION
We run propose-downstream for both prod and stg, so this way we can merge any of the created PRs.

RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
