### PR TITLE
Force clean workdir after propose downstream

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -858,7 +858,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         finally:
             if not use_local_content and not upstream_ref:
                 logger.info(f"Checking out the original branch {current_up_branch}.")
-                self.up.local_project.git_repo.git.checkout(current_up_branch)
+                self.up.local_project.git_repo.git.checkout(current_up_branch, "-f")
             self.dg.refresh_specfile()
             self.dg.local_project.git_repo.git.reset("--hard", "HEAD")
         return pr


### PR DESCRIPTION
While in a propose downstream task, sources in repo can be changed by user actions.
After task is completed, force switch to the main repo branch.

Fixes packit/packit-service#1580


RELEASE NOTES BEGIN

No more annoying issues will be created after a successfull propose downstream.

RELEASE NOTES END
