### PR TITLE
fix(bodhi): properly authenticate via kerberos with bodhi 6

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1572,11 +1572,18 @@ The first dist-git commit to be synced is '{short_hash}'.
             build_id=build_id, timeout=timeout, report_func=report_func
         )
 
-    @staticmethod
-    def push_bodhi_update(update_alias: str):
+    def push_bodhi_update(self, update_alias: str):
+        """Push selected bodhi update from testing to stable."""
         from bodhi.client.bindings import UpdateNotFound
 
-        bodhi_client = get_bodhi_client()
+        bodhi_client = get_bodhi_client(
+            fas_username=self.config.fas_user,
+            fas_password=self.config.fas_password,
+            kerberos_realm=self.config.kerberos_realm,
+        )
+        # make sure we have the credentials
+        bodhi_client.login_with_kerberos()
+        bodhi_client.ensure_auth()
         try:
             response = bodhi_client.request(update=update_alias, request="stable")
             logger.debug(f"Bodhi response:\n{response}")

--- a/packit/cli/create_update.py
+++ b/packit/cli/create_update.py
@@ -41,6 +41,11 @@ class BugzillaIDs(click.ParamType):
     "(defaults to repo's default branch)",
 )
 @click.option(
+    "--dist-git-path",
+    help="Path to dist-git repo to work in. "
+    "Otherwise clone the repo in a temporary directory.",
+)
+@click.option(
     "--koji-build",
     help="Koji build (NVR) to add to the bodhi update (can be specified multiple times)",
     required=False,
@@ -75,6 +80,7 @@ class BugzillaIDs(click.ParamType):
 def create_update(
     config,
     dist_git_branch,
+    dist_git_path,
     koji_build,
     update_notes,
     update_type,
@@ -87,7 +93,9 @@ def create_update(
     PATH_OR_URL argument is a local path or a URL to the upstream git repository,
     it defaults to the current working directory
     """
-    api = get_packit_api(config=config, local_project=path_or_url)
+    api = get_packit_api(
+        config=config, dist_git_path=dist_git_path, local_project=path_or_url
+    )
     default_dg_branch = api.dg.local_project.git_project.default_branch
     dist_git_branch = dist_git_branch or default_dg_branch
     branches_to_update = get_branches(

--- a/packit/utils/bodhi.py
+++ b/packit/utils/bodhi.py
@@ -59,7 +59,8 @@ class OurBodhiClient(BodhiClient):
             super().__init__()
             # in our openshift deployment, ~/.config is not writable, but $HOME is
             # so let's put the token there
-            # TODO: make this properly configurable in bodhi
+            # TODO: implement once bodhi 6.1 will be out:
+            #       https://github.com/fedora-infra/bodhi/pull/4603
             if not os.access(self.oidc.storage.path, os.W_OK):
                 self.oidc.storage.path = os.path.join(
                     os.environ["HOME"], "bodhi-client.json"

--- a/packit/utils/bodhi.py
+++ b/packit/utils/bodhi.py
@@ -81,14 +81,8 @@ class OurBodhiClient(BodhiClient):
     def ensure_auth(self):
         """clear existing authentication data and obtain new"""
         if self.is_bodhi_6:
-            self.clear_auth()
-            logger.info("Bodhi OIDC authentication follows.")
-            if self.fas_username and self.kerberos_realm:
-                # using local TGT to authenticate with id.fp.o
-                self.login_with_kerberos()
-            else:
-                # terminal prompt
-                super().ensure_auth()
+            # DO NOT TRY to be smart here: let all the authentication up to bodhi
+            super().ensure_auth()
         else:
             self._session.cookies.clear()
             self.csrf_token = None
@@ -108,6 +102,7 @@ class OurBodhiClient(BodhiClient):
         Raises:
             PackitException if there is a problem during the auth process
         """
+        logger.info("Obtain OIDC authentication token via Kerberos.")
         authorization_endpoint = self.oidc.metadata["authorization_endpoint"]
         uri, state_ = self.oidc.client.create_authorization_url(authorization_endpoint)
         response = requests.get(

--- a/tests/integration/test_create_update.py
+++ b/tests/integration/test_create_update.py
@@ -284,6 +284,7 @@ def test_basic_bodhi_update(
         OurBodhiClient,
         save=lambda **kwargs: bodhi_response,
         ensure_auth=lambda: None,  # this is where the browser/OIDC fun happens
+        login_with_kerberos=lambda: None,
     )
 
     api.create_update(
@@ -343,6 +344,8 @@ def test_bodhi_update_with_bugs(
                 "bugs": ["1", "2", "3"],
             },
         ),
+        ensure_auth=lambda: None,
+        login_with_kerberos=lambda: None,
     )
     flexmock(OurBodhiClient).should_receive("login_with_kerberos").and_return(None)
 
@@ -377,6 +380,7 @@ def test_bodhi_update_auth_with_fas(
         latest_builds=lambda package: latest_builds_from_koji,
         save=lambda **kwargs: bodhi_response,
         ensure_auth=lambda: None,
+        login_with_kerberos=lambda: None,
     )
 
     api.create_update(

--- a/tests/integration/test_push_updates.py
+++ b/tests/integration/test_push_updates.py
@@ -5,6 +5,8 @@ import pytest
 from flexmock import flexmock
 from munch import Munch
 
+from packit.utils.bodhi import OurBodhiClient
+
 
 @pytest.fixture()
 def query_response():
@@ -402,5 +404,11 @@ def test_push_updates(
     BodhiClient.should_receive("request").with_args(
         update="FEDORA-2019-89c99f680c", request="stable"
     ).and_return(request_response).once()
+
+    flexmock(
+        OurBodhiClient,
+        ensure_auth=lambda: None,  # this is where the browser/OIDC fun happens
+        login_with_kerberos=lambda: None,
+    )
 
     api.push_updates()


### PR DESCRIPTION
TL;DR upstream bodhi.ensure_auth caches an auth cookie and this is
required for the auth to work properly

long story: since the upstream ensure_auth() was not run, bodhi_client
and bodhi_server did not treated us as authenticated, hence the error
message:

    Unauthorized: new_update__POST failed permission check...

Therefore, after we login via kerberos, we need to complete the
authentication with upstream bodhi_client.ensure_auth to obtain the auth
cookie.

There is also no point in being smart about the auth process as bodhi
handles it completely.

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.

Fixes packit/packit-service#1681

RELEASE NOTES BEGIN

Packit can now correctly authenticate with Bodhi 6 and therefore create Bodhi updates. 🚀

RELEASE NOTES END