### PR TITLE
Create a copr build timeout exception

### DIFF
--- a/packit/exceptions.py
+++ b/packit/exceptions.py
@@ -62,6 +62,10 @@ class PackitCoprSettingsException(PackitException):
         super().__init__(*args)
 
 
+class PackitCoprBuildTimeoutException(PackitException):
+    """Copr build has timed out"""
+
+
 class PackitInvalidConfigException(PackitConfigException):
     """provided configuration file is not valid"""
 


### PR DESCRIPTION
It just creates a new Exception to be used in packit-service.

Related to packit/packit#1450

Merge before packit/packit-service#1632
