### PR TITLE
Use (py)rpkg to interact with lookaside cache

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -22,12 +22,12 @@ BuildRequires:  python3-tabulate
 BuildRequires:  python3-cccolutils
 BuildRequires:  python3-copr
 BuildRequires:  python3-koji
+BuildRequires:  python3-rpkg
 BuildRequires:  python3-lazy-object-proxy
 BuildRequires:  python3-marshmallow
 BuildRequires:  python3-marshmallow-enum
 BuildRequires:  python3-requests
 BuildRequires:  python3-requests-kerberos
-BuildRequires:  rebase-helper
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(setuptools-scm)
 BuildRequires:  python3dist(setuptools-scm-git-archive)

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -313,7 +313,7 @@ class DistGit(PackitRepositoryBase):
         :return: path to the archive
         """
         with cwd(self.local_project.working_dir):
-            self.download_remote_sources()
+            self.download_remote_sources(self.config.pkg_tool)
         archive = self.absolute_source_dir / self.upstream_archive_name
         if not archive.exists():
             raise PackitException(

--- a/packit/exceptions.py
+++ b/packit/exceptions.py
@@ -79,6 +79,14 @@ class PackitMergeException(PackitException):
     """Failed to merge PR into base branch"""
 
 
+class PackitDownloadFailedException(PackitException):
+    """Failed to download file"""
+
+
+class PackitLookasideCacheException(PackitException):
+    """Problem with lookaside cache"""
+
+
 class PackitSRPMNotFoundException(PackitSRPMException):
     """SRPM created but not found"""
 

--- a/packit/utils/lookaside.py
+++ b/packit/utils/lookaside.py
@@ -1,0 +1,51 @@
+import configparser
+
+from pathlib import Path
+from typing import Dict, List, Union
+
+import pyrpkg
+
+from packit.exceptions import PackitLookasideCacheException
+
+
+def get_lookaside_sources(
+    pkg_tool: str,
+    package: str,
+    basepath: Union[Path, str],
+) -> List[Dict[str, str]]:
+    """
+    Gets URLs to sources stored in lookaside cache.
+
+    Args:
+        pkg_tool: Packaging tool associated with a lookaside cache instance
+          to be used to get the URLs.
+        package: Package name.
+        basepath: Path to a dist-git repo containing the "sources" file.
+
+    Returns:
+        List of dicts with path (filename) and URL.
+
+    Raises:
+        PackitLookasideCacheException if reading rpkg configuration or
+          parsing the "sources" file fails.
+    """
+    try:
+        parser = configparser.ConfigParser()
+        parser.read(f"/etc/rpkg/{pkg_tool}.conf")
+        config = dict(parser.items(pkg_tool, raw=True))
+        cache = pyrpkg.lookaside.CGILookasideCache(
+            config["lookasidehash"], config["lookaside"], config["lookaside_cgi"]
+        )
+        if config.get("lookaside_namespaced", False):
+            package = f"rpms/{package}"
+    except (configparser.Error, KeyError) as e:
+        raise PackitLookasideCacheException("Failed to read rpkg configuration") from e
+    try:
+        sources = pyrpkg.sources.SourcesFile(Path(basepath) / "sources", "bsd")
+    except (pyrpkg.errors.MalformedLineError, ValueError) as e:
+        raise PackitLookasideCacheException("Failed to parse sources") from e
+    result = []
+    for entry in sources.entries:
+        url = cache.get_download_url(package, entry.file, entry.hash, entry.hashtype)
+        result.append({"path": entry.file, "url": url})
+    return result

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ install_requires =
     ogr
     packaging
     python-gnupg
-    rebasehelper
     requests
     requests-kerberos
     setuptools
@@ -54,6 +53,7 @@ install_requires =
     tabulate
     bodhi-client
     koji
+    rpkg
     cachetools
     python-fedora
     typing-extensions;python_version<"3.8"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -98,7 +98,7 @@ def mock_spec_download_remote_s(
 ):
     spec_dir_path = spec_dir_path or repo_path
 
-    def mock_download_remote_sources():
+    def mock_download_remote_sources(*_):
         """mock download of the remote archive and place it into dist-git repo"""
         archive_cmd = [
             "git",

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -10,7 +10,7 @@ from flexmock import flexmock
 from pkg_resources import DistributionNotFound, Distribution
 
 from packit.api import get_packit_version
-from packit.exceptions import PackitException, ensure_str
+from packit.exceptions import PackitException, PackitLookasideCacheException, ensure_str
 from packit.utils import sanitize_branch_name, sanitize_branch_name_for_rpm
 from packit.utils.decorators import fallback_return_value
 from packit.utils.repo import (
@@ -24,6 +24,7 @@ from packit.utils.repo import (
 from packit.utils.commands import run_command
 from packit.utils.source_script import create_source_script
 from packit.utils.upstream_version import requests, get_upstream_version
+from packit.utils.lookaside import configparser, pyrpkg, get_lookaside_sources
 
 
 @pytest.mark.parametrize(
@@ -561,3 +562,124 @@ def test_get_upstream_version(package, version):
     flexmock(requests).should_receive("get").replace_with(mocked_get)
 
     assert get_upstream_version(package) == version
+
+
+@pytest.mark.parametrize(
+    "config, sources, package, result",
+    [
+        (
+            {
+                "lookaside": "https://src.fedoraproject.org/repo/pkgs",
+                "lookaside_cgi": "https://src.fedoraproject.org/repo/pkgs/upload.cgi",
+                "lookasidehash": "sha512",
+            },
+            [
+                {
+                    "file": "packitos-0.57.0.tar.gz",
+                    "hash": "27e4f97e262d7b1eb0af79ef9ea8ceae"
+                    "d024dfe7b3d7ca0141d63195e7a9d6ee"
+                    "a147d8eef919cd7919435abc5b729ca0"
+                    "4d9800a9df1c0334c6ca42a5747a8755",
+                    "hashtype": "sha512",
+                },
+            ],
+            "packit",
+            [
+                {
+                    "path": "packitos-0.57.0.tar.gz",
+                    "url": "https://src.fedoraproject.org/repo/pkgs"
+                    "/packit/packitos-0.57.0.tar.gz/sha512/"
+                    "27e4f97e262d7b1eb0af79ef9ea8ceae"
+                    "d024dfe7b3d7ca0141d63195e7a9d6ee"
+                    "a147d8eef919cd7919435abc5b729ca0"
+                    "4d9800a9df1c0334c6ca42a5747a8755"
+                    "/packitos-0.57.0.tar.gz",
+                },
+            ],
+        ),
+        (
+            {
+                "lookaside": "https://sources.stream.centos.org/sources",
+                "lookaside_cgi": "https://sources.stream.rdu2.redhat.com/lookaside/upload.cgi",
+                "lookasidehash": "sha512",
+                "lookaside_namespaced": True,
+            },
+            [
+                {
+                    "file": "man-pages-5.10.tar.xz",
+                    "hash": "a23f90136b0bf471f5ae3917ae0e558f"
+                    "ec0671cace8ccdd8e244f41f11fefa4a"
+                    "c0df84cf972cc20a1792d7b930db5e2c"
+                    "451881c0937edabf7d5e1ec46c4760ed",
+                    "hashtype": "sha512",
+                },
+                {
+                    "file": "man-pages-additional-20140218.tar.xz",
+                    "hash": "c7874db32a9bdefaea6c6be6549e6e65"
+                    "38fa1d93260bf342dd0d9821fa05754a"
+                    "a79a723e701493c81b2e1f460918429e"
+                    "b9b5edb704b55878b1e5ed585a3ff07d",
+                    "hashtype": "sha512",
+                },
+                {
+                    "file": "man-pages-posix-2017-a.tar.xz",
+                    "hash": "dac6bd5bb3e1d5f8918bad3eb15e08ee"
+                    "b3e06ae160c04ccd5619bfb0c536139a"
+                    "c06faa62b6856656a1bb9a7496f3148e"
+                    "52a5227b83e4099be6e6b93230de211d",
+                    "hashtype": "sha512",
+                },
+            ],
+            "man-pages",
+            [
+                {
+                    "path": "man-pages-5.10.tar.xz",
+                    "url": "https://sources.stream.centos.org/sources"
+                    "/rpms/man-pages/man-pages-5.10.tar.xz/sha512/"
+                    "a23f90136b0bf471f5ae3917ae0e558f"
+                    "ec0671cace8ccdd8e244f41f11fefa4a"
+                    "c0df84cf972cc20a1792d7b930db5e2c"
+                    "451881c0937edabf7d5e1ec46c4760ed"
+                    "/man-pages-5.10.tar.xz",
+                },
+                {
+                    "path": "man-pages-additional-20140218.tar.xz",
+                    "url": "https://sources.stream.centos.org/sources"
+                    "/rpms/man-pages/man-pages-additional-20140218.tar.xz/sha512/"
+                    "c7874db32a9bdefaea6c6be6549e6e65"
+                    "38fa1d93260bf342dd0d9821fa05754a"
+                    "a79a723e701493c81b2e1f460918429e"
+                    "b9b5edb704b55878b1e5ed585a3ff07d"
+                    "/man-pages-additional-20140218.tar.xz",
+                },
+                {
+                    "path": "man-pages-posix-2017-a.tar.xz",
+                    "url": "https://sources.stream.centos.org/sources"
+                    "/rpms/man-pages/man-pages-posix-2017-a.tar.xz/sha512/"
+                    "dac6bd5bb3e1d5f8918bad3eb15e08ee"
+                    "b3e06ae160c04ccd5619bfb0c536139a"
+                    "c06faa62b6856656a1bb9a7496f3148e"
+                    "52a5227b83e4099be6e6b93230de211d"
+                    "/man-pages-posix-2017-a.tar.xz",
+                },
+            ],
+        ),
+        ({}, [], "test", []),
+    ],
+)
+def test_get_lookaside_sources(config, sources, package, result):
+    flexmock(
+        configparser,
+        ConfigParser=lambda: flexmock(
+            read=lambda _: None, items=lambda _, **__: config
+        ),
+    )
+    flexmock(
+        pyrpkg.sources,
+        SourcesFile=lambda *_: flexmock(entries=[flexmock(**s) for s in sources]),
+    )
+    if "lookaside" not in config:
+        with pytest.raises(PackitLookasideCacheException):
+            get_lookaside_sources("", package, "")
+    else:
+        assert get_lookaside_sources("", package, "") == result


### PR DESCRIPTION
RELEASE NOTES BEGIN

Packit now uses (py)rpkg instead of rebasehelper to parse "sources" files in dist-git repos and to interact with lookaside cache.

RELEASE NOTES END
