### PR TITLE
Add missing python-fedora dependency

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -30,6 +30,7 @@ BuildRequires:  python3dist(setuptools-scm)
 BuildRequires:  python3dist(setuptools-scm-git-archive)
 BuildRequires:  python3-bodhi-client < 6.0
 BuildRequires:  python3-cachetools
+BuildRequires:  python3-fedora
 %if 0%{?rhel}
 # epel-8 requires typing-extensions due to old python version
 BuildRequires:  python3-typing-extensions

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ install_requires =
     bodhi-client < 6.0
     koji
     cachetools
+    python-fedora
     typing-extensions;python_version<"3.8"
 python_requires = >=3.6
 include_package_data = True


### PR DESCRIPTION
`bodhi-client` no longer depends on `python-fedora`, so it is necessary to declare the dependency explicitly.