### PR TITLE
Return existing PR from sync_release

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -30,6 +30,10 @@ BuildRequires:  python3dist(setuptools-scm)
 BuildRequires:  python3dist(setuptools-scm-git-archive)
 BuildRequires:  python3-bodhi-client
 BuildRequires:  python3-cachetools
+%if 0%{?rhel}
+# epel-8 requires typing-extensions due to old python version
+BuildRequires:  python3-typing-extensions
+%endif
 Requires:       python3-%{real_name} = %{version}-%{release}
 
 %description

--- a/packit/api.py
+++ b/packit/api.py
@@ -26,8 +26,13 @@ from typing import (
     Optional,
     Union,
     overload,
-    Literal,
 )
+
+# Literal is available only since Python3.8, workaround for el8
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 import git
 from git.exc import GitCommandError

--- a/packit/api.py
+++ b/packit/api.py
@@ -16,7 +16,18 @@ import re
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Sequence, Callable, List, Tuple, Dict, Iterable, Optional, Union
+from typing import (
+    Sequence,
+    Callable,
+    List,
+    Tuple,
+    Dict,
+    Iterable,
+    Optional,
+    Union,
+    overload,
+    Literal,
+)
 
 import git
 from git.exc import GitCommandError
@@ -622,6 +633,48 @@ The first dist-git commit to be synced is '{short_hash}'.
         else:
             return f"'{source_git}' is up to date with '{dist_git}'."
 
+    @overload
+    def sync_release(
+        self,
+        dist_git_branch: Optional[str] = None,
+        version: Optional[str] = None,
+        tag: Optional[str] = None,
+        use_local_content=False,
+        add_new_sources=True,
+        force_new_sources=False,
+        upstream_ref: Optional[str] = None,
+        create_pr: Literal[True] = True,
+        force: bool = False,
+        create_sync_note: bool = True,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        sync_default_files: bool = True,
+        local_pr_branch_suffix: str = "update",
+        mark_commit_origin: bool = False,
+    ) -> PullRequest:
+        """Overload for type-checking; return PullRequest if create_pr=True."""
+
+    @overload
+    def sync_release(
+        self,
+        dist_git_branch: Optional[str] = None,
+        version: Optional[str] = None,
+        tag: Optional[str] = None,
+        use_local_content=False,
+        add_new_sources=True,
+        force_new_sources=False,
+        upstream_ref: Optional[str] = None,
+        create_pr: Literal[False] = False,
+        force: bool = False,
+        create_sync_note: bool = True,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        sync_default_files: bool = True,
+        local_pr_branch_suffix: str = "update",
+        mark_commit_origin: bool = False,
+    ) -> None:
+        """Overload for type-checking; return None if create_pr=False."""
+
     def sync_release(
         self,
         dist_git_branch: Optional[str] = None,
@@ -667,7 +720,8 @@ The first dist-git commit to be synced is '{short_hash}'.
                 commit message to mark the hash of the upstream (source-git) commit.
 
         Returns:
-            The created PullRequest if create_pr is True, else None.
+            The created (or existing if one already exists) PullRequest if
+            create_pr is True, else None.
 
         Raises:
             PackitException, if both 'version' and 'tag' are provided.
@@ -774,21 +828,19 @@ The first dist-git commit to be synced is '{short_hash}'.
                 check_dist_git_pristine=False,
             )
 
-            new_pr = None
+            pr = None
             if create_pr:
                 title = title or f"Update to upstream release {version}"
 
-                existing_pr = self.dg.existing_pr(
-                    title, description.rstrip(), dist_git_branch
-                )
-                if not existing_pr:
-                    new_pr = self.push_and_create_pr(
+                pr = self.dg.existing_pr(title, description.rstrip(), dist_git_branch)
+                if not pr:
+                    pr = self.push_and_create_pr(
                         pr_title=title,
                         pr_description=description,
                         dist_git_branch=dist_git_branch,
                     )
                 else:
-                    logger.debug(f"PR already exists: {existing_pr.url}")
+                    logger.debug(f"PR already exists: {pr.url}")
             else:
                 self.dg.push(refspec=f"HEAD:{dist_git_branch}")
         finally:
@@ -796,7 +848,7 @@ The first dist-git commit to be synced is '{short_hash}'.
                 self.up.local_project.git_repo.git.checkout(current_up_branch)
             self.dg.refresh_specfile()
             self.dg.local_project.git_repo.git.reset("--hard", "HEAD")
-        return new_pr
+        return pr
 
     def _prepare_files_to_sync(
         self, synced_files: List[SyncFilesItem], full_version: str, upstream_tag: str

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ install_requires =
     bodhi-client
     koji
     cachetools
+    typing-extensions
 python_requires = >=3.6
 include_package_data = True
 setup_requires =


### PR DESCRIPTION
This makes the implementation consistent with the docstring meaning that
a PR is returned if create_pr=True. The usage of such implementation is
easier in a sense that if create_pr is set to True and no exception was
raised, the caller can expect a valid PR to be returned which was not
the case previously and lead to surprising tracebacks.

Also make the typing stricter by using overloads for the literal
create_pr values.

Signed-off-by: František Nečas <fnecas@redhat.com>

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`. (not relevant)

Fixes https://github.com/packit/packit-service/issues/1504

 (lets see if github can close issues in another repo)