### PR TITLE
provide ref name when specfile cannot be found

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -850,6 +850,7 @@ The first dist-git commit to be synced is '{short_hash}'.
                 self.dg.push(refspec=f"HEAD:{dist_git_branch}")
         finally:
             if not use_local_content and not upstream_ref:
+                logger.info(f"Checking out the original branch {current_up_branch}.")
                 self.up.local_project.git_repo.git.checkout(current_up_branch)
             self.dg.refresh_specfile()
             self.dg.local_project.git_repo.git.reset("--hard", "HEAD")

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -91,7 +91,11 @@ class PackitRepositoryBase:
                 self.local_project.working_dir / self.package_config.specfile_path
             )
             if not self._specfile_path.exists():
-                raise FileNotFoundError(f"Specfile {self._specfile_path} not found.")
+                # since propose-downstream checks out a tag, we should inform user
+                # on which ref this has happened: https://github.com/packit/packit/issues/1625
+                raise FileNotFoundError(
+                    f"Specfile {self._specfile_path} not found on ref {self.local_project.ref}."
+                )
 
         return self._specfile_path
 


### PR DESCRIPTION
This is a simle UX change.

Helps with https://github.com/packit/packit/issues/1625

```
This also adds an info log line when Packit checks out the original
branch on which the user ran the command. If something wrong happens,
this should be the last log and could help the user diagnose the
problem.
```

RELEASE NOTES BEGIN

Git ref name that Packit works with during `propose-downstream` is now made more obvious in logs.

RELEASE NOTES END