### PR TITLE
Fix(distgit): make method get_latest_build_in_tag to be static

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -411,7 +411,8 @@ class DistGit(PackitRepositoryBase):
         )
         pkg_tool.build(scratch=scratch, nowait=nowait, koji_target=koji_target)
 
-    def get_latest_build_in_tag(self, downstream_package_name, dist_git_branch):
+    @staticmethod
+    def get_latest_build_in_tag(downstream_package_name, dist_git_branch):
         """Query Koji for the latest build of a package in a tag.
 
         Args:


### PR DESCRIPTION
see the first point in [this comment](https://github.com/packit/packit-service/pull/1654#issuecomment-1248236973)

Related to [packit-service#1654](https://github.com/packit/packit-service/pull/1654)
