### PR TITLE
Remove the spaces from a Kanban board name

### DIFF
--- a/.github/workflows/opened-issues-to-the-board.yml
+++ b/.github/workflows/opened-issues-to-the-board.yml
@@ -10,6 +10,6 @@ jobs:
     steps:
       - uses: alex-page/github-project-automation-plus@v0.8.1
         with:
-          project: "Packit Kanban Board"
+          project: "PackitKanbanBoard"
           column: new
           repo-token: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
So we try it is not an issue when trying to find it. (https://github.com/packit/packit/runs/8208141368?check_suite_focus=true)

Signed-off-by: Frantisek Lachman <flachman@redhat.com>