### PR TITLE
Drop support for EPEL 8 and Python < 3.9

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -39,7 +39,6 @@ jobs:
     # Use the stage instance once it works in downstream.
     dist_git_branches:
       - fedora-all
-      - epel-8
       - epel-9
 
   - job: sync_from_downstream
@@ -49,13 +48,11 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-stable
-      - epel-8
       - epel-9
   - job: tests
     trigger: pull_request
     targets:
       - fedora-stable
-      - epel-8
       - epel-9
 
   - job: copr_build
@@ -63,7 +60,6 @@ jobs:
     branch: main
     targets:
       - fedora-stable
-      - epel-8
       - epel-9
     project: packit-dev
     list_on_homepage: True
@@ -74,7 +70,6 @@ jobs:
     branch: stable
     targets:
       - fedora-stable
-      - epel-8
       - epel-9
     project: packit-stable
     list_on_homepage: True
@@ -84,7 +79,6 @@ jobs:
     trigger: release
     targets:
       - fedora-stable
-      - epel-8
       - epel-9
     project: packit-releases
     list_on_homepage: True
@@ -97,7 +91,6 @@ jobs:
     allowed_pr_authors: ["packit-stg", "packit"]
     dist_git_branches:
       - fedora-all
-      - epel-8
       - epel-9
 
   - job: bodhi_update
@@ -105,7 +98,6 @@ jobs:
     packit_instances: ["stg"]
     dist_git_branches:
       - fedora-branched
-      - epel-8
       - epel-9
 #  - job: vm_image_build
 #    trigger: pull_request

--- a/packit/api.py
+++ b/packit/api.py
@@ -20,6 +20,7 @@ from typing import (
     Sequence,
     Callable,
     List,
+    Literal,
     Tuple,
     Dict,
     Iterable,
@@ -28,13 +29,7 @@ from typing import (
     overload,
 )
 
-# Literal is available only since Python3.8, workaround for el8
 from packit.vm_image_build import ImageBuilder
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 import git
 from git.exc import GitCommandError

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,11 +17,9 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Software Development
     Topic :: Utilities
 keywords =
@@ -56,8 +54,7 @@ install_requires =
     rpkg
     cachetools
     python-fedora
-    typing-extensions;python_version<"3.8"
-python_requires = >=3.6
+python_requires = >=3.9
 include_package_data = True
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
RELEASE NOTES BEGIN
Packit now requires Python 3.9 or later.
RELEASE NOTES END
