### PR TITLE
Prepare sources symlinks

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1219,6 +1219,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         bump_version: bool = True,
         release_suffix: Optional[str] = None,
         result_dir: Union[Path, str] = None,
+        create_symlinks: Optional[bool] = True,
     ) -> None:
         """
         Prepare sources for an SRPM build.
@@ -1228,6 +1229,9 @@ The first dist-git commit to be synced is '{short_hash}'.
             release_suffix: specifies local release suffix. `None` represents default suffix.
             bump_version: specifies whether version should be changed in the spec-file.
             result_dir: directory where the specfile directory content should be copied
+            create_symlinks: whether symlinks should be created instead of copying the files
+                (currently when the archive is created outside the specfile dir, or in the future
+                 if we will create symlinks in some other places)
         """
         self.up.run_action(actions=ActionName.post_upstream_clone)
 
@@ -1236,6 +1240,7 @@ The first dist-git commit to be synced is '{short_hash}'.
                 upstream_ref=upstream_ref,
                 bump_version=bump_version,
                 release_suffix=release_suffix,
+                create_symlinks=create_symlinks,
             )
         except Exception as ex:
             raise PackitSRPMException(

--- a/packit/cli/prepare_sources.py
+++ b/packit/cli/prepare_sources.py
@@ -90,6 +90,13 @@ def load_job_config(job_config):
     type=click.STRING,
     help="Specifies target branch which PR should be merged into.",
 )
+@click.option(
+    "--create-symlinks/--no-create-symlinks",
+    is_flag=True,
+    default=True,
+    help="Specifies whether Packit should create symlinks or copy the "
+    "files (e.g. archive outside specfile dir).",
+)
 @click.argument(
     "path_or_url",
     type=LocalProjectParameter(
@@ -115,6 +122,7 @@ def prepare_sources(
     pr_id,
     merge_pr,
     target_branch,
+    create_symlinks,
 ):
     """
     Prepare sources for a new SRPM build using content of the upstream repository.
@@ -142,4 +150,5 @@ def prepare_sources(
         bump_version=bump,
         release_suffix=release_suffix,
         result_dir=result_dir,
+        create_symlinks=create_symlinks,
     )

--- a/packit/utils/source_script.py
+++ b/packit/utils/source_script.py
@@ -27,5 +27,8 @@ def create_source_script(
     if release_suffix:
         options += ["--release-suffix", f"'{release_suffix}'"]
 
+    # do not create symlinks in Copr environment
+    options += ["--no-create-symlinks"]
+
     options += [url]
     return COPR_SOURCE_SCRIPT.format(options=" ".join(options))

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -391,7 +391,8 @@ def test_get_message_from_metadata(metadata, header, result):
             None,
             None,
             "https://github.com/packit/ogr",
-            'packit -d prepare-sources --result-dir "$resultdir" https://github.com/packit/ogr',
+            'packit -d prepare-sources --result-dir "$resultdir" --no-create-symlinks '
+            "https://github.com/packit/ogr",
         ),
         (
             "123",
@@ -400,7 +401,7 @@ def test_get_message_from_metadata(metadata, header, result):
             None,
             None,
             "https://github.com/packit/ogr",
-            'packit -d prepare-sources --result-dir "$resultdir" --ref 123 '
+            'packit -d prepare-sources --result-dir "$resultdir" --ref 123 --no-create-symlinks '
             "https://github.com/packit/ogr",
         ),
         (
@@ -411,7 +412,7 @@ def test_get_message_from_metadata(metadata, header, result):
             None,
             "https://github.com/packit/ogr",
             'packit -d prepare-sources --result-dir "$resultdir" --pr-id 1 '
-            "--no-merge-pr https://github.com/packit/ogr",
+            "--no-merge-pr --no-create-symlinks https://github.com/packit/ogr",
         ),
         (
             None,
@@ -421,7 +422,7 @@ def test_get_message_from_metadata(metadata, header, result):
             None,
             "https://github.com/packit/ogr",
             'packit -d prepare-sources --result-dir "$resultdir" --pr-id 1 '
-            "--merge-pr --target-branch main https://github.com/packit/ogr",
+            "--merge-pr --target-branch main --no-create-symlinks https://github.com/packit/ogr",
         ),
         (
             None,
@@ -431,7 +432,8 @@ def test_get_message_from_metadata(metadata, header, result):
             0,
             "https://github.com/packit/ogr",
             'packit -d prepare-sources --result-dir "$resultdir" --pr-id 1 '
-            "--merge-pr --target-branch main --job-config-index 0 https://github.com/packit/ogr",
+            "--merge-pr --target-branch main --job-config-index 0 "
+            "--no-create-symlinks https://github.com/packit/ogr",
         ),
     ],
 )


### PR DESCRIPTION
TODO:
- [x] Update the documentation in `packit/packit.dev`.

Fixes #1637 


RELEASE NOTES BEGIN
Packit `prepare-sources` command now has the `--create-symlinks/--no-create-symlinks` option, which enables copying the archive instead of symlinking. This will be used in the Copr environment, where symlinking the archive previously caused issues.

RELEASE NOTES END
