### PR TITLE
Declare dependency on fedora.client

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -11,6 +11,7 @@ URL:            https://github.com/packit/packit
 Source0:        %pypi_source
 BuildArch:      noarch
 BuildRequires:  python3-devel
+BuildRequires:  python3-fedora
 BuildRequires:  python3-click-man
 BuildRequires:  python3-GitPython
 BuildRequires:  python3-gnupg

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
     munch
     ogr
     packaging
+    python-fedora
     python-gnupg
     rebasehelper
     requests


### PR DESCRIPTION
    + python3 setup.py --command-packages=click_man.commands man_pages --target /builddir/build/BUILDROOT/packit-0.52.1-2.fc37.x86_64/usr/share/man/man1
    running man_pages
    Load entry point packit
    Traceback (most recent call last):
      File "/builddir/build/BUILD/packitos-0.52.1/setup.py", line 8, in <module>
        setup(use_scm_version=True)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/setuptools/__init__.py", line 155, in setup
        return distutils.core.setup(**attrs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 148, in setup
        return run_commands(dist)
               ^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 163, in run_commands
        dist.run_commands()
        ^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 967, in run_commands
        self.run_command(cmd)
        ^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 986, in run_command
        cmd_obj.run()
        ^^^^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/click_man/commands/man_pages.py", line 65, in run
        cli = entry_point.resolve()
              ^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/pkg_resources/__init__.py", line 2464, in resolve
        module = __import__(self.module_name, fromlist=['__name__'], level=0)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/builddir/build/BUILD/packitos-0.52.1/packit/cli/packit_base.py", line 9, in <module>
        from packit.cli.build import build
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/builddir/build/BUILD/packitos-0.52.1/packit/cli/build.py", line 10, in <module>
        from packit.cli.utils import cover_packit_exception, get_packit_api
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/builddir/build/BUILD/packitos-0.52.1/packit/cli/utils.py", line 18, in <module>
        from packit.api import PackitAPI
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/builddir/build/BUILD/packitos-0.52.1/packit/api.py", line 41, in <module>
        from packit.distgit import DistGit
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/builddir/build/BUILD/packitos-0.52.1/packit/distgit.py", line 14, in <module>
        from fedora.client import AuthError, LoginRequiredError
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ModuleNotFoundError: No module named 'fedora'

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

RELEASE NOTES BEGIN

Packit now declares a dependency on the python-fedora project because it uses the fedora Python module. This fixes failure to build from source in Fedora as well as possible failures on runtime.

RELEASE NOTES END
