### PR TITLE
allow having custom archives in root while specfile is in a subdirectory

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -1103,7 +1103,12 @@ class Archive:
 
         if archive_path.parent.absolute() != absolute_specfile_dir:
             archive_in_spec_dir = absolute_specfile_dir / archive_path.name
-            relative_archive_path = archive_path.relative_to(absolute_specfile_dir)
+
+            # [PurePath.relative_to()](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.relative_to)
+            # requires self to be the subpath of the argument, but
+            # [os.path.relpath()](https://docs.python.org/3/library/os.path.html#os.path.relpath)
+            # does not.
+            relative_archive_path = os.path.relpath(archive_path, absolute_specfile_dir)
 
             logger.info(
                 "Linking to the specfile directory:"


### PR DESCRIPTION
TODO:

- [x] Write new tests or update the old ones to cover new functionality.


    `Path.relative_to` can raise `ValueError` when `specfile_dir` is in a
    subdir and archive path is in the project's root. This commit uses
    `os.path.relpath` instead that supports having the source path in a
    subdir. It's a different implementation than `.relative_to`.


Fixes: https://github.com/packit/packit/issues/1621


RELEASE NOTES BEGIN

Packit now correctly handles creation of custom archives in root while a specfile is in a subdirectory.

RELEASE NOTES END