### PR TITLE
Add extra parameters to the JobConfig

### DIFF
--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -65,6 +65,7 @@ class CommonPackageConfig:
                         will run koji builds
         allowed_committers: list of Fedora accounts for which distgit pushes we
                         will run koji builds
+        tf_post_install_script: post install script to run before the tf tests
     """
 
     def __init__(
@@ -119,6 +120,7 @@ class CommonPackageConfig:
         enable_net: bool = True,
         allowed_pr_authors: Optional[List[str]] = None,
         allowed_committers: Optional[List[str]] = None,
+        tf_post_install_script: Optional[str] = None,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -203,6 +205,7 @@ class CommonPackageConfig:
             allowed_pr_authors if allowed_pr_authors is not None else ["packit"]
         )
         self.allowed_committers = allowed_committers or []
+        self.tf_post_install_script = tf_post_install_script
 
     @property
     def targets_dict(self):
@@ -295,7 +298,8 @@ class CommonPackageConfig:
             f"env={self.env},"
             f"enable_net={self.enable_net},"
             f"allowed_pr_authors={self.allowed_pr_authors},"
-            f"allowed_committers={self.allowed_committers})"
+            f"allowed_committers={self.allowed_commiters},"
+            f"tf_post_install_script='{self.tf_post_install_script}')"
         )
 
     @property

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -299,7 +299,7 @@ class CommonPackageConfig:
             f"enable_net={self.enable_net},"
             f"allowed_pr_authors={self.allowed_pr_authors},"
             f"allowed_committers={self.allowed_commiters},"
-            f"tf_post_install_script='{self.tf_post_install_script}')"
+            f"tf_post_install_script='''{self.tf_post_install_script}''')"
         )
 
     @property

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -98,7 +98,7 @@ class JobConfig(CommonPackageConfig):
         enable_net: bool = True,
         allowed_pr_authors: Optional[List[str]] = None,
         allowed_committers: Optional[List[str]] = None,
-        tmt_plan_regex: Optional[str] = None,
+        tmt_plan: Optional[str] = None,
         tf_post_install_script: Optional[str] = None,
     ):
         super().__init__(
@@ -156,7 +156,7 @@ class JobConfig(CommonPackageConfig):
         )
         self.type: JobType = type
         self.trigger: JobConfigTriggerType = trigger
-        self.tmt_plan_regex: str = tmt_plan_regex
+        self.tmt_plan: str = tmt_plan
 
     def __repr__(self):
         return (
@@ -208,8 +208,8 @@ class JobConfig(CommonPackageConfig):
             f"enable_net={self.enable_net},"
             f"allowed_pr_authors={self.allowed_pr_authors},"
             f"allowed_committers={self.allowed_committers},"
-            f"tmt_plan_regex={self.tmt_plan_regex},"
-            f"tf_post_install_script={self.tf_post_install_script})"
+            f"tmt_plan='{self.tmt_plan}',"
+            f"tf_post_install_script='''{self.tf_post_install_script}''')"
         )
 
     @classmethod
@@ -269,7 +269,7 @@ class JobConfig(CommonPackageConfig):
             and self.skip_build == other.skip_build
             and self.env == other.env
             and self.enable_net == other.enable_net
-            and self.tmt_plan_regex == other.tmt_plan_regex
+            and self.tmt_plan == other.tmt_plan
             and self.tf_post_install_script == other.tf_post_install_script
         )
 

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -98,6 +98,8 @@ class JobConfig(CommonPackageConfig):
         enable_net: bool = True,
         allowed_pr_authors: Optional[List[str]] = None,
         allowed_committers: Optional[List[str]] = None,
+        tmt_plan_regex: Optional[str] = None,
+        tf_post_install_script: Optional[str] = None,
     ):
         super().__init__(
             config_file_path=config_file_path,
@@ -150,9 +152,11 @@ class JobConfig(CommonPackageConfig):
             enable_net=enable_net,
             allowed_pr_authors=allowed_pr_authors,
             allowed_committers=allowed_committers,
+            tf_post_install_script=tf_post_install_script,
         )
         self.type: JobType = type
         self.trigger: JobConfigTriggerType = trigger
+        self.tmt_plan_regex: str = tmt_plan_regex
 
     def __repr__(self):
         return (
@@ -203,7 +207,9 @@ class JobConfig(CommonPackageConfig):
             f"env={self.env},"
             f"enable_net={self.enable_net},"
             f"allowed_pr_authors={self.allowed_pr_authors},"
-            f"allowed_commiters={self.allowed_committers})"
+            f"allowed_committers={self.allowed_committers},"
+            f"tmt_plan_regex={self.tmt_plan_regex},"
+            f"tf_post_install_script={self.tf_post_install_script})"
         )
 
     @classmethod
@@ -263,6 +269,8 @@ class JobConfig(CommonPackageConfig):
             and self.skip_build == other.skip_build
             and self.env == other.env
             and self.enable_net == other.enable_net
+            and self.tmt_plan_regex == other.tmt_plan_regex
+            and self.tf_post_install_script == other.tf_post_install_script
         )
 
 

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -388,7 +388,7 @@ class JobConfigSchema(CommonConfigSchema):
     enable_net = fields.Boolean(missing=True)
     allowed_pr_authors = fields.List(fields.String(), missing=None)
     allowed_committers = fields.List(fields.String(), missing=None)
-    tmt_plan_regex = fields.String(missing=None)
+    tmt_plan = fields.String(missing=None)
     tf_post_install_script = fields.String(missing=None)
 
     metadata = fields.Nested(JobMetadataSchema)

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -388,6 +388,8 @@ class JobConfigSchema(CommonConfigSchema):
     enable_net = fields.Boolean(missing=True)
     allowed_pr_authors = fields.List(fields.String(), missing=None)
     allowed_committers = fields.List(fields.String(), missing=None)
+    tmt_plan_regex = fields.String(missing=None)
+    tf_post_install_script = fields.String(missing=None)
 
     metadata = fields.Nested(JobMetadataSchema)
 

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -857,7 +857,7 @@ def test_package_config_parse_error(raw):
                     {
                         "job": "copr_build",
                         "trigger": "release",
-                        "tmt_plan_regex": "^packit!",
+                        "tmt_plan": "^packit!",
                         "tf_post_install_script": "echo 'hi packit!'",
                     },
                 ],
@@ -870,7 +870,7 @@ def test_package_config_parse_error(raw):
                         type=JobType.copr_build,
                         specfile_path="fedora/package.spec",
                         trigger=JobConfigTriggerType.release,
-                        tmt_plan_regex="^packit!",
+                        tmt_plan="^packit!",
                         tf_post_install_script="echo 'hi packit!'",
                     ),
                 ],

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -850,6 +850,33 @@ def test_package_config_parse_error(raw):
             ),
             id="sync_changelog_false_by_default",
         ),
+        pytest.param(
+            {
+                "specfile_path": "fedora/package.spec",
+                "jobs": [
+                    {
+                        "job": "copr_build",
+                        "trigger": "release",
+                        "tmt_plan_regex": "^packit!",
+                        "tf_post_install_script": "echo 'hi packit!'",
+                    },
+                ],
+            },
+            PackageConfig(
+                specfile_path="fedora/package.spec",
+                sync_changelog=False,
+                jobs=[
+                    JobConfig(
+                        type=JobType.copr_build,
+                        specfile_path="fedora/package.spec",
+                        trigger=JobConfigTriggerType.release,
+                        tmt_plan_regex="^packit!",
+                        tf_post_install_script="echo 'hi packit!'",
+                    ),
+                ],
+            ),
+            id="extra_tf_api_parameters",
+        ),
     ],
 )
 def test_package_config_parse(raw, expected):

--- a/tests/unit/test_prepare_sources.py
+++ b/tests/unit/test_prepare_sources.py
@@ -57,7 +57,7 @@ from packit.config import JobConfig, JobType, JobConfigTriggerType
                 "trigger": "release",
                 "spec_source_id": "Source0",
                 "allowed_gpg_keys": null,
-                "tmt_plan_regex": null,
+                "tmt_plan": null,
                 "tf_post_install_script": null
             }
             """,

--- a/tests/unit/test_prepare_sources.py
+++ b/tests/unit/test_prepare_sources.py
@@ -11,21 +11,56 @@ from packit.config import JobConfig, JobType, JobConfigTriggerType
     "raw_job_config,expected",
     [
         pytest.param(
-            '{"upstream_package_name": null, "downstream_package_name": null, '
-            '"archive_root_dir_template": "{upstream_pkg_name}-{version}", '
-            '"patch_generation_ignore_paths": [], "dist_git_namespace": "rpms", "actions": {}, '
-            '"upstream_project_url": null, "sources": [], "create_pr": true, "merge_pr_in_ci": '
-            'true, "job": "copr_build", "upstream_ref": null, "upstream_tag_template": '
-            '"{version}", "config_file_path": null, "synced_files": [], "sync_changelog": false,'
-            ' "patch_generation_patch_id_digits": 4, "preserve_project": false, '
-            '"branch": null, "additional_repos": [], "env": {}, "additional_packages": [], '
-            '"skip_build": false, "scratch": false, "targets": {}, "fmf_url": null, "fmf_ref":'
-            ' null, "owner": null, "use_internal_tf": false, "list_on_homepage": false, '
-            '"project": "example1", "dist_git_branches": [], "timeout": 7200, '
-            '"notifications": {"pull_request": {"successful_build": false}}, '
-            '"copy_upstream_release_description": false, "specfile_path": null, '
-            '"dist_git_base_url": "https://src.fedoraproject.org/", "trigger": "release", '
-            '"spec_source_id": "Source0", "allowed_gpg_keys": null}',
+            """\
+            {
+                "upstream_package_name": null,
+                "downstream_package_name": null,
+                "archive_root_dir_template": "{upstream_pkg_name}-{version}",
+                "patch_generation_ignore_paths": [],
+                "dist_git_namespace": "rpms",
+                "actions": {},
+                "upstream_project_url": null,
+                "sources": [],
+                "create_pr": true,
+                "merge_pr_in_ci": true,
+                "job": "copr_build",
+                "upstream_ref": null,
+                "upstream_tag_template": "{version}",
+                "config_file_path": null,
+                "synced_files": [],
+                "sync_changelog": false,
+                "patch_generation_patch_id_digits": 4,
+                "preserve_project": false,
+                "branch": null,
+                "additional_repos": [],
+                "env": {},
+                "additional_packages": [],
+                "skip_build": false,
+                "scratch": false,
+                "targets": {},
+                "fmf_url": null,
+                "fmf_ref": null,
+                "owner": null,
+                "use_internal_tf": false,
+                "list_on_homepage": false,
+                "project": "example1",
+                "dist_git_branches": [],
+                "timeout": 7200,
+                "notifications": {
+                    "pull_request": {
+                        "successful_build": false
+                    }
+                },
+                "copy_upstream_release_description": false,
+                "specfile_path": null,
+                "dist_git_base_url": "https://src.fedoraproject.org/",
+                "trigger": "release",
+                "spec_source_id": "Source0",
+                "allowed_gpg_keys": null,
+                "tmt_plan_regex": null,
+                "tf_post_install_script": null
+            }
+            """,
             JobConfig(
                 type=JobType.copr_build,
                 trigger=JobConfigTriggerType.release,


### PR DESCRIPTION
Adding some extra parameters to the JobConfig to be submitted to the TF API.

The parameters are:
* tmt_plan_regex: Specify a regex to run only a specific set of tests.
* tf_post_install_script: Specify bash commands to run in TF after
  installation.

Fixes #1600 

Signed-off-by: Rodolfo Olivieri <rolivier@redhat.com>

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->
I changed the way the json is represented in one of the unit_tests, let me know if it's okay to be in that way (looks nicer now). If not, I can change it back! 