### PR TITLE
refactor!: search the repo for the specfile in PackageConfig

### DIFF
--- a/files/zuul-reverse-dep-packit-service.yaml
+++ b/files/zuul-reverse-dep-packit-service.yaml
@@ -12,3 +12,7 @@
       command: make check
       args:
         chdir: "{{ reverse_dir }}"
+      # Set 'COLOR' to no in the packit-service/Makefile to disable
+      # colored output in Zuul, in order to improve log readability.
+      environment:
+        COLOR: "no"

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -80,11 +80,6 @@ class PackageConfig(CommonPackageConfig):
 
         package_config = PackageConfigSchema().load(raw_dict)
 
-        if not package_config.specfile_path and not all(
-            job.type == JobType.tests and job.skip_build for job in package_config.jobs
-        ):
-            raise PackitConfigException("Spec file was not found!")
-
         return package_config
 
     def get_copr_build_project_value(self) -> Optional[str]:

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -228,7 +228,8 @@ def get_local_package_config(
 
 
 def get_package_config_from_repo(
-    project: GitProject, ref: Optional[str] = None, spec_file_path: Optional[str] = None
+    project: GitProject,
+    ref: Optional[str] = None,
 ) -> Optional[PackageConfig]:
     for config_file_name in CONFIG_FILE_NAMES:
         try:
@@ -259,15 +260,12 @@ def get_package_config_from_repo(
         raise PackitConfigException(
             f"Cannot load package config {config_file_name!r}. {ex}"
         )
-    if not spec_file_path:
-        logger.warning(f"Spec file path is not specified in {config_file_name}.")
-        spec_file_path = get_specfile_path_from_repo(project=project, ref=ref)
 
     return parse_loaded_config(
         loaded_config=loaded_config,
         config_file_path=config_file_name,
         repo_name=project.repo,
-        spec_file_path=spec_file_path,
+        spec_file_path=get_specfile_path_from_repo(project=project, ref=ref),
     )
 
 

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -11,7 +11,7 @@ from ogr.exceptions import GithubAppNotInstalledError
 from yaml import safe_load
 
 from packit.config.common_package_config import CommonPackageConfig
-from packit.config.job_config import JobConfig, get_default_jobs, JobType
+from packit.config.job_config import JobConfig, JobType
 from packit.constants import CONFIG_FILE_NAMES
 from packit.exceptions import PackitConfigException
 
@@ -59,10 +59,6 @@ class PackageConfig(CommonPackageConfig):
             raw_dict.update(config_file_path=config_file_path)
 
         # we need to process defaults first so they get propagated to JobConfigs
-
-        if "jobs" not in raw_dict:
-            # we want default jobs to go through the proper parsing process
-            raw_dict["jobs"] = get_default_jobs()
 
         if not raw_dict.get("upstream_package_name", None) and repo_name:
             raw_dict["upstream_package_name"] = repo_name

--- a/packit/config/package_config_validator.py
+++ b/packit/config/package_config_validator.py
@@ -38,9 +38,8 @@ class PackageConfigValidator:
             config = PackageConfig.get_from_dict(
                 self.content,
                 config_file_path=str(self.config_file_path),
-                spec_file_path=str(
-                    get_local_specfile_path(self.config_file_path.parent)
-                ),
+                search_specfile=get_local_specfile_path,
+                dir=self.config_file_path.parent,
             )
         except ValidationError as e:
             schema_errors = e.messages

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -25,7 +25,6 @@ from packit.config.package_config import (
 import packit.config.package_config
 from packit.config.sources import SourcesItem
 from packit.constants import CONFIG_FILE_NAMES
-from packit.exceptions import PackitConfigException
 from packit.schema import PackageConfigSchema
 from packit.sync import SyncFilesItem
 from tests.spellbook import UP_OSBUILD, SYNC_FILES
@@ -1463,7 +1462,7 @@ def test_get_specfile_sync_files_nodownstreamname_item():
     ],
 )
 def test_package_config_specfile_not_present_raise(raw):
-    with pytest.raises(PackitConfigException):
+    with pytest.raises(ValidationError):
         PackageConfig.get_from_dict(raw_dict=raw)
 
 

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -1086,7 +1086,7 @@ def test_dist_git_package_url():
 
 
 @pytest.mark.parametrize(
-    "content,project,mock_spec_search,spec_path_option,spec_path",
+    "content,project,spec_path",
     [
         (
             "synced_files:\n"
@@ -1094,8 +1094,6 @@ def test_dist_git_package_url():
             "  - src: .packit.yaml\n"
             "    dest: .packit2.yaml",
             GitProject(repo="", service=GitService(), namespace=""),
-            True,
-            None,
             "packit.spec",
         ),
         (
@@ -1104,8 +1102,6 @@ def test_dist_git_package_url():
             "  - src: .packit.yaml\n"
             "    dest: .packit2.yaml",
             GitProject(repo="", service=GitService(), namespace=""),
-            False,
-            "packit.spec",
             "packit.spec",
         ),
     ],
@@ -1113,18 +1109,13 @@ def test_dist_git_package_url():
 def test_get_package_config_from_repo(
     content,
     project: GitProject,
-    mock_spec_search: bool,
     spec_path: Optional[str],
-    spec_path_option: Optional[str],
 ):
     gp = flexmock(GitProject)
     gp.should_receive("full_repo_name").and_return("a/b")
     gp.should_receive("get_file_content").and_return(content)
-    if mock_spec_search:
-        gp.should_receive("get_files").and_return(["packit.spec"]).once()
-    config = get_package_config_from_repo(
-        project=project, spec_file_path=spec_path_option
-    )
+    gp.should_receive("get_files").and_return(["packit.spec"]).once()
+    config = get_package_config_from_repo(project=project)
     assert isinstance(config, PackageConfig)
     assert config.specfile_path == spec_path
     assert config.files_to_sync == [

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -1125,16 +1125,21 @@ def test_get_package_config_from_repo(
 
 
 @pytest.mark.parametrize(
-    "content",
+    "content, specfile_path",
     [
-        "{}",
-        "{jobs: [{job: build, trigger: commit}]}",
-        "{downstream_package_name: horkyze, jobs: [{job: build, trigger: commit}]}",
-        "{upstream_package_name: slize, jobs: [{job: build, trigger: commit}]}",
+        ("{}", "packit.spec"),
+        ("{jobs: [{job: build, trigger: commit}]}", "packit.spec"),
+        (
+            "{downstream_package_name: horkyze, jobs: [{job: build, trigger: commit}]}",
+            "horkyze.spec",
+        ),
+        (
+            "{upstream_package_name: slize, jobs: [{job: build, trigger: commit}]}",
+            "packit.spec",
+        ),
     ],
 )
-def test_get_package_config_from_repo_spec_file_not_defined(content):
-    specfile_path = "packit.spec"
+def test_get_package_config_from_repo_spec_file_not_defined(content, specfile_path):
     gp = flexmock(GitProject)
     gp.should_receive("full_repo_name").and_return("a/b")
     gp.should_receive("get_file_content").and_return(content)
@@ -1142,7 +1147,7 @@ def test_get_package_config_from_repo_spec_file_not_defined(content):
     git_project = GitProject(repo="", service=GitService(), namespace="")
     config = get_package_config_from_repo(project=git_project)
     assert isinstance(config, PackageConfig)
-    assert Path(config.specfile_path).name == specfile_path
+    assert config.specfile_path == specfile_path
     assert config.create_pr
     for j in config.jobs:
         assert j.specfile_path == specfile_path


### PR DESCRIPTION
Previously the repo (local or the forge) was recursively searched for
the specfile _before_ calling PackageConfig.get_from_dict(), and any
specfile found was passed on to the method.

This works, if there is a single package and specfile in the repo.
Introducing monorepo support though requires the ability to tell which
paths of the repo to search for the specfile. These paths won't be
available only after the configuration is parsed.

In order to avoid exposing parsing the config outside of PackageConfig,
call the search functions in PackageConfig.get_from_dict(), which should
enable implementing monorepo support.

This also introduces a BREAKING CHANGE, and aligns detecting
'specfile_path', according to the documentation:
1. Use specfile_path, if defined.
2. Use downstream_package_name.spec, if downstream_package_name is
   defined.
3. Search for a *.spec file in the repo.

Previously to this, points 2. and 3. were done the other way around.

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [-] Update or write new documentation in `packit/packit.dev`.

RELEASE NOTES BEGIN
BREAKING CHANGE: fixed an issue where the repo was searched for the specfile _before_ checking if 'downstream_package_name' is set, and '<downstream_package_name>.spec' can be used as the 'specfile_path'.
RELEASE NOTES END
