### PR TITLE
fix: accept a missing 'specfile_path' in test-only jobs

### DIFF
--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -64,6 +64,7 @@ class JobConfig(MultiplePackages):
         type: JobType,
         trigger: JobConfigTriggerType,
         packages: Dict[str, CommonPackageConfig],
+        skip_build: bool = False,
     ):
         super().__init__(packages)
         # Directly manipulating __dict__ is not recommended.
@@ -72,6 +73,7 @@ class JobConfig(MultiplePackages):
         # dropped from config objects.
         self.__dict__["type"] = type
         self.__dict__["trigger"] = trigger
+        self.__dict__["skip_build"] = skip_build
 
     def __repr__(self):
         # required to avoid cyclical imports

--- a/tests/unit/test_package_config.py
+++ b/tests/unit/test_package_config.py
@@ -1843,7 +1843,6 @@ def test_package_config_specfile_not_present_raise(raw):
     "raw",
     [
         {
-            "downstream_package_name": "package",
             "jobs": [
                 {
                     "job": "tests",
@@ -1854,7 +1853,6 @@ def test_package_config_specfile_not_present_raise(raw):
             ],
         },
         {
-            "downstream_package_name": "package",
             "jobs": [
                 {
                     "job": "tests",
@@ -1865,15 +1863,23 @@ def test_package_config_specfile_not_present_raise(raw):
                 {
                     "job": "tests",
                     "trigger": "pull_request",
-                    "targets": ["fedora-stable", "fedora-development"],
-                    "skip_build": True,
+                    "metadata": {
+                        "targets": ["fedora-stable", "fedora-development"],
+                        "skip_build": True,
+                    },
                 },
             ],
         },
     ],
 )
-def test_package_config_specilfe_not_present_not_raise(raw):
-    assert PackageConfig.get_from_dict(raw_dict=raw)
+def test_specfile_path_not_defined_in_test_only_jobs(raw):
+    """Packages in test jobs, which are configured to not to require building
+    a package don't need a 'specfile_path' set.
+
+    Note: don't set 'downstream_package_name' either, as that implicitly sets
+    'specfile_path' :-)
+    """
+    assert PackageConfig.get_from_dict(raw_dict=raw, repo_name="package")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_prepare_sources.py
+++ b/tests/unit/test_prepare_sources.py
@@ -15,6 +15,7 @@ from packit.config import CommonPackageConfig, JobConfig, JobType, JobConfigTrig
             {
                 "job": "copr_build",
                 "trigger": "release",
+                "skip_build": false,
                 "packages": {
                     "package": {
                         "upstream_package_name": null,
@@ -38,7 +39,6 @@ from packit.config import CommonPackageConfig, JobConfig, JobType, JobConfigTrig
                         "additional_repos": [],
                         "env": {},
                         "additional_packages": [],
-                        "skip_build": false,
                         "scratch": false,
                         "targets": {},
                         "fmf_url": null,


### PR DESCRIPTION
This was the case before, but the latest revamp if the configuration schema and classes caused it to regress. Tests did not catch it because 'downstream_package_name' was set, which caused 'specfile_path' to be implicitly set.

Resolves #1767.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.

RELEASE NOTES BEGIN

Fixed a regression in configuration schema, which caused test-only job configs without a 'specfile_path' to be considered invalid.

RELEASE NOTES END
