### PR TITLE
bodhi: initialize auth before creating updates

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -468,6 +468,8 @@ class DistGit(PackitRepositoryBase):
             fas_password=self.config.fas_password,
             kerberos_realm=self.config.kerberos_realm,
         )
+        # make sure we have the credentials
+        bodhi_client.ensure_auth()
 
         if not koji_builds:
             koji_builds = [
@@ -496,7 +498,7 @@ class DistGit(PackitRepositoryBase):
                     f"Bodhi client raised a login error: {ex}. "
                     f"Let's clear the session, csrf token and retry."
                 )
-                bodhi_client.refresh_auth()
+                bodhi_client.ensure_auth()
                 result = bodhi_client.save(**save_kwargs)
 
             logger.debug(f"Bodhi response:\n{result}")

--- a/packit/utils/bodhi.py
+++ b/packit/utils/bodhi.py
@@ -77,7 +77,7 @@ class OurBodhiClient(BodhiClient):
                 retries=3,
             )
 
-    def refresh_auth(self):
+    def ensure_auth(self):
         """clear existing authentication data and obtain new"""
         if self.is_bodhi_6:
             self.clear_auth()
@@ -87,7 +87,7 @@ class OurBodhiClient(BodhiClient):
                 self.login_with_kerberos()
             else:
                 # terminal prompt
-                self.ensure_auth()
+                super().ensure_auth()
         else:
             self._session.cookies.clear()
             self.csrf_token = None


### PR DESCRIPTION
The problem is the code path for creating bodhi updates before this
commit would not go through the Kerberos route which meant it would
prompt in terminal - that doesn't work in a worker:

https://sentry.io/organizations/red-hat-0p/issues/3422419746/?referrer=github_integration

With this change, once we init the bodhi_client before creating updates, we
also make sure the auth is obtained using Kerberos.

Fixes #1650

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.

RELEASE NOTES BEGIN

Packit can now correctly create bodhi updates using the new Bodhi 6 client.

RELEASE NOTES END