### PR TITLE
CI: force installation of bodhi 5 client

### DIFF
--- a/files/tasks/generic-dnf-requirements.yaml
+++ b/files/tasks/generic-dnf-requirements.yaml
@@ -8,6 +8,14 @@
       - python3-pip
       - rpmdevtools
       - python3-bodhi-client
+      # workaround for https://github.com/fedora-infra/bodhi/issues/4660
+      # we need to explicitly install here so that `install-requirements-rpms.yaml` and the rev-dep p-s test
+      # install bpdhi 5 and not 6
+      - https://kojipkgs.fedoraproject.org/packages/bodhi/5.7.5/1.fc35/noarch/python3-bodhi-5.7.5-1.fc35.noarch.rpm
+      - https://kojipkgs.fedoraproject.org/packages/bodhi/5.7.5/1.fc35/noarch/python3-bodhi-client-5.7.5-1.fc35.noarch.rpm
       - fedpkg
       - rsync
+    state: present
+    # needed when installing from koji - there are no GPG-signed packages
+    disable_gpg_check: true
   become: true


### PR DESCRIPTION
```
Here's the dependency stack:

reverse-dep-packit-service-tests zuul job
⮩ packit-tests-pip-deps zuul job
  ⮩ install-requirements-pip.yaml playbook
    ⮩ generic-dnf-requirements.yaml playbook
```

Hence the bodhi client is installed much sooner than in the actual
playbook for the rev-dep test. This is not obvious from the Zuul
interface.