### PR TITLE
reload specfile after running fix_spec action

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -932,6 +932,8 @@ class SRPMBuilder:
 
         Args:
             archive: Path to the archive.
+            bump_version: Should version be increased?
+            release_suffix: Append this suffix to the %release.
         """
         current_commit = self.upstream.local_project.commit_hexsha
         # the logic behind the naming:
@@ -964,6 +966,7 @@ class SRPMBuilder:
                 bump_version=bump_version,
                 release_suffix=release_suffix,
             )
+        self.upstream.specfile.reload()  # the specfile could have been changed by the action
 
     def prepare(self, bump_version: bool, release_suffix: Optional[str] = None):
         if self.upstream_ref:

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -19,7 +19,7 @@ from packit.actions import ActionName
 from packit.config import Config, get_local_package_config
 from packit.exceptions import PackitSRPMException
 from packit.local_project import LocalProject
-from packit.upstream import Archive, Upstream
+from packit.upstream import Archive, Upstream, SRPMBuilder
 from packit.utils.commands import cwd
 from packit.utils.repo import create_new_repo
 
@@ -259,6 +259,19 @@ def test_fix_spec(upstream_instance):
     release = ups.specfile.expanded_release
     # 1.20200710085501945230.master.0.g133ff39
     assert re.match(r"\d\.\d{20}\.\w+\.\d+\.g\w{7}", release)
+
+
+def test_fix_spec_persists(upstream_instance):
+    """verify that changing specfile in fix_spec action persists"""
+    _, upstream = upstream_instance
+    upstream.package_config.actions = {
+        ActionName.fix_spec: "sed -i 's/^Version:.*$/Version: 1.0.0/' beer.spec"
+    }
+    SRPMBuilder(upstream)._fix_specfile_to_use_local_archive(
+        "archive.tar.gz", bump_version=False, release_suffix="1.%dist"
+    )
+
+    assert upstream.specfile.version == "1.0.0"
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_upstream.py
+++ b/tests/unit/test_upstream.py
@@ -323,6 +323,8 @@ def test_release_suffix(
         bump_version=False,
         release_suffix=expanded_release_suffix,
     )
+    upstream_mock._specfile = flexmock()
+    upstream_mock._specfile.should_receive("reload").once()
 
     SRPMBuilder(upstream_mock)._fix_specfile_to_use_local_archive(
         archive=archive, bump_version=False, release_suffix=release_suffix


### PR DESCRIPTION
TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] also updated the docstring in the method I interacted with

fix_spec can change a specfile and if it's no reloaded the changes are
discarded

Example: https://dashboard.packit.dev/results/srpm-builds/81313

RELEASE NOTES BEGIN

Action `fix_spec_file` can change a spec file - Packit now preserves that change.

RELEASE NOTES END