### PR TITLE
Multi-source RPM support in propose-downstream

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1107,10 +1107,7 @@ The first dist-git commit to be synced is '{short_hash}'.
                 and upstream_archive_name in sources_file.read_text()
             )
 
-            if (
-                archive_name_in_cache
-                and archive_name_in_sources_file
-            ):
+            if archive_name_in_cache and archive_name_in_sources_file:
                 continue
             else:
                 archives_to_upload = True

--- a/packit/api.py
+++ b/packit/api.py
@@ -1094,8 +1094,6 @@ The first dist-git commit to be synced is '{short_hash}'.
             pkg_tool: Tool to upload sources.
         """
 
-        # btw this is really naive: the name could be the same but the hash can be different
-        # TODO: we should do something when such situation happens
         archives_to_upload = False
         sources_file = self.dg.local_project.working_dir / "sources"
         for upstream_archive_name in self.dg.upstream_archive_names:

--- a/packit/api.py
+++ b/packit/api.py
@@ -935,9 +935,12 @@ The first dist-git commit to be synced is '{short_hash}'.
     def _prepare_files_to_sync(
         self, synced_files: List[SyncFilesItem], full_version: str, upstream_tag: str
     ) -> List[SyncFilesItem]:
-        """Update the spec-file by setting the version and updating the changelog
+        """
+        Returns the list of files to sync to dist-git as is.
 
-        Skip everything if the changelog should be synced from upstream.
+        With spec-file, we have two modes:
+        * The `sync_changelog` option is set. => Spec-file can be synced as other files.
+        * Sync the content of the spec-file (but changelog) here and exclude spec-file otherwise.
 
         Args:
             synced_files: A list of SyncFilesItem.
@@ -1096,6 +1099,10 @@ The first dist-git commit to be synced is '{short_hash}'.
 
         archives_to_upload = False
         sources_file = self.dg.local_project.working_dir / "sources"
+
+        # Here, dist-git spec-file has already been updated from the upstream spec-file.
+        # => Any update done to the Source tags in upstream
+        # is already available in the dist-git spec-file.
         for upstream_archive_name in self.dg.upstream_archive_names:
             archive_name_in_cache = self.dg.is_archive_in_lookaside_cache(
                 upstream_archive_name

--- a/packit/api.py
+++ b/packit/api.py
@@ -1107,9 +1107,7 @@ The first dist-git commit to be synced is '{short_hash}'.
                 and upstream_archive_name in sources_file.read_text()
             )
 
-            if archive_name_in_cache and archive_name_in_sources_file:
-                continue
-            else:
+            if not archive_name_in_cache or not archive_name_in_sources_file:
                 archives_to_upload = True
         if not archives_to_upload and not force_new_sources:
             return

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -389,7 +389,12 @@ class PackitRepositoryBase:
         comment: Optional[str] = None,
     ):
         """
-        Update this specfile using provided specfile
+        Update the spec-file in this repository using the provided spec-file.
+
+        1. The whole content of the spec-file is copied.
+        2. The changelog is preserved.
+        3. If provided, new version is set.
+        4. If provided, new changelog entry is added.
 
         Args:
             specfile: specfile to get changes from (we update self.specfile)

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -10,6 +10,7 @@ from enum import Enum
 
 from os import getenv
 from os.path import basename
+from re import split
 from typing import Dict, List, Optional, Union, Any, Set
 
 from packit.actions import ActionName
@@ -65,7 +66,8 @@ class CommonPackageConfig:
             and update to dist-git.
         create_sync_note: Whether to create README.packit when proposing an
             update to dist-git.
-        spec_source_id: ID of the 'Source' tag in the specfile to be updated.
+        spec_source_id: The 'Source' tag in the specfile to be updated.
+        spec_source_id_number: The numeric part of the above
         notifications: Notifications to send on a successful build.
         identifier: Suffix to be added to checks. Used to differentiate check flags
             which otherwise would have identical names.
@@ -340,6 +342,15 @@ class CommonPackageConfig:
                 f"{self.dist_git_base_url}{self.dist_git_namespace}/"
                 f"{self.downstream_package_name}.git"
             )
+
+    @property
+    def spec_source_id_number(self) -> int:
+        """
+        Return spec_source_id as a number, reverse of spec_source_id_fm
+        """
+        return int(
+            next(iter(split(r"(\d+)", self.spec_source_id)[1:]), 0)
+        )
 
     def get_specfile_sync_files_item(self, from_downstream: bool = False):
         """

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -348,9 +348,7 @@ class CommonPackageConfig:
         """
         Return spec_source_id as a number, reverse of spec_source_id_fm
         """
-        return int(
-            next(iter(split(r"(\d+)", self.spec_source_id)[1:]), 0)
-        )
+        return int(next(iter(split(r"(\d+)", self.spec_source_id)[1:]), 0))
 
     def get_specfile_sync_files_item(self, from_downstream: bool = False):
         """

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -306,8 +306,11 @@ class DistGit(PackitRepositoryBase):
         :return: names of the archives, e.g. ['sen-0.6.1.tar.gz']
         """
         with self.specfile.sources() as sources:
-            archive_names = [s.expanded_filename for s in sources if s.remote or
-                             s.number == self.package_config.spec_source_id_number]
+            archive_names = [
+                s.expanded_filename
+                for s in sources
+                if s.remote or s.number == self.package_config.spec_source_id_number
+            ]
         logger.debug(f"Upstream archive names: {archive_names}")
         return archive_names
 
@@ -349,7 +352,9 @@ class DistGit(PackitRepositoryBase):
         )
         pkg_tool_.sources()
 
-    def upload_to_lookaside_cache(self, archives: Iterable[Path], pkg_tool: str = "") -> None:
+    def upload_to_lookaside_cache(
+        self, archives: Iterable[Path], pkg_tool: str = ""
+    ) -> None:
         """Upload files (archives) to the lookaside cache.
 
         If the archive is already uploaded, the rpkg tool doesn't do anything.

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -299,7 +299,11 @@ class DistGit(PackitRepositoryBase):
     @property
     def upstream_archive_names(self) -> List[str]:
         """
-        :return: name of the archive, e.g. sen-0.6.1.tar.gz
+        Files that are considered upstream and should be uploaded to lookaside.
+        Currently that's the source identified by spec_source_id (Source0 by default)
+        and all other sources specified as URLs in the spec file.
+
+        :return: names of the archives, e.g. ['sen-0.6.1.tar.gz']
         """
         with self.specfile.sources() as sources:
             archive_names = [s.expanded_filename for s in sources if s.remote or

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -381,6 +381,10 @@ class DistGit(PackitRepositoryBase):
             raise PackitException(ex)
 
     def is_archive_in_lookaside_cache(self, archive_path: str) -> bool:
+        """
+        We are using a name to check the presence in the lookaside cache.
+        (This is the same approach fedpkg itself uses.)
+        """
         archive_name = os.path.basename(archive_path)
         try:
             res = requests.head(

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -5,7 +5,7 @@ import logging
 import os
 import tempfile
 from pathlib import Path
-from typing import Optional, Sequence, List, Union
+from typing import Optional, Sequence, List, Union, Iterable
 
 import cccolutils
 import git
@@ -297,33 +297,35 @@ class DistGit(PackitRepositoryBase):
         return dist_git_pr
 
     @property
-    def upstream_archive_name(self) -> str:
+    def upstream_archive_names(self) -> List[str]:
         """
         :return: name of the archive, e.g. sen-0.6.1.tar.gz
         """
         with self.specfile.sources() as sources:
-            source = next(s for s in sources if s.number == 0)
-            archive_name = source.expanded_filename
-        logger.debug(f"Upstream archive name: {archive_name}")
-        return archive_name
+            archive_names = [s.expanded_filename for s in sources if s.remote]
+        logger.debug(f"Upstream archive names: {archive_names}")
+        return archive_names
 
-    def download_upstream_archive(self) -> Path:
+    def download_upstream_archives(self) -> List[Path]:
         """
-        Fetch archive for the current upstream release defined in dist-git's spec
+        Fetch archives for the current upstream release defined in dist-git's spec
 
-        :return: path to the archive
+        :return: list of path to the archives
         """
-        logger.info(f"Downloading archive: {self.upstream_archive_name}")
+        archives = []
+        logger.info(f"Downloading archives: {self.upstream_archive_names}")
         with cwd(self.local_project.working_dir):
             self.download_remote_sources(self.config.pkg_tool)
-        archive = self.absolute_source_dir / self.upstream_archive_name
-        if not archive.exists():
-            raise PackitException(
-                "Upstream archive was not downloaded. Check that {} exists in dist-git.".format(
-                    self.upstream_archive_name
+        for upstream_archive_name in self.upstream_archive_names:
+            archive = self.absolute_source_dir / upstream_archive_name
+            if not archive.exists():
+                raise PackitException(
+                    "Upstream archive was not downloaded. Check that {} exists in dist-git.".format(
+                        upstream_archive_name
+                    )
                 )
-            )
-        return archive
+            archives.append(archive)
+        return archives
 
     def download_source_files(self, pkg_tool: str = ""):
         """Download source files from the lookaside cache
@@ -342,8 +344,8 @@ class DistGit(PackitRepositoryBase):
         )
         pkg_tool_.sources()
 
-    def upload_to_lookaside_cache(self, archive: Path, pkg_tool: str = "") -> None:
-        """Upload files (archive) to the lookaside cache.
+    def upload_to_lookaside_cache(self, archives: Iterable[Path], pkg_tool: str = "") -> None:
+        """Upload files (archives) to the lookaside cache.
 
         If the archive is already uploaded, the rpkg tool doesn't do anything.
 
@@ -361,7 +363,7 @@ class DistGit(PackitRepositoryBase):
             tool=pkg_tool or self.config.pkg_tool,
         )
         try:
-            pkg_tool_.new_sources(sources=archive)
+            pkg_tool_.new_sources(sources=archives)
         except Exception as ex:
             logger.error(
                 f"'{pkg_tool_.tool} new-sources' failed for the following reason: {ex!r}"

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -302,7 +302,8 @@ class DistGit(PackitRepositoryBase):
         :return: name of the archive, e.g. sen-0.6.1.tar.gz
         """
         with self.specfile.sources() as sources:
-            archive_names = [s.expanded_filename for s in sources if s.remote]
+            archive_names = [s.expanded_filename for s in sources if s.remote or
+                             s.number == self.package_config.spec_source_id_number]
         logger.debug(f"Upstream archive names: {archive_names}")
         return archive_names
 

--- a/packit/pkgtool.py
+++ b/packit/pkgtool.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, Iterable
 
 from packit.exceptions import PackitCommandFailedError
 
@@ -39,13 +39,14 @@ class PkgTool:
             f"tool='{self.tool}')"
         )
 
-    def new_sources(self, sources: Optional[Path] = None, fail: bool = True):
+    def new_sources(self, sources: Optional[Iterable[Path]] = None, fail: bool = True):
+        sources = sources or []
         if not self.directory.is_dir():
             raise Exception(f"Cannot access {self.tool} repository: {self.directory}")
 
-        sources_ = str(sources) if sources else ""
+        sources_ = [str(source) for source in sources] if sources else []
         return commands.run_command_remote(
-            cmd=[self.tool, "new-sources", sources_],
+            cmd=[self.tool, "new-sources"] + sources_,
             cwd=self.directory,
             error_message="Adding new sources failed:",
             print_live=True,

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -460,9 +460,7 @@ class Upstream(PackitRepositoryBase):
                 macro.options.n = archive_root_dir
 
     def _fix_spec_source(self, archive):
-        number = int(
-            next(iter(re.split(r"(\d+)", self.package_config.spec_source_id)[1:]), 0)
-        )
+        number = self.package_config.spec_source_id_number
         with self.specfile.sources() as sources:
             source = next((s for s in sources if s.number == number), None)
             if source:

--- a/packit/utils/changelog_helper.py
+++ b/packit/utils/changelog_helper.py
@@ -69,10 +69,14 @@ class ChangelogHelper:
 
     def update_dist_git(self, full_version: str, upstream_tag: str) -> None:
         """
-        Update the spec-file in dist-git by setting the 'Version' tag and
-        adding a new entry in the %changelog section.
-        If downstream spec file has the %autochangelog macro then
-        preserve it and do not write a comment to the %changelog section.
+        Update the spec-file in dist-git:
+        * Sync content from upstream spec-file.
+        * Set 'Version'.
+        * Add new entry in the %changelog section
+          (if %autochangelog macro is not used).
+
+        Copy the upstream spec-file as is if no spec-file is present in downstream.
+        (E.g. for new packages)
 
         Args:
             full_version: Version to be set in the spec-file.

--- a/tests/data/upstream_git/beer.spec
+++ b/tests/data/upstream_git/beer.spec
@@ -8,7 +8,7 @@ Release:        1%{?dist}
 Summary:        A tool to make you happy
 
 License:        Beerware
-Source:         %{upstream_name}-%{version}.tar.gz
+Source0:         %{upstream_name}-%{version}.tar.gz
 BuildArch:      noarch
 
 ### patches ###

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -144,7 +144,8 @@ def mock_remote_functionality(distgit: Path, upstream: Path):
     )
     flexmock(DistGit).should_receive("existing_pr").and_return(None)
 
-    def mocked_new_sources(sources=[]):
+    def mocked_new_sources(sources=None):
+        sources = sources or []
         if not all(Path(s).is_file() for s in sources):
             raise RuntimeError("archive does not exist")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -74,12 +74,17 @@ def mock_remote_functionality_sourcegit(sourcegit_and_remote, distgit_and_remote
 
 
 def mock_spec_download_remote_s(
-    repo_path: Path, spec_dir_path: Optional[Path] = None, archive_ref: str = "HEAD"
+    repo_path: Path,
+    spec_dir_path: Optional[Path] = None,
+    archive_ref: str = "HEAD",
+    files_to_create=None,
 ):
+    files_to_create = files_to_create or []
     spec_dir_path = spec_dir_path or repo_path
 
     def mock_download_remote_sources(*_):
         """mock download of the remote archive and place it into dist-git repo"""
+
         archive_cmd = [
             "git",
             "archive",
@@ -90,6 +95,8 @@ def mock_spec_download_remote_s(
             archive_ref,
         ]
         subprocess.check_call(archive_cmd, cwd=repo_path)
+        for f in files_to_create:
+            subprocess.check_call(["touch", f], cwd=repo_path)
 
     flexmock(PackitRepositoryBase, download_remote_sources=mock_download_remote_sources)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -144,8 +144,8 @@ def mock_remote_functionality(distgit: Path, upstream: Path):
     )
     flexmock(DistGit).should_receive("existing_pr").and_return(None)
 
-    def mocked_new_sources(sources=None):
-        if not Path(sources).is_file():
+    def mocked_new_sources(sources=[]):
+        if not all(Path(s).is_file() for s in sources):
             raise RuntimeError("archive does not exist")
 
     flexmock(PkgTool, new_sources=mocked_new_sources)

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -342,6 +342,7 @@ def test__fix_spec_source(upstream_instance, spec_source_id, expected_line):
     u, ups = upstream_instance
 
     data = u.joinpath("beer.spec").read_text()
+    data = re.sub(r"Source0", "Source", data)
     data = re.sub(r"(Source:.*)", "\\1\nSource100: extra-sources.tar.gz", data)
     with open(u.joinpath("beer.spec"), "w") as f:
         f.write(data)

--- a/tests/integration/test_using_cockpit.py
+++ b/tests/integration/test_using_cockpit.py
@@ -40,8 +40,8 @@ def cockpit_ostree(tmp_path, upstream_without_config):
 def test_update_on_cockpit_ostree(cockpit_ostree):
     upstream_path, dist_git_path = cockpit_ostree
 
-    def mocked_new_sources(sources=None):
-        if not Path(sources).is_file():
+    def mocked_new_sources(sources=[]):
+        if not all(Path(s).is_file() for s in sources):
             raise RuntimeError("archive does not exist")
 
     flexmock(PkgTool, new_sources=mocked_new_sources)
@@ -51,8 +51,8 @@ def test_update_on_cockpit_ostree(cockpit_ostree):
         DistGit,
         push_to_fork=lambda *args, **kwargs: None,
         is_archive_in_lookaside_cache=lambda archive_path: False,
-        upload_to_lookaside_cache=lambda archive, pkg_tool: None,
-        download_upstream_archive=lambda: "the-archive",
+        upload_to_lookaside_cache=lambda archives, pkg_tool: None,
+        download_upstream_archives=lambda: ["the-archive"],
     )
     flexmock(DistGit).should_receive("existing_pr").and_return(None)
     flexmock(
@@ -80,8 +80,8 @@ def test_update_on_cockpit_ostree(cockpit_ostree):
 def test_update_on_cockpit_ostree_pr_exists(cockpit_ostree):
     upstream_path, dist_git_path = cockpit_ostree
 
-    def mocked_new_sources(sources=None):
-        if not Path(sources).is_file():
+    def mocked_new_sources(sources=[]):
+        if not all(Path(s).is_file() for s in sources):
             raise RuntimeError("archive does not exist")
 
     flexmock(PkgTool, new_sources=mocked_new_sources)
@@ -91,8 +91,8 @@ def test_update_on_cockpit_ostree_pr_exists(cockpit_ostree):
         DistGit,
         push_to_fork=lambda *args, **kwargs: None,
         is_archive_in_lookaside_cache=lambda archive_path: False,
-        upload_to_lookaside_cache=lambda archive, pkg_tool: None,
-        download_upstream_archive=lambda: "the-archive",
+        upload_to_lookaside_cache=lambda archives, pkg_tool: None,
+        download_upstream_archives=lambda: ["the-archive"],
     )
     pr = flexmock(url="https://example.com/pull/1")
     flexmock(DistGit).should_receive("existing_pr").and_return(pr)

--- a/tests/integration/test_using_cockpit.py
+++ b/tests/integration/test_using_cockpit.py
@@ -40,7 +40,8 @@ def cockpit_ostree(tmp_path, upstream_without_config):
 def test_update_on_cockpit_ostree(cockpit_ostree):
     upstream_path, dist_git_path = cockpit_ostree
 
-    def mocked_new_sources(sources=[]):
+    def mocked_new_sources(sources=None):
+        sources = sources or []
         if not all(Path(s).is_file() for s in sources):
             raise RuntimeError("archive does not exist")
 
@@ -80,7 +81,8 @@ def test_update_on_cockpit_ostree(cockpit_ostree):
 def test_update_on_cockpit_ostree_pr_exists(cockpit_ostree):
     upstream_path, dist_git_path = cockpit_ostree
 
-    def mocked_new_sources(sources=[]):
+    def mocked_new_sources(sources=None):
+        sources = sources or []
         if not all(Path(s).is_file() for s in sources):
             raise RuntimeError("archive does not exist")
 


### PR DESCRIPTION
TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

The heuristic for detecting which Sources go to lookaside is insufficient. Some cases to consider are in https://docs.fedoraproject.org/en-US/packaging-guidelines/SourceURL/#_troublesome_urls  https://docs.fedoraproject.org/en-US/packaging-guidelines/SourceURL/#when-upstream-uses-prohibited-code (those two can be solved by specifying the problematic Source as `spec_source_id`, if it is not Source0 already) and in  https://docs.fedoraproject.org/en-US/packaging-guidelines/#_verifying_signatures . For implementing complicated rules like in the latter one will probably need another configuration option that will list sources that need to go to lookaside.

The change is mostly compatible, although packages that have other Sources than 0 (or spec_source_id) specified as URLs and don't want them to be uploaded to lookaside will still have a problem. So will packages that are using a non-default spec_source_id but still want to upload Source0 (I don't expect there will be any, IMO hardcoding 0 instead of using `spec_source_id` was a bug).

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Related to #1691 #1355 , but these seem to be about building in Copr, not proposing PRs to pagure.

RELEASE NOTES BEGIN

`packit propose-downstream` now uploads all remote sources (those specified as URLs) and the source specified by `spec_source_id` (whether remote or not) to lookaside. Previously, only Source0 was uploaded.

Source0 is no longer treated specially, but as `spec_source_id` is `Source0` by default, Source0 is still being uploaded by default unless `spec_source_id` is overriden.

RELEASE NOTES END
