### PR TITLE
Require typing-extensions only when Python < 3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     bodhi-client
     koji
     cachetools
-    typing-extensions
+    typing-extensions;python_version<"3.8"
 python_requires = >=3.6
 include_package_data = True
 setup_requires =


### PR DESCRIPTION
This makes sense as it's only used when Python < 3.8.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>
