### PR TITLE
Remove 'dist_git_clone_path' from CommonPackageConfig

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -131,12 +131,14 @@ class PackitAPI:
         upstream_local_project: LocalProject = None,
         downstream_local_project: LocalProject = None,
         stage: bool = False,
+        dist_git_clone_path: Optional[str] = None,
     ) -> None:
         self.config = config
         self.package_config: CommonPackageConfig = package_config
         self.upstream_local_project = upstream_local_project
         self.downstream_local_project = downstream_local_project
         self.stage = stage
+        self._dist_git_clone_path: Optional[str] = dist_git_clone_path
 
         self._up: Optional[Upstream] = None
         self._dg: Optional[DistGit] = None
@@ -187,6 +189,7 @@ class PackitAPI:
                 config=self.config,
                 package_config=self.package_config,
                 local_project=self.downstream_local_project,
+                clone_path=self._dist_git_clone_path,
             )
         return self._dg
 

--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -117,15 +117,13 @@ def get_packit_api(
     else:
         package_config = PackageConfig()
 
-    if dist_git_path:
-        package_config.dist_git_clone_path = dist_git_path
-
     if dist_git_path and Path(dist_git_path) == local_project.working_dir:
         return PackitAPI(
             config=config,
             package_config=package_config,
             upstream_local_project=None,
             downstream_local_project=local_project,
+            dist_git_clone_path=dist_git_path,
         )
 
     if not local_project.git_repo:
@@ -173,6 +171,7 @@ def get_packit_api(
         package_config=package_config,
         upstream_local_project=lp_upstream,
         downstream_local_project=lp_downstream,
+        dist_git_clone_path=dist_git_path,
     )
 
 

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -63,7 +63,6 @@ class CommonPackageConfig:
             stored.
         dist_git_namespace: Namespace in dist-git where the downstream package
             is stored.
-        dist_git_clone_path:
         actions: Custom steps used during different operations.
         upstream_ref: The ref used for the last upstream release.
         allowed_gpg_keys: GPG-key fingerprints allowed to sign commits to be
@@ -207,8 +206,6 @@ class CommonPackageConfig:
         self.dist_git_namespace: str = dist_git_namespace or getenv(
             "DISTGIT_NAMESPACE", DISTGIT_NAMESPACE
         )
-        # path to a local git clone of the dist-git repo; None means to clone in a tmpdir
-        self.dist_git_clone_path: Optional[str] = None
         self.actions = actions or {}
         self.upstream_ref: Optional[str] = upstream_ref
         self.allowed_gpg_keys = allowed_gpg_keys


### PR DESCRIPTION
'dist_git_clone_path' is a context dependent value, so instead of
storing and passing around in the package configuration, turn it into an
argument.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.

Related to #1616.
