### PR TITLE
fix(bodhi kerberos auth): use only when configured

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1581,8 +1581,10 @@ The first dist-git commit to be synced is '{short_hash}'.
             fas_password=self.config.fas_password,
             kerberos_realm=self.config.kerberos_realm,
         )
+        # only use Kerberos when fas_user and kerberos_realm are set
+        if self.config.fas_user and self.config.kerberos_realm:
+            bodhi_client.login_with_kerberos()
         # make sure we have the credentials
-        bodhi_client.login_with_kerberos()
         bodhi_client.ensure_auth()
         try:
             response = bodhi_client.request(update=update_alias, request="stable")

--- a/packit/cli/create_update.py
+++ b/packit/cli/create_update.py
@@ -90,6 +90,14 @@ def create_update(
     """
     Create a bodhi update for the selected upstream project
 
+    If you are not authenticated with the bodhi server, please make sure that you
+    navigate in your browser to the URL provided by the bodhi-client and then paste
+    the `code=XX...` to the terminal when prompted.
+
+    If you set `fas_user` and `kerberos_realm` in your "~/.config/packit.yaml" and
+    have an active Kerberos TGT, you will be automatically authenticated. Otherwise,
+    you need to follow the prompt
+
     PATH_OR_URL argument is a local path or a URL to the upstream git repository,
     it defaults to the current working directory
     """

--- a/packit/cli/push_updates.py
+++ b/packit/cli/push_updates.py
@@ -28,6 +28,13 @@ def push_updates(update_alias, config, path_or_url):
     Find all Bodhi updates that have been in testing for more than 'Stable days' (7 by default)
     and push them to stable.
 
+    If you are not authenticated with the bodhi server, please make sure that you
+    navigate in your browser to the URL provided by the bodhi-client and then paste
+    the `code=XX...` to the terminal when prompted.
+
+    If you set `fas_user` and `kerberos_realm` in your "~/.config/packit.yaml" and
+    have an active Kerberos TGT, you will be automatically authenticated. Otherwise,
+    you need to follow the prompt
     """
     api = get_packit_api(config=config, local_project=path_or_url)
     api.push_updates(update_alias)

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -472,8 +472,10 @@ class DistGit(PackitRepositoryBase):
             fas_password=self.config.fas_password,
             kerberos_realm=self.config.kerberos_realm,
         )
+        # only use Kerberos when fas_user and kerberos_realm are set
+        if self.config.fas_user and self.config.kerberos_realm:
+            bodhi_client.login_with_kerberos()
         # make sure we have the credentials
-        bodhi_client.login_with_kerberos()
         bodhi_client.ensure_auth()
 
         if not koji_builds:
@@ -503,7 +505,8 @@ class DistGit(PackitRepositoryBase):
                     f"Bodhi client raised a login error: {ex}. "
                     f"Let's clear the session, csrf token and retry."
                 )
-                bodhi_client.login_with_kerberos()
+                if self.config.fas_user and self.config.kerberos_realm:
+                    bodhi_client.login_with_kerberos()
                 bodhi_client.ensure_auth()
                 result = bodhi_client.save(**save_kwargs)
 


### PR DESCRIPTION
only use Kerberos when fas_user and kerberos_realm are set in user's
packit.yaml

In theory, we could check if kerberos session is active but let's keep
this strict in the meantime.

- [x] Update or write new documentation in `packit/packit.dev`. https://github.com/packit/packit.dev/pull/543

Blocks #1748

No release notes as this bug wasn't released to users.

RELEASE NOTES BEGIN

N/A

RELEASE NOTES END