### PR TITLE
Add tmt_plan and tf_post_install_script to schema

### DIFF
--- a/packit/schema.py
+++ b/packit/schema.py
@@ -240,6 +240,8 @@ class JobMetadataSchema(Schema):
     skip_build = fields.Boolean()
     env = fields.Dict(keys=fields.String(), missing=None)
     enable_net = fields.Boolean(missing=True)
+    tmt_plan = fields.String(missing=None)
+    tf_post_install_script = fields.String(missing=None)
 
     @pre_load
     def ordered_preprocess(self, data, **_):


### PR DESCRIPTION
These two options were missing from the Job schema, hence an error was
thrown when it was used in a config.

Fixes: https://github.com/teemtee/upgrade/pull/3#issuecomment-1191339590

RELEASE NOTES BEGIN

Packit now correctly supports `tmt_plan` and `tf_post_install_script` in the configuration.

RELEASE NOTES END
