### PR TITLE
Provide a better error message for bodhi#4660

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -492,6 +492,12 @@ class DistGit(PackitRepositoryBase):
             try:
                 result = bodhi_client.save(**save_kwargs)
             except BodhiClientException as ex:
+                if "Unauthorized: new_update__POST failed permission check" in str(ex):
+                    raise PackitException(
+                        "You are using Bodhi 6 client. There is an issue with creating "
+                        "updates using this version: "
+                        "https://github.com/fedora-infra/bodhi/issues/4660"
+                    )
                 logger.debug(
                     f"Bodhi client raised a login error: {ex}. "
                     f"Let's clear the session, csrf token and retry."


### PR DESCRIPTION
Fixes: https://github.com/packit/packit-service/issues/1587
Real issue: https://github.com/fedora-infra/bodhi/issues/4660

Luckily we don't need to change versions in requirements:
* In service we explicitly install bodhi 5: https://github.com/packit/packit-service/pull/1590
* For CLI users: Packit CLI can work with both Bodhi client versions, users need to downgrade manually

RELEASE NOTES BEGIN
Packit now provides a more helpful error message when it hits a known issue while creating a Bodhi update: https://github.com/fedora-infra/bodhi/issues/4660
RELEASE NOTES END