### PR TITLE
packit-stable: use fedora-stable instead of fedora-all

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -69,7 +69,7 @@ jobs:
     trigger: commit
     branch: stable
     targets:
-      - fedora-all
+      - fedora-stable
       - epel-8
     project: packit-stable
     list_on_homepage: True


### PR DESCRIPTION
if any of the targets fail to build, the whole build fails

packit-stable is used in our SRPM build env