### PR TITLE
Get packit forge projects allowed in copr method

### DIFF
--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -396,3 +396,15 @@ class CoprHelper:
             raise PackitCoprProjectException(
                 f"There is no such target {chroot} in {owner}/{project}."
             )
+
+    def get_packit_forge_projects_allowed(self, owner: str, project: str) -> str:
+        """Get a str with a list of the allowed packit forge projects"""
+        copr_proj = self.copr_client.project_proxy.get(
+            ownername=owner, projectname=project
+        )
+        try:
+            return copr_proj["packit_forge_projects_allowed"]
+        except KeyError:
+            raise PackitCoprProjectException(
+                f"There is no such key 'packit_forge_projects_allowed' in {owner}/{project}."
+            )


### PR DESCRIPTION
TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.

Fixes packit/packit-service#1523

Merge before packit/packit-service#1638
