### PR TITLE
more descriptive log in download_upstream_archive()

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -320,7 +320,8 @@ class DistGit(PackitRepositoryBase):
         if not archive.exists():
             raise PackitException(
                 "Upstream archive was not downloaded. Check that {} exists in dist-git.".format(
-                    self.upstream_archive_name)
+                    self.upstream_archive_name
+                )
             )
         return archive
 

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -313,14 +313,15 @@ class DistGit(PackitRepositoryBase):
 
         :return: path to the archive
         """
+        logger.info(f"Downloading archive: {self.upstream_archive_name}")
         with cwd(self.local_project.working_dir):
             self.download_remote_sources(self.config.pkg_tool)
         archive = self.absolute_source_dir / self.upstream_archive_name
         if not archive.exists():
             raise PackitException(
-                "Upstream archive was not downloaded, something is wrong."
+                "Upstream archive was not downloaded. Check that {} exists in dist-git.".format(
+                    self.upstream_archive_name)
             )
-        logger.info(f"Downloaded archive: {archive}")
         return archive
 
     def download_source_files(self, pkg_tool: str = ""):


### PR DESCRIPTION
instead of previous

```
2022-08-25 11:39:52.881 api.py            INFO   Using 'rawhide' dist-git branch.
100%[=============================>]    42.37K  eta 00:00:00
2022-08-25 11:40:00.760 utils.py          ERROR  Upstream archive was not downloaded. Something is wrong.
```
it now prints
```
2022-08-25 11:39:52.881 api.py            INFO   Using 'rawhide' dist-git branch.
100%[=============================>]    42.37K  eta 00:00:00
2022-08-25 11:40:00.593 distgit.py        INFO   Downloading archive: fedora-license-data-1.2.tar.gz
2022-08-25 11:40:00.760 utils.py          ERROR  Upstream archive was not downloaded. Check that fedora-license-data-1.2.tar.gz exists in dist-git.
```
RELEASE NOTES BEGIN

packit propose-downstream is now more informative when sources cannot be downloaded.

RELEASE NOTES END
