### PR TITLE
Fix release_suffix behaviour

### DIFF
--- a/packit/utils/changelog_helper.py
+++ b/packit/utils/changelog_helper.py
@@ -146,7 +146,7 @@ class ChangelogHelper:
         version: str,
         commit: str,
         bump_version: bool,
-        release_suffix: Optional[str],
+        release: str,
     ) -> None:
         """
         Updates changelog when creating SRPM within upstream repository.
@@ -165,13 +165,10 @@ class ChangelogHelper:
             # no describe, no tag - just a boilerplate message w/ commit hash
             # or, there were no changes b/w HEAD and last_tag, which implies last_tag == HEAD
             msg = f"- Development snapshot ({commit})"
-        release = self.up.get_spec_release(
-            bump_version=bump_version,
-            release_suffix=release_suffix,
-        )
-        logger.debug(f"Setting Release in spec to {release!r}.")
         # instead of changing version, we change Release field
         # upstream projects should take care of versions
-        self.up.specfile.set_version_and_release(version, release)
+        if bump_version:
+            logger.debug(f"Setting Release in spec to {release!r}.")
+            self.up.specfile.set_version_and_release(version, release)
         if msg is not None:
             self.up.specfile.add_changelog_entry(msg)

--- a/tests/integration/test_changelog_helper.py
+++ b/tests/integration/test_changelog_helper.py
@@ -42,7 +42,7 @@ def test_srpm_action(upstream, downstream):
     ChangelogHelper(upstream, downstream, package_config).prepare_upstream_locally(
         "0.1.0", "abc123a", True, None
     )
-    with upstream._specfile.sections() as sections:
+    with upstream.specfile.sections() as sections:
         assert "- hello from test_srpm_action" in sections.changelog
 
 
@@ -51,7 +51,7 @@ def test_srpm_commits(upstream, downstream):
     ChangelogHelper(upstream, downstream, package_config).prepare_upstream_locally(
         "0.1.0", "abc123a", True, None
     )
-    with upstream._specfile.sections() as sections:
+    with upstream.specfile.sections() as sections:
         assert "- Development snapshot (abc123a)" in sections.changelog
 
 
@@ -62,7 +62,7 @@ def test_srpm_no_tags(upstream, downstream):
     ChangelogHelper(upstream, downstream, package_config).prepare_upstream_locally(
         "0.1.0", "abc123a", True, None
     )
-    with upstream._specfile.sections() as sections:
+    with upstream.specfile.sections() as sections:
         assert "- Development snapshot (abc123a)" in sections.changelog
 
 
@@ -73,7 +73,7 @@ def test_srpm_no_bump(upstream, downstream):
     ChangelogHelper(upstream, downstream, package_config).prepare_upstream_locally(
         "0.1.0", "abc123a", False, None
     )
-    with upstream._specfile.sections() as sections:
+    with upstream.specfile.sections() as sections:
         assert "- Development snapshot (abc123a)" not in sections.changelog
 
 

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -257,7 +257,12 @@ def test_fix_spec(upstream_instance):
 
     ups.package_config.upstream_package_name = "beer"
     archive = ups.create_archive()
-    ups.fix_spec(archive=archive, version="_1.2.3", commit="_abcdef123")
+    ups.fix_spec(
+        archive=archive,
+        version="_1.2.3",
+        commit="_abcdef123",
+        release_suffix="1.20200710085501945230.master.0.g133ff39",
+    )
 
     release = ups.specfile.expanded_release
     # 1.20200710085501945230.master.0.g133ff39


### PR DESCRIPTION
Fixes packit#1695

The actual behaviour table: https://gist.github.com/majamassarini/f2ebf6a78ca8af189208e77074a16dff

RELEASE NOTES BEGIN

Version and revision are no more updated in  `SPEC` files when the `--no-bump` flag is specified and `None` revisions are no more created.

RELEASE NOTES END
