### PR TITLE
Account for pagination in Bodhi API

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1610,14 +1610,21 @@ The first dist-git commit to be synced is '{short_hash}'.
 
     def get_testing_updates(self, update_alias: Optional[str]) -> List:
         bodhi_client = get_bodhi_client()
-        results = bodhi_client.query(
-            alias=update_alias,
-            packages=self.dg.package_config.downstream_package_name,
-            status="testing",
-        )["updates"]
+        updates = []
+        page = pages = 1
+        while page <= pages:
+            results = bodhi_client.query(
+                alias=update_alias,
+                packages=self.dg.package_config.downstream_package_name,
+                status="testing",
+                page=page,
+            )
+            updates.extend(results["updates"])
+            page += 1
+            pages = results["pages"]
         logger.debug("Bodhi updates with status 'testing' fetched.")
 
-        return results
+        return updates
 
     @staticmethod
     def days_in_testing(update) -> int:

--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -239,12 +239,16 @@ def get_aliases() -> Dict[str, List[str]]:
         Dictionary containing aliases.
     """
     bodhi_client = get_bodhi_client()
-    releases = bodhi_client.get_releases(exclude_archived=True)
+    releases = []
+    page = pages = 1
+    while page <= pages:
+        results = bodhi_client.get_releases(exclude_archived=True, page=page)
+        releases.extend(results.releases)
+        page += 1
+        pages = results.pages
     current_fedora_releases, pending_fedora_releases, epel_releases = [], [], []
 
-    for release in filter(
-        lambda r: r.state in ["current", "pending"], releases.releases
-    ):
+    for release in filter(lambda r: r.state in ["current", "pending"], releases):
         if release.id_prefix == "FEDORA" and release.name != "ELN":
             name = release.long_name.lower().replace(" ", "-")
             if release.state == "current":

--- a/packit/status.py
+++ b/packit/status.py
@@ -132,20 +132,27 @@ class Status:
         :return: None
         """
         bodhi_client = get_bodhi_client()
-        results = bodhi_client.query(
-            packages=self.dg.package_config.downstream_package_name
-        )["updates"]
+        updates = []
+        page = pages = 1
+        while page <= pages:
+            results = bodhi_client.query(
+                packages=self.dg.package_config.downstream_package_name,
+                page=page,
+            )
+            updates.extend(results["updates"])
+            page += 1
+            pages = results["pages"]
         logger.debug("Bodhi updates fetched.")
 
         stable_branches: Set[str] = set()
         all_updates = [
             [
-                result["title"],
-                result["karma"],
-                result["status"],
-                result["release"]["branch"],
+                update["title"],
+                update["karma"],
+                update["status"],
+                update["release"]["branch"],
             ]
-            for result in results
+            for update in updates
         ]
         updates = []
         for [update, karma, status, branch] in all_updates:

--- a/tests/integration/test_push_updates.py
+++ b/tests/integration/test_push_updates.py
@@ -193,7 +193,9 @@ def query_response():
                         "test_cases": [],
                     }
                 )
-            ]
+            ],
+            "page": 1,
+            "pages": 1,
         }
     )
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -27,7 +27,7 @@ def bodhi_client_response():
             }
             for name, long_name, id_prefix, state in releases_list
         ]
-        response = {"releases": releases}
+        response = {"releases": releases, "page": 1, "pages": 1}
         return munchify(response)
 
     return response_factory

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -10,7 +10,7 @@ from packit.utils.bodhi import OurBodhiClient
 def test_status_updates(config_mock, package_config_mock, upstream_mock, distgit_mock):
     flexmock(
         OurBodhiClient,
-        query=lambda packages: {
+        query=lambda packages, page: {
             "updates": [
                 {
                     "title": "python-requre-0.8.1-2.fc33",
@@ -24,7 +24,9 @@ def test_status_updates(config_mock, package_config_mock, upstream_mock, distgit
                     "status": "stable",
                     "release": {"branch": "f34"},
                 },
-            ]
+            ],
+            "page": 1,
+            "pages": 1,
         },
     )
 


### PR DESCRIPTION
Results of Bodhi API queries can be paginated, in such case it is necessary to retrieve all pages.

Fixes: packit/packit-service#1642