### PR TITLE
Smoke-test wheel creation from sdist

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,7 +19,7 @@ jobs:
         # https://pypa-build.readthedocs.io
         run: |
           python -m pip install build
-          python -m build --sdist --wheel
+          python -m build
 
       - name: Publish 📦 to PyPI
         # https://github.com/pypa/gh-action-pypi-publish


### PR DESCRIPTION
When `python -m build` is invoked with `--sdist` and/or `--wheel` args, both artifacts get created from source. This is bad because it differs from what pip does when it needs to build a package from the source distribution before installation.

Without said args, the `build` tool will first create an sdist from your Git checkout and then, it'll create a wheel out of that tarball, just like pip does. This helps catch cases when the contents of sdist is not enough to produce a working binary distribution, or when the resulting artifact differs a lot from the result of a build derived from a Git checkout.

This patch addresses the above issue per the best practices.