### PR TITLE
Deprecate `production_build` in favour of `upstream_koji_build`

### DIFF
--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -17,14 +17,31 @@ class JobType(Enum):
     """Type of the job used by users in the config"""
 
     propose_downstream = "propose_downstream"
-    build = "build"
+    pull_from_upstream = "pull_from_upstream"
+    build = "build"  # deprecated
     sync_from_downstream = "sync_from_downstream"
     copr_build = "copr_build"
-    production_build = "production_build"  # upstream koji build
+    production_build = "production_build"  # deprecated
+    upstream_koji_build = "upstream_koji_build"
     koji_build = "koji_build"  # downstream koji build
     tests = "tests"
     bodhi_update = "bodhi_update"
     vm_image_build = "vm_image_build"
+
+
+DEPRECATED_JOB_TYPES = {
+    JobType.build: "The `build` job type aimed to be an alias for "
+    "`copr_build` when Packit supported just one "
+    "build type. "
+    "There are currently more types of builds and just `build` can be misleading. "
+    "Please, be explicit and use `copr_build` instead.",
+    JobType.production_build: "The `production_build` name for upstream Koji build is misleading "
+    "because it is not used to run production/non-scratch builds and "
+    "because it can be confused with the `koji_build` job that is triggered for dist-git commits. "
+    "(The `koji_build` job can trigger both scratch and non-scratch/production builds.) "
+    "To be explicit, use `upstream_koji_build` for builds triggered in upstream "
+    "and `koji_build` for builds triggered in downstream.",
+}
 
 
 class JobConfigTriggerType(Enum):

--- a/tests/integration/test_get_api.py
+++ b/tests/integration/test_get_api.py
@@ -164,7 +164,7 @@ def test_url_is_upstream():
                 ("origin", "git@github.com:user/ogr.git"),
             ],
             JobConfig(
-                type=JobType.build,
+                type=JobType.copr_build,
                 trigger=JobConfigTriggerType.pull_request,
                 upstream_project_url="https://github.com/packit/ogr",
             ),

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -19,14 +19,16 @@ from packit.schema import JobConfigSchema, JobMetadataSchema
 
 
 def get_job_config_dict_simple(**update):
-    result = {"job": "build", "trigger": "release"}
+    result = {"job": "copr_build", "trigger": "release"}
     result.update(update)
     return result
 
 
 def get_job_config_simple(**kwargs):
     """pass kwargs to JobConfig constructor"""
-    return JobConfig(type=JobType.build, trigger=JobConfigTriggerType.release, **kwargs)
+    return JobConfig(
+        type=JobType.copr_build, trigger=JobConfigTriggerType.release, **kwargs
+    )
 
 
 @pytest.fixture()

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -943,7 +943,7 @@ def test_package_config_parse(raw, expected):
                 "specfile_path": "fedora/package.spec",
                 "jobs": [
                     {
-                        "job": "build",
+                        "job": "copr_build",
                         "trigger": "release",
                         "specfile_path": "somewhere/package.spec",
                     }
@@ -953,7 +953,7 @@ def test_package_config_parse(raw, expected):
                 specfile_path="fedora/package.spec",
                 jobs=[
                     JobConfig(
-                        type=JobType.build,
+                        type=JobType.copr_build,
                         trigger=JobConfigTriggerType.release,
                         specfile_path="somewhere/package.spec",
                     )
@@ -970,7 +970,7 @@ def test_package_config_parse(raw, expected):
                 "targets": ["fedora-36"],
                 "jobs": [
                     {
-                        "job": "build",
+                        "job": "copr_build",
                         "trigger": "release",
                         "specfile_path": "somewhere/package.spec",
                         "files_to_sync": ["a", "b", "c"],
@@ -986,7 +986,7 @@ def test_package_config_parse(raw, expected):
                 _targets=["fedora-36"],
                 jobs=[
                     JobConfig(
-                        type=JobType.build,
+                        type=JobType.copr_build,
                         trigger=JobConfigTriggerType.release,
                         specfile_path="somewhere/package.spec",
                         files_to_sync=[SyncFilesItem([x], x) for x in ("a", "b", "c")],


### PR DESCRIPTION
Deprecate also the `build` alias since it's too generic.

Signed-off-by: Frantisek Lachman <flachman@redhat.com>

Related to: #1658
Merge before: packit/packit-service#1656

... no release notes here, will be covered in the service PR