### PR TITLE
Update the Copr exception we catch when editing Copr project

### DIFF
--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -12,6 +12,7 @@ from copr.v3.exceptions import (
     CoprNoResultException,
     CoprException,
     CoprRequestException,
+    CoprAuthException,
 )
 from munch import Munch
 
@@ -144,7 +145,7 @@ class CoprHelper:
                 self.copr_client.project_proxy.edit(
                     ownername=owner, projectname=project, **kwargs
                 )
-            except CoprRequestException as ex:
+            except CoprAuthException as ex:
                 if "Only owners and admins may update their projects." in str(ex):
                     if request_admin_if_needed:
                         logger.info(

--- a/tests/integration/test_copr_build.py
+++ b/tests/integration/test_copr_build.py
@@ -8,6 +8,7 @@ from copr.v3 import (
     CoprNoResultException,
     CoprRequestException,
     ProjectProxy,
+    CoprAuthException,
 )
 from flexmock import flexmock
 from munch import munchify
@@ -481,7 +482,7 @@ def test_copr_build_existing_project_error_on_change_settings(
     ).and_return()
 
     flexmock(ProjectProxy).should_receive("edit").and_raise(
-        CoprRequestException, "Only owners and admins may update their projects."
+        CoprAuthException, "Only owners and admins may update their projects."
     ).once()
 
     flexmock(CoprHelper).should_receive("get_copr_client").and_return(


### PR DESCRIPTION
When editing Copr projects, we have been catching CoprRequestException
and based on that handling the situation when Packit has lack of permissions
to update a Copr project. Copr API now raises CoprAuthException for this case,
therefore the exception we catch is changed here to CoprAuthException.

Fixes packit/packit-service#1613

RELEASE NOTES BEGIN

We have fixed the handling of the situation when Packit lacks permission to update a Copr project.

RELEASE NOTES END
