### PR TITLE
Get upstream versions using release-monitoring.org API

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -215,7 +215,7 @@ class Upstream(PackitRepositoryBase):
             upstream, str(destination), files_to_ignore=files_to_ignore
         )
 
-    def get_latest_released_version(self) -> str:
+    def get_latest_released_version(self) -> Optional[str]:
         """
         Return version of the upstream project for the latest official release
 

--- a/packit/utils/upstream_version.py
+++ b/packit/utils/upstream_version.py
@@ -1,18 +1,38 @@
-from logging import getLogger
+import requests
 
-try:
-    from rebasehelper.plugins.plugin_manager import plugin_manager
-except ImportError:
-    from rebasehelper.versioneer import versioneers_runner
+from typing import Dict, Optional
 
 
-logger = getLogger(__name__)
+def get_upstream_version(package_name: str) -> Optional[str]:
+    """
+    Gets the latest upstream version of the specified package.
 
+    Args:
+        package_name: Package name (name of SRPM in Fedora).
 
-def get_upstream_version(package_name):
-    """Gets the latest upstream version of the specified package."""
-    try:
-        get_version = plugin_manager.versioneers.run
-    except NameError:
-        get_version = versioneers_runner.run
-    return get_version(None, package_name, None)
+    Returns:
+        The latest upstream version or None if no matching project
+        was found on release-monitoring.org.
+    """
+
+    def query(endpoint, **kwargs):
+        response = requests.get(
+            f"https://release-monitoring.org/api/{endpoint}", params=kwargs
+        )
+        if not response.ok:
+            return {}
+        return response.json()
+
+    if not package_name:
+        return None
+    result = query(f"project/Fedora/{package_name}")
+    version = result.get("version")
+    if not version:
+        # if there is no Fedora mapping, try using package name as project name
+        result = query("projects", pattern=package_name)
+        projects = result.get("projects", [])
+        project: Dict = next(
+            iter(p for p in projects if p.get("name") == package_name), {}
+        )
+        version = project.get("version")
+    return version

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -23,6 +23,7 @@ from packit.utils.repo import (
 )
 from packit.utils.commands import run_command
 from packit.utils.source_script import create_source_script
+from packit.utils.upstream_version import requests, get_upstream_version
 
 
 @pytest.mark.parametrize(
@@ -510,3 +511,53 @@ index 0000000..6178079
     assert "+a" in hunks[0]
     assert "diff --git a/b.txt b/b.txt" in hunks[1]
     assert "+b" in hunks[1]
+
+
+@pytest.mark.parametrize(
+    "package, version",
+    [
+        ("libtiff", "4.4.0"),
+        ("tiff", "4.4.0"),
+        ("python-specfile", "0.5.0"),
+        ("specfile", "0.5.0"),
+        ("python3-specfile", None),
+        ("mock", "3.1-1"),
+        ("packitos", "0.56.0"),
+        ("packit", None),
+    ],
+)
+def test_get_upstream_version(package, version):
+    def mocked_get(url, params):
+        packages = {
+            "libtiff": "tiff",
+            "python-specfile": "specfile",
+            "mock": "mock",
+        }
+        projects = {
+            "tiff": "4.4.0",
+            "specfile": "0.5.0",
+            "mock": "3.1-1",
+            "packitos": "0.56.0",
+        }
+        if url.endswith("projects"):
+            project, version = next(
+                iter(
+                    (k, v)
+                    for k, v in projects.items()
+                    if k.startswith(params["pattern"])
+                ),
+                (None, None),
+            )
+            items = [{"name": project, "version": version}] if project else []
+            return flexmock(ok=True, json=lambda: {"projects": items})
+        else:
+            package_name = url.split("/")[-1]
+            project = packages.get(package_name)
+            version = projects.get(project)
+            if version:
+                return flexmock(ok=True, json=lambda: {"version": version})
+        return flexmock(ok=False)
+
+    flexmock(requests).should_receive("get").replace_with(mocked_get)
+
+    assert get_upstream_version(package) == version


### PR DESCRIPTION
This is another step towards removing `rebasehelper` dependency.