### PR TITLE
Switch to release-monitoring.org API v2

### DIFF
--- a/packit/utils/upstream_version.py
+++ b/packit/utils/upstream_version.py
@@ -1,6 +1,6 @@
 import requests
 
-from typing import Dict, Optional
+from typing import Optional
 
 
 def get_upstream_version(package_name: str) -> Optional[str]:
@@ -16,23 +16,19 @@ def get_upstream_version(package_name: str) -> Optional[str]:
     """
 
     def query(endpoint, **kwargs):
+        kwargs["items_per_page"] = 1
         response = requests.get(
-            f"https://release-monitoring.org/api/{endpoint}", params=kwargs
+            f"https://release-monitoring.org/api/v2/{endpoint}", params=kwargs
         )
         if not response.ok:
             return {}
-        return response.json()
+        items = response.json().get("items", [])
+        return next(iter(items), {})
 
     if not package_name:
         return None
-    result = query(f"project/Fedora/{package_name}")
-    version = result.get("version")
-    if not version:
-        # if there is no Fedora mapping, try using package name as project name
-        result = query("projects", pattern=package_name)
-        projects = result.get("projects", [])
-        project: Dict = next(
-            iter(p for p in projects if p.get("name") == package_name), {}
-        )
-        version = project.get("version")
-    return version
+    result = query("packages", distribution="Fedora", name=package_name)
+    # if there is no Fedora mapping, try using package name as project name
+    project_name = result.get("project", package_name)
+    result = query("projects", name=project_name)
+    return result.get("version")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -540,24 +540,15 @@ def test_get_upstream_version(package, version):
             "mock": "3.1-1",
             "packitos": "0.56.0",
         }
-        if url.endswith("projects"):
-            project, version = next(
-                iter(
-                    (k, v)
-                    for k, v in projects.items()
-                    if k.startswith(params["pattern"])
-                ),
-                (None, None),
-            )
-            items = [{"name": project, "version": version}] if project else []
-            return flexmock(ok=True, json=lambda: {"projects": items})
+        if url.endswith("packages"):
+            project = packages.get(params["name"])
+            items = [{"project": project}] if project else []
+        elif url.endswith("projects"):
+            version = projects.get(params["name"])
+            items = [{"version": version}] if version else []
         else:
-            package_name = url.split("/")[-1]
-            project = packages.get(package_name)
-            version = projects.get(project)
-            if version:
-                return flexmock(ok=True, json=lambda: {"version": version})
-        return flexmock(ok=False)
+            return flexmock(ok=False)
+        return flexmock(ok=True, json=lambda: {"items": items})
 
     flexmock(requests).should_receive("get").replace_with(mocked_get)
 


### PR DESCRIPTION
It turns out my assumption about rate limiting on v2 API was incorrect, @Zlopez confirmed there is no rate limiting in place and I haven't been able to reproduce the test failures since, so it was most likely some sort of a temporary network hiccup.