### PR TITLE
implement `packit build in-image-builder`

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -99,3 +99,14 @@ jobs:
     dist_git_branches:
       - fedora-branched
       - epel-8
+#  - job: vm_image_build
+#    trigger: pull_request
+#    packit_instances: ["stg"]
+#    image_distribution: rhel-8
+#    image_type: aws
+#    image_architecture: x86_64
+#    image_account_id: "727920394381"
+#    packages_to_install: [packit]
+#    owner: packit
+#    project: packit-dev
+#    targets: [epel-8]

--- a/packit/cli/build.py
+++ b/packit/cli/build.py
@@ -11,6 +11,7 @@ from packit.cli.builds.copr_build import copr
 from packit.cli.builds.koji_build import koji
 from packit.cli.builds.local_build import local
 from packit.cli.builds.mock_build import mock
+from packit.cli.builds.in_image_builder import in_image_builder
 
 logger = logging.getLogger(__name__)
 
@@ -32,3 +33,4 @@ build.add_command(copr)
 build.add_command(koji)
 build.add_command(local)
 build.add_command(mock)
+build.add_command(in_image_builder)

--- a/packit/cli/builds/copr_build.py
+++ b/packit/cli/builds/copr_build.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 @click.command("in-copr", context_settings=get_context_settings())
-@click.option("--nowait", is_flag=True, default=False, help="Don't wait for build")
+@click.option("--wait/--no-wait", default=True, help="Wait for the build to finish")
 @click.option(
     "--owner",
     help="Copr user, owner of the project. (defaults to username from copr config)",
@@ -104,7 +104,7 @@ logger = logging.getLogger(__name__)
 @cover_packit_exception
 def copr(
     config,
-    nowait,
+    wait,
     owner,
     project,
     targets,
@@ -182,5 +182,5 @@ def copr(
         srpm_path=config.srpm_path,
     )
     click.echo(f"Build id: {build_id}, repo url: {repo_url}")
-    if not nowait:
+    if wait:
         api.watch_copr_build(build_id=build_id, timeout=60 * 60 * 2)

--- a/packit/cli/builds/in_image_builder.py
+++ b/packit/cli/builds/in_image_builder.py
@@ -1,0 +1,88 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+import time
+from os import getcwd
+
+import click
+
+from packit.cli.types import LocalProjectParameter
+from packit.cli.utils import cover_packit_exception, get_packit_api
+from packit.config import pass_config, JobType
+
+logger = logging.getLogger("packit")
+
+
+@click.command("in-image-builder")
+@click.option(
+    "--job-config-index",
+    default=None,
+    type=click.INT,
+    help="Use N-th job definition to load configuration for the image build. "
+    "The type needs to be vm_image_build.",
+)
+@click.option("--wait/--no-wait", default=False, help="Wait for the build to finish")
+@click.argument("image_name", default=None, type=click.STRING)
+@click.argument("path_or_url", type=LocalProjectParameter(), default=getcwd())
+@pass_config
+@cover_packit_exception
+def in_image_builder(
+    config,
+    wait,
+    image_name,
+    job_config_index,
+    path_or_url,
+):
+    """
+    Create a VM image in Image Builder.
+
+    ### EXPERIMENTAL ###
+
+    This command is experimental and the integration with Image Builder will be
+    changed in a backwards incompatible way in the future.
+
+    Packit loads image build configuration from your packit.yaml file.
+
+    When `--job-config-index` is not specified, the job configuration is loaded from your
+    .packit.yaml and the first matching vm_image_build job is used.
+
+    IMAGE_NAME is the name of the image to be created. Please pick something unique so it's
+    easy to identify for you in the Image Builder interface and can be well associated
+    with the image content.
+
+    [PATH_OR_URL] argument is a local path or a URL to the upstream git repository,
+    it defaults to the current working directory
+    """
+    api = get_packit_api(
+        config=config,
+        local_project=path_or_url,
+        job_config_index=job_config_index,
+        job_type=JobType.vm_image_build,
+    )
+
+    build_id = api.submit_vm_image_build(
+        image_distribution=api.package_config.image_distribution,
+        image_name=image_name,
+        image_request=api.package_config.image_request,
+        image_customizations=api.package_config.image_customizations,
+        copr_namespace=api.package_config.owner,
+        copr_project=api.package_config.project,
+        copr_chroot=api.package_config.copr_chroot,
+    )
+    logger.info(f"Image Build ID: {build_id}")
+    logger.info("Browse in: https://console.redhat.com/insights/image-builder")
+
+    if not wait:
+        return 0
+    logger.info(f"Getting status for build {build_id}.")
+    while True:
+        status = api.get_vm_image_build_status(build_id)
+        if status not in ("building", "pending"):
+            break
+        logger.info(f"Status: {status}")
+        time.sleep(5.0)
+
+    # IB offers this link:
+    # https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#LaunchInstanceWizard:ami=ami-08ee0689a0547e7ea
+    # we could construct & print it too

--- a/packit/cli/builds/koji_build.py
+++ b/packit/cli/builds/koji_build.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 @click.option(
     "--scratch", is_flag=True, default=False, help="Submit a scratch koji build"
 )
-@click.option("--nowait", is_flag=True, default=False, help="Don't wait on build")
+@click.option("--wait/--no-wait", default=True, help="Wait for the build to finish")
 @click.option(
     "--release-suffix",
     default=None,
@@ -67,7 +67,7 @@ def koji(
     from_upstream,
     koji_target,
     scratch,
-    nowait,
+    wait,
     release_suffix,
     default_release_suffix,
     path_or_url,
@@ -113,7 +113,7 @@ def koji(
                 out = api.build(
                     dist_git_branch=branch,
                     scratch=scratch,
-                    nowait=nowait,
+                    nowait=not wait,
                     koji_target=target,
                     from_upstream=from_upstream,
                     release_suffix=release_suffix,

--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -16,7 +16,7 @@ from packit.config.common_package_config import CommonPackageConfig
 from packit.config.package_config import PackageConfig
 
 from packit.api import PackitAPI
-from packit.config import Config, get_local_package_config
+from packit.config import Config, get_local_package_config, JobType
 from packit.constants import DIST_GIT_HOSTNAME_CANDIDATES
 from packit.exceptions import PackitException, PackitNotAGitRepoException
 from packit.local_project import LocalProject
@@ -94,6 +94,7 @@ def get_packit_api(
     dist_git_path: Optional[str] = None,
     load_packit_yaml: bool = True,
     job_config_index: Optional[int] = None,
+    job_type: Optional[JobType] = None,
 ) -> PackitAPI:
     """
     Load the package config, set other options and return the PackitAPI
@@ -113,6 +114,16 @@ def get_packit_api(
                     "job_config_index is bigger than number of jobs in package config!"
                 )
             package_config = package_config.jobs[job_config_index]
+            logger.debug(f"Final package (job) config: {package_config}")
+        elif job_type is not None:
+            try:
+                package_config = [
+                    job for job in package_config.jobs if job.type == job_type
+                ][0]
+            except IndexError:
+                raise PackitException(
+                    f"No job with type {job_type} found in package config."
+                )
             logger.debug(f"Final package (job) config: {package_config}")
     else:
         package_config = PackageConfig()

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -174,13 +174,9 @@ class CommonPackageConfig:
         # # vm-image-build
         # example: "rhel-86"
         image_distribution: Optional[str] = None,
-        image_architecture: Optional[str] = None,
-        # example: "aws"
-        image_type: Optional[str] = None,
-        # example: "727920393541"
-        image_account_id: Optional[str] = None,
-        # example: ["foo", "bar-1.2.3"]
-        packages_to_install: Optional[List[str]] = None,
+        image_request: Optional[Dict] = None,
+        image_customizations: Optional[Dict] = None,
+        copr_chroot: Optional[str] = None,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -267,10 +263,9 @@ class CommonPackageConfig:
         self.tf_post_install_script = tf_post_install_script
 
         self.image_distribution = image_distribution
-        self.image_architecture = image_architecture
-        self.image_type = image_type
-        self.image_account_id = image_account_id
-        self.packages_to_install = packages_to_install
+        self.image_request = image_request
+        self.image_customizations = image_customizations
+        self.copr_chroot = copr_chroot
 
     @property
     def targets_dict(self):

--- a/packit/config/config.py
+++ b/packit/config/config.py
@@ -37,6 +37,7 @@ class Config:
         fas_user: Optional[str] = None,
         fas_password: Optional[str] = None,
         keytab_path: Optional[str] = None,
+        redhat_api_refresh_token: Optional[str] = None,
         upstream_git_remote: Optional[str] = None,
         kerberos_realm: Optional[str] = "FEDORAPROJECT.ORG",
         koji_build_command: Optional[str] = "koji build",
@@ -56,6 +57,7 @@ class Config:
         self.fas_user: Optional[str] = fas_user
         self.fas_password: Optional[str] = fas_password
         self.keytab_path: Optional[str] = keytab_path
+        self.redhat_api_refresh_token: Optional[str] = redhat_api_refresh_token
         self.kerberos_realm = kerberos_realm
         self.koji_build_command = koji_build_command
         if not which(pkg_tool):

--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -373,3 +373,26 @@ class CoprHelper:
                 client.mock_chroot_proxy.get_list().keys(),
             )
         )
+
+    def get_build(self, build_id: int) -> Dict:
+        """
+        Get build details from Copr.
+
+        Arguments:
+            build_id -- Copr build id.
+
+        :return: Dict
+        """
+        return self.copr_client.build_proxy.get(build_id)
+
+    def get_repo_download_url(self, owner: str, project: str, chroot: str) -> str:
+        """Provide a link to yum repo for the particular chroot"""
+        copr_proj = self.copr_client.project_proxy.get(
+            ownername=owner, projectname=project
+        )
+        try:
+            return copr_proj["chroot_repos"][chroot]
+        except KeyError:
+            raise PackitCoprProjectException(
+                f"There is no such target {chroot} in {owner}/{project}."
+            )

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -344,11 +344,13 @@ class CommonConfigSchema(Schema):
     allowed_committers = fields.List(fields.String(), missing=None)
     tmt_plan = fields.String(missing=None)
     tf_post_install_script = fields.String(missing=None)
+
+    # Image Builder integration
     image_distribution = fields.String(missing=None)
-    image_architecture = fields.String(missing=None)
-    image_type = fields.String(missing=None)
-    image_account_id = fields.String(missing=None)
-    packages_to_install = fields.List(fields.String(), missing=None)
+    # these two are freeform so that users can immediately use IB's new features
+    image_request = fields.Dict(missing=None)
+    image_customizations = fields.Dict(missing=None)
+    copr_chroot = fields.String(missing=None)
 
     @staticmethod
     def spec_source_id_serialize(value: CommonPackageConfig):
@@ -569,6 +571,7 @@ class UserConfigSchema(Schema):
     fas_user = fields.String()
     fas_password = fields.String()
     keytab_path = fields.String()
+    redhat_api_refresh_token = fields.String()
     upstream_git_remote = fields.String()
     github_token = fields.String()
     pagure_user_token = fields.String()

--- a/packit/vm_image_build.py
+++ b/packit/vm_image_build.py
@@ -1,0 +1,239 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+"""
+Code that backs up Image Builder integration.
+
+Guides and more info about Image Builder:
+    https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/composing_a_customized_rhel_system_image/index
+    https://www.redhat.com/en/blog/using-hosted-image-builder-its-api
+    https://github.com/packit/research/tree/main/image-builder
+"""
+import logging
+from typing import Optional, Dict, List, Union
+
+import requests
+
+from packit.exceptions import PackitException
+
+logger = logging.getLogger("packit")
+REDHAT_SSO_AUTH_URL = (
+    "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
+)
+REDHAT_API_GET_USER_URL = "https://api.access.redhat.com/account/v1/user"
+IMAGE_BUILDER_API_URL = "https://console.redhat.com/api/image-builder/v1"
+
+
+class ImageBuilder:
+    """
+    Client class to work with Image Builder API and Red Hat SSO.
+    """
+
+    def __init__(
+        self,
+        refresh_token: str,
+    ):
+        """
+        Args:
+            refresh_token: your personal token to access Red Hat SSO, obtain at:
+                https://access.redhat.com/management/api
+        """
+        self.refresh_token = refresh_token
+        self._access_token: Optional[str] = None
+
+        self.image_builder_session = requests.Session()
+        self.refresh_auth()
+
+    def refresh_auth(self):
+        """
+        Refresh the access token and the image_builder_session headers.
+        """
+        self._access_token = self._get_access_token()
+        # TODO: raise if access token is None
+        self.image_builder_session.headers.update(
+            {
+                "Authorization": f"Bearer {self._access_token}",
+                "Accept": "application/json",
+            }
+        )
+
+    def image_builder_request(
+        self, method: str, path: str, payload: Optional[dict] = None
+    ):
+        """
+        Request to the Image Builder API.
+
+        Args:
+            method: HTTP method to use (GET, POST, PUT, DELETE)
+            path: path to the API endpoint
+            payload: payload to send with the request
+
+        Returns:
+            requests.Response object.
+        """
+        # don't try to refresh twice
+        token_is_fresh = False
+        while True:
+            # TODO: figure out retries if something goes wrong here
+            response = self.image_builder_session.request(
+                method, f"{IMAGE_BUILDER_API_URL}/{path}", json=payload
+            )
+            if response.status_code == 401 and not token_is_fresh:
+                token_is_fresh = True
+                self.refresh_auth()
+                continue
+            response.raise_for_status()
+            return response
+
+    def _get_access_token(self) -> Optional[str]:
+        """
+        Obtain access token from Red Hat SSO using the provided refresh token.
+
+            curl -X POST -d grant_type=refresh_token \
+              -d client_id=rhsm-api -d refresh_token=$o \
+              https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+        Returns:
+            access token (used for interacting with the API)
+        """
+        sso = requests.Session()
+        response = sso.post(
+            REDHAT_SSO_AUTH_URL,
+            data={
+                "grant_type": "refresh_token",
+                "client_id": "rhsm-api",
+                "refresh_token": self.refresh_token,
+            },
+        )
+        response_json = response.json()
+        try:
+            return response_json["access_token"]
+        except KeyError:
+            logger.info(
+                f"Failed to get access token ({response.status_code}): {response_json}"
+            )
+            return None
+
+    def check_token(self) -> dict:
+        """
+        Using the obtained access token, check that it is valid by obtaining the
+        user info.
+
+        Returns:
+            Dict payload with the user info.
+        """
+        response = requests.get(
+            REDHAT_API_GET_USER_URL,
+            headers={"Authorization": f"Bearer {self._access_token}"},
+        )
+        json_output = response.json()
+        return json_output
+
+    def create_image(
+        self,
+        image_distribution: str,
+        image_name: str,
+        image_request: Dict,
+        image_customizations: Dict,
+        repo_url: str,
+    ):
+        """
+        Create an image using the Image Builder API.
+        Images are called a compose in context of Image Builder.
+
+        request and customization fields are passed to Image Builder, see
+        their API for the definition, example:
+
+          "customizations": {
+            "filesystem": [
+              {
+                "min_size": 1024,
+                "mountpoint": "/var"
+              }
+            ],
+            "packages": [ "postgresql" ],
+          }
+          "image_requests": [
+            {
+              "architecture": "x86_64",
+              "image_type": "aws",
+              "upload_request": {
+                "options": {
+                  "share_with_accounts": [
+                    "123456789012"
+                  ]
+                },
+                "type": "aws"
+              }
+            }
+          ]
+
+        Args:
+            image_distribution: distribution name (base operating system), e.g. "rhel-8"
+            image_name: image name, e.g. "packit-test-john-foo"
+            image_request: Image request definition of an image build
+            image_customizations: Image customizations definition of an image build
+            repo_url: yum repository URL, e.g.
+                "https://download.copr.fedorainfracloud.org/" +
+                "results/@cockpit/cockpit-preview/centos-stream-9-x86_64/"
+        """
+        image_customizations.setdefault("payload_repositories", [])
+        # variable assignment is done for sake of mypy:
+        #   https://stackoverflow.com/a/54788883/909579
+        payload_repositories: List[Dict[str, Union[str, bool]]] = image_customizations[
+            "payload_repositories"
+        ]
+        logger.debug(
+            f"image_customizations -> payload_repositories {payload_repositories}"
+        )
+        payload = {
+            "image_name": image_name,
+            "distribution": image_distribution,
+            "image_requests": [image_request],
+            "customizations": image_customizations,
+        }
+        payload_repositories.append(
+            {
+                "rhsm": False,
+                "baseurl": repo_url,
+                # needs to be the actual key, not link:
+                # https://issues.redhat.com/browse/HMSIB-14
+                # "gpgkey": "https://download.copr.../@cockpit/cockpit-preview/pubkey.gpg",
+                "check_gpg": False,
+            }
+        )
+        response = self.image_builder_request("POST", "compose", payload=payload)
+
+        response_json = response.json()
+        try:
+            return response_json["id"]
+        except KeyError:
+            logger.error(
+                f"Failed to create image ({response.status_code}): {response_json}"
+            )
+            raise PackitException(f"Failed to create image: {response_json}")
+
+    def get_image_status(self, build_id: str):
+        """
+        Get image build status.
+
+        Args:
+            build_id: Build ID of the image.
+
+        Returns:
+            Status of the build (example: success, building, pending)
+        """
+        # Examples of /composes/{build_id}
+        # {'image_status': {'status': 'building'}}
+        # {'image_status': {
+        #     'status': 'success', 'upload_status': {
+        #         'options': {
+        #             'ami': 'ami-08ee0689a0547e7ea',
+        #             'region': 'us-east-1'
+        #         },
+        #         'status': 'success', 'type': 'aws'
+        #     }
+        # }
+        response_json = self.image_builder_request("GET", f"composes/{build_id}").json()
+        logger.debug(f"Image build metadata: {response_json}")
+        return response_json["image_status"]["status"]

--- a/tests/integration/test_copr_build.py
+++ b/tests/integration/test_copr_build.py
@@ -579,7 +579,7 @@ def test_copr_build_cli_no_project_configured(upstream_and_remote, copr_client_m
     ).and_return(copr_client_mock)
     CoprHelper.get_available_chroots.cache_clear()
 
-    run_packit(["build", "in-copr", "--nowait"], working_dir=upstream)
+    run_packit(["build", "in-copr", "--no-wait"], working_dir=upstream)
 
 
 def test_copr_build_cli_project_set_via_cli(upstream_and_remote, copr_client_mock):
@@ -606,7 +606,7 @@ def test_copr_build_cli_project_set_via_cli(upstream_and_remote, copr_client_moc
     CoprHelper.get_available_chroots.cache_clear()
 
     run_packit(
-        ["build", "in-copr", "--nowait", "--project", "the-project"],
+        ["build", "in-copr", "--no-wait", "--project", "the-project"],
         working_dir=upstream,
     )
 
@@ -638,7 +638,7 @@ def test_copr_build_cli_project_set_from_config(upstream_and_remote, copr_client
         srpm_path=None,
     ).and_return(("id", "url")).once()
 
-    run_packit(["build", "in-copr", "--nowait"], working_dir=upstream)
+    run_packit(["build", "in-copr", "--no-wait"], working_dir=upstream)
 
 
 def test_create_copr_project(copr_client_mock):

--- a/tests/unit/test_image_builder.py
+++ b/tests/unit/test_image_builder.py
@@ -1,0 +1,54 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+from flexmock import flexmock
+from packit.vm_image_build import ImageBuilder
+
+
+def test_create_image():
+    """Test creating an image"""
+    ib = ImageBuilder("foo-token")
+    # auth is tested in tests_recording
+    flexmock(ib).should_receive("refresh_auth").and_return(None)
+    payload = {
+        "image_name": "mona-lisa",
+        "distribution": "rhel-90",
+        "image_requests": [
+            {
+                "architecture": "x86_64",
+                "image_type": "aws",
+                "upload_request": {
+                    "options": {"share_with_accounts": ["123456789012"]},
+                    "type": "aws",
+                },
+            }
+        ],
+        "customizations": {
+            "payload_repositories": [
+                {
+                    "rhsm": False,
+                    "baseurl": "https://copr.fedoraproject.org/coprs/foo/bar/",
+                    "check_gpg": False,
+                },
+            ],
+            "packages": ["mona-lisa"],
+        },
+    }
+    request_response = {"id": "foo-baz-bar"}
+    flexmock(ib).should_receive("image_builder_request").with_args(
+        "POST", "compose", payload=payload
+    ).and_return(flexmock(json=lambda: request_response))
+    response = ib.create_image(
+        "rhel-90",
+        "mona-lisa",
+        {
+            "architecture": "x86_64",
+            "image_type": "aws",
+            "upload_request": {
+                "options": {"share_with_accounts": ["123456789012"]},
+                "type": "aws",
+            },
+        },
+        {"packages": ["mona-lisa"]},
+        "https://copr.fedoraproject.org/coprs/foo/bar/",
+    )
+    assert response == "foo-baz-bar"

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -883,11 +883,18 @@ def test_package_config_parse_error(raw):
                     {
                         "job": "vm_image_build",
                         "trigger": "pull_request",
-                        "packages_to_install": ["peddle", "board"],
                         "image_distribution": "rhel-90",
-                        "image_type": "aws",
-                        "image_account_id": "yolo",
-                        "image_architecture": "x86_64",
+                        "image_request": {
+                            "architecture": "x86_64",
+                            "image_type": "aws",
+                            "upload_request": {
+                                "options": {"share_with_accounts": ["123456789012"]},
+                                "type": "aws",
+                            },
+                        },
+                        "image_customizations": {
+                            "packages": ["peddle", "board"],
+                        },
                     }
                 ],
             },
@@ -899,11 +906,18 @@ def test_package_config_parse_error(raw):
                         specfile_path="fedora/package.spec",
                         type=JobType.vm_image_build,
                         trigger=JobConfigTriggerType.pull_request,
-                        packages_to_install=["peddle", "board"],
                         image_distribution="rhel-90",
-                        image_type="aws",
-                        image_account_id="yolo",
-                        image_architecture="x86_64",
+                        image_request={
+                            "architecture": "x86_64",
+                            "image_type": "aws",
+                            "upload_request": {
+                                "options": {"share_with_accounts": ["123456789012"]},
+                                "type": "aws",
+                            },
+                        },
+                        image_customizations={
+                            "packages": ["peddle", "board"],
+                        },
                     ),
                 ],
             ),

--- a/tests_recording/test_data/test_image_builder/TestLocalProject.test_get_token.yaml
+++ b/tests_recording/test_data/test_image_builder/TestLocalProject.test_get_token.yaml
@@ -1,0 +1,108 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    POST:
+      https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token:
+      - metadata:
+          latency: 0.283463716506958
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests_recording.test_image_builder
+          - packit.vm_image_build
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            access_token: foo
+            expires_in: 900
+            not-before-policy: 0
+            refresh_expires_in: 0
+            refresh_token: bar
+            scope: offline_access
+            session_state: 7b968000-fd86-46aa-bc49-4c1526ec5717
+            token_type: Bearer
+          _next: null
+          elapsed: 0.283222
+          encoding: utf-8
+          headers:
+            Cache-Control: no-store
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Length: '1839'
+            Content-Type: application/json
+            Date: Mon, 15 Aug 2022 11:08:25 GMT
+            Keep-Alive: timeout=300
+            Pragma: no-cache
+            Set-Cookie: foo=baz;
+              path=/; HttpOnly; Secure; SameSite=None
+            Vary: Accept-Encoding
+            referrer-policy: strict-origin
+            strict-transport-security: max-age=31536000; includeSubDomains
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-rh-edge-cache-status: Miss from child, Miss from parent
+            x-rh-edge-reference-id: 0.446ed417.1660561705.10367b2a
+            x-rh-edge-request-id: 10367b2a
+            x-site: prod-spoke-aws-us-east-1
+            x-xss-protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+      - metadata:
+          latency: 0.2908346652984619
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests_recording.test_image_builder
+          - packit.vm_image_build
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            access_token: foo
+            expires_in: 900
+            not-before-policy: 0
+            refresh_expires_in: 0
+            refresh_token: bar
+            scope: offline_access
+            session_state: 7b968000-fd86-46aa-bc49-4c1526ec5717
+            token_type: Bearer
+          _next: null
+          elapsed: 0.29051
+          encoding: utf-8
+          headers:
+            Cache-Control: no-store
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Length: '1841'
+            Content-Type: application/json
+            Date: Mon, 15 Aug 2022 11:08:25 GMT
+            Keep-Alive: timeout=300
+            Pragma: no-cache
+            Set-Cookie: bar=baz;
+              path=/; HttpOnly; Secure; SameSite=None
+            Vary: Accept-Encoding
+            referrer-policy: strict-origin
+            strict-transport-security: max-age=31536000; includeSubDomains
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-rh-edge-cache-status: Miss from child, Miss from parent
+            x-rh-edge-reference-id: 0.446ed417.1660561705.10367db8
+            x-rh-edge-request-id: 10367db8
+            x-site: prod-spoke-aws-us-east-1
+            x-xss-protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests_recording/test_data/test_image_builder/TestLocalProject.test_token_auto_refresh.yaml
+++ b/tests_recording/test_data/test_image_builder/TestLocalProject.test_token_auto_refresh.yaml
@@ -1,0 +1,106 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    GET:
+      https://console.redhat.com/api/image-builder/v1/composes/e31d475a-1d32-4cac-844e-a6a613f80439:
+      - metadata:
+          latency: 0.5824246406555176
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests_recording.test_image_builder
+          - packit.vm_image_build
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            image_status:
+              status: success
+              upload_status:
+                options:
+                  url: https://image-builder-service-production.s3.amazonaws.com/composer-api-317e0fb8-b439-40f7-8487-cde551da7915-installer.iso?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=asd&X-Amz-Date=20220804T162550Z&X-Amz-Expires=604800&X-Amz-Security-Token=foo&X-Amz-SignedHeaders=host&X-Amz-Signature=qwe
+                status: success
+                type: aws.s3
+          _next: null
+          elapsed: 0.582197
+          encoding: UTF-8
+          headers:
+            Cache-Control: private
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Length: '1342'
+            Content-Type: application/json; charset=UTF-8
+            Date: Mon, 15 Aug 2022 11:09:45 GMT
+            Server: openresty
+            Set-Cookie: asd=qwe;
+              path=/; HttpOnly; Secure; SameSite=None
+            Strict-Transport-Security: max-age=31536000; includeSubDomains
+            Vary: Accept-Encoding
+            X-Frame-Options: SAMEORIGIN
+            x-content-type-options: nosniff
+            x-rh-edge-cache-status: Miss from child, Miss from parent
+            x-rh-edge-reference-id: 0.47611702.1660561785.824021b7
+            x-rh-edge-request-id: 824021b7
+            x-rh-insights-request-id: c6726edf351a49418b92da12cb6e44c7
+          raw: !!binary ""
+          reason: OK
+          status_code: 200
+    POST:
+      https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token:
+      - metadata:
+          latency: 0.3449738025665283
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests_recording.test_image_builder
+          - packit.vm_image_build
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            access_token: bar
+            expires_in: 900
+            not-before-policy: 0
+            refresh_expires_in: 0
+            refresh_token: foo
+            scope: offline_access
+            session_state: 7b968000-fd86-46aa-bc49-4c1526ec5717
+            token_type: Bearer
+          _next: null
+          elapsed: 0.344729
+          encoding: utf-8
+          headers:
+            Cache-Control: no-store
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Length: '1844'
+            Content-Type: application/json
+            Date: Mon, 15 Aug 2022 11:09:45 GMT
+            Keep-Alive: timeout=300
+            Pragma: no-cache
+            Set-Cookie: asd=qwe;
+              path=/; HttpOnly; Secure; SameSite=None
+            Vary: Accept-Encoding
+            referrer-policy: strict-origin
+            strict-transport-security: max-age=31536000; includeSubDomains
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-rh-edge-cache-status: Miss from child, Miss from parent
+            x-rh-edge-reference-id: 0.446ed417.1660561785.10392bfb
+            x-rh-edge-request-id: 10392bfb
+            x-site: prod-spoke-aws-us-east-1
+            x-xss-protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests_recording/test_image_builder.py
+++ b/tests_recording/test_image_builder.py
@@ -1,0 +1,38 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+from requre.cassette import DataTypes
+from requre.modules_decorate_all_methods import record_requests_module
+
+from packit.vm_image_build import ImageBuilder
+from tests_recording.testbase import PackitTest
+
+
+@record_requests_module
+class TestLocalProject(PackitTest):
+    """Test Image Builder API and Red Hat Auth requests"""
+
+    def cassette_setup(self, cassette):
+        """requre requires this method to be present"""
+        cassette.data_miner.data_type = DataTypes.Dict
+
+    def test_get_token(self):
+        """Test PR checkout with and without merging"""
+
+        ib = ImageBuilder(refresh_token=self.config.redhat_api_refresh_token)
+        ib.refresh_auth()
+
+        assert (
+            ib.image_builder_session.headers["Authorization"]
+            == f"Bearer {ib._access_token}"
+        )
+
+    def test_token_auto_refresh(self):
+        """make sure that 401 requests obtain a new API token"""
+
+        ib = ImageBuilder(refresh_token=self.config.redhat_api_refresh_token)
+        # when regenerating this, go to https://console.redhat.com/insights/image-builder
+        # and find a successful build of an image
+        response_json = ib.image_builder_request(
+            "GET", "composes/e31d475a-1d32-4cac-844e-a6a613f80439"
+        ).json()
+        assert response_json["image_status"]["status"] == "success"


### PR DESCRIPTION
TODO:

- [x] Write new tests or update the old ones to cover new functionality. (at least 2 test cases for the new code)
- [x] Update doc-strings where appropriate. (at minimim the 2 new API methods and the new vm_image_build module)
- [x] agree on design of the CLI interface

<!-- notes for reviewers -->

```
$ packit build in-image-builder --help
Usage: packit build in-image-builder [OPTIONS] IMAGE_NAME [PATH_OR_URL]

  Create a VM image in Image Builder.

  Packit loads image build configuration from your packit.yaml file.

  When `--job-config-index` is not specified, the job configuration is loaded
  from your .packit.yaml and the first matching vm_image_build job is used.

  IMAGE_NAME is the name of the image to be created. Please pick something
  unique so it's easy to identify for you in the Image Builder interface and
  can be well associated with the image content.

  [PATH_OR_URL] argument is a local path or a URL to the upstream git
  repository, it defaults to the current working directory

Options:
  --job-config-index INTEGER  Use N-th job definition to load configuration
                              for the image build. The type needs to be
                              vm_image_build.
  --wait / --no-wait          Wait for the build to finish
  -h, --help                  Show this message and exit.
```

Context: https://github.com/packit/research/tree/main/image-builder

RELEASE NOTES BEGIN

* Packit CLI can now submit VM images in [Red Hat Image Builder](https://console.redhat.com/insights/image-builder).
* All build-related commands have now consistent `--wait / --no-wait` options.


RELEASE NOTES END