### PR TITLE
Use github-actions bot to run prepare-release steps

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -16,7 +16,7 @@ jobs:
             image: packit
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build Image
         id: build-image

--- a/.github/workflows/do_release.yml
+++ b/.github/workflows/do_release.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: |
+      - name: Create GitHub release
+        run: |
           VERSION=$(grep -oP '^# \K[0-9.]*' CHANGELOG.md | head -n 1)
           # Take the lines between the first two headers from CHANGELOG.md,
           # and use it as a description for the new release.

--- a/.github/workflows/do_release.yml
+++ b/.github/workflows/do_release.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release') && github.repository_owner == 'packit'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
           VERSION=$(grep -oP '^# \K[0-9.]*' CHANGELOG.md | head -n 1)
           # Take the lines between the first two headers from CHANGELOG.md,

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -8,8 +8,6 @@ on:
 
 jobs:
   prepare-release:
-    # To not run in forks
-    if: github.repository_owner == 'packit'
     runs-on: ubuntu-latest
 
     steps:
@@ -21,13 +19,10 @@ jobs:
         with:
           version: ${{ inputs.version }}
           specfiles: packit.spec
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
         with:
           labels: release
-          token: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}
           commit-message: Release ${{ inputs.version }}
           title: Release ${{ inputs.version }}
           body: Update the changelog and the specfile for release ${{ inputs.version }}.

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v2
 
       - name: Build a source tarball and a binary wheel

--- a/files/install-requirements-git.yaml
+++ b/files/install-requirements-git.yaml
@@ -2,9 +2,9 @@
 - name: Install ogr & sandcastle & requre from git
   hosts: all
   tasks:
-    - include_tasks: tasks/generic-dnf-requirements.yaml
-    - include_tasks: tasks/python-compile-deps.yaml
-    - include_tasks: tasks/ogr.yaml
-    - include_tasks: tasks/specfile.yaml
-    - include_tasks: tasks/sandcastle.yaml
-    - include_tasks: tasks/requre.yaml
+    - ansible.builtin.include_tasks: tasks/generic-dnf-requirements.yaml
+    - ansible.builtin.include_tasks: tasks/python-compile-deps.yaml
+    - ansible.builtin.include_tasks: tasks/ogr.yaml
+    - ansible.builtin.include_tasks: tasks/specfile.yaml
+    - ansible.builtin.include_tasks: tasks/sandcastle.yaml
+    - ansible.builtin.include_tasks: tasks/requre.yaml

--- a/files/install-requirements-pip.yaml
+++ b/files/install-requirements-pip.yaml
@@ -2,10 +2,10 @@
 - name: pip install packit dependencies
   hosts: all
   tasks:
-    - include_tasks: tasks/generic-dnf-requirements.yaml
-    - include_tasks: tasks/python-compile-deps.yaml
+    - ansible.builtin.include_tasks: tasks/generic-dnf-requirements.yaml
+    - ansible.builtin.include_tasks: tasks/python-compile-deps.yaml
     - name: Install deps from PyPI
-      pip:
+      ansible.builtin.pip:
         name: "{{ item }}"
       with_items:
         - ogr
@@ -14,4 +14,4 @@
         - requre
         - cachetools
       become: true
-    - include_tasks: tasks/requre.yaml
+    - ansible.builtin.include_tasks: tasks/requre.yaml

--- a/files/install-requirements-rpms.yaml
+++ b/files/install-requirements-rpms.yaml
@@ -2,11 +2,11 @@
 - name: Install RPM dependencies for packit
   hosts: all
   tasks:
-    - include_tasks: tasks/project-dir.yaml
-    - include_tasks: tasks/generic-dnf-requirements.yaml
-    - include_tasks: tasks/build-rpm-deps.yaml
+    - ansible.builtin.include_tasks: tasks/project-dir.yaml
+    - ansible.builtin.include_tasks: tasks/generic-dnf-requirements.yaml
+    - ansible.builtin.include_tasks: tasks/build-rpm-deps.yaml
     - name: Install python3-requre rpm
-      dnf:
+      ansible.builtin.dnf:
         name: python3-requre
       become: true
-    - include_tasks: tasks/requre.yaml
+    - ansible.builtin.include_tasks: tasks/requre.yaml

--- a/files/local-tests-requirements.yaml
+++ b/files/local-tests-requirements.yaml
@@ -2,13 +2,13 @@
 - name: Install dependencies for packit tests
   hosts: all
   tasks:
-    - include_tasks: tasks/project-dir.yaml
-    - include_tasks: tasks/rpm-test-deps.yaml
-    - include_tasks: tasks/ogr.yaml
-    - include_tasks: tasks/sandcastle.yaml
-    - include_tasks: tasks/centpkg.yaml
+    - ansible.builtin.include_tasks: tasks/project-dir.yaml
+    - ansible.builtin.include_tasks: tasks/rpm-test-deps.yaml
+    - ansible.builtin.include_tasks: tasks/ogr.yaml
+    - ansible.builtin.include_tasks: tasks/sandcastle.yaml
+    - ansible.builtin.include_tasks: tasks/centpkg.yaml
     # To (re-)generate tests_recording/test_data/
-    - include_tasks: tasks/requre.yaml
+    - ansible.builtin.include_tasks: tasks/requre.yaml
     - name: Install pre-commit
-      dnf:
+      ansible.builtin.dnf:
         name: pre-commit

--- a/files/packit-testing-farm-prepare-session-recording.yaml
+++ b/files/packit-testing-farm-prepare-session-recording.yaml
@@ -2,7 +2,7 @@
 - name: This is a recipe for preparing the environment when running tests inside testing-farm
   hosts: all
   tasks:
-    - include_tasks: tasks/generic-dnf-requirements.yaml
-    - include_tasks: tasks/python-compile-deps.yaml
-    - include_tasks: tasks/rpm-test-deps.yaml
-    - include_tasks: tasks/requre.yaml
+    - ansible.builtin.include_tasks: tasks/generic-dnf-requirements.yaml
+    - ansible.builtin.include_tasks: tasks/python-compile-deps.yaml
+    - ansible.builtin.include_tasks: tasks/rpm-test-deps.yaml
+    - ansible.builtin.include_tasks: tasks/requre.yaml

--- a/files/packit-testing-farm-prepare.yaml
+++ b/files/packit-testing-farm-prepare.yaml
@@ -2,7 +2,7 @@
 - name: This is a recipe for preparing the environment when running tests inside testing-farm
   hosts: all
   tasks:
-    - include_tasks: tasks/generic-dnf-requirements.yaml
-    - include_tasks: tasks/python-compile-deps.yaml
-    - include_tasks: tasks/rpm-test-deps.yaml
-    - include_tasks: tasks/sandcastle.yaml
+    - ansible.builtin.include_tasks: tasks/generic-dnf-requirements.yaml
+    - ansible.builtin.include_tasks: tasks/python-compile-deps.yaml
+    - ansible.builtin.include_tasks: tasks/rpm-test-deps.yaml
+    - ansible.builtin.include_tasks: tasks/sandcastle.yaml

--- a/files/tasks/project-dir.yaml
+++ b/files/tasks/project-dir.yaml
@@ -11,7 +11,7 @@
   tags:
     - no-cache
   register: src_path
-- name: Make sure {{ project_dir }} is present
+- name: Assert project_dir is present
   ansible.builtin.assert:
     that:
       - src_path.stat.isdir

--- a/files/zuul-reverse-dep-packit-service.yaml
+++ b/files/zuul-reverse-dep-packit-service.yaml
@@ -2,14 +2,14 @@
 - name: Check if we are not breaking packit-service
   hosts: all
   tasks:
-    - set_fact:
+    - ansible.builtin.set_fact:
         reverse_dir: "{{ ansible_user_dir }}/{{ zuul.projects['github.com/packit/packit-service'].src_dir }}"
-    - include_tasks: tasks/project-dir.yaml
-    - include_tasks: tasks/packit-service-requirements.yaml
-    - include_tasks: tasks/install-packit-service.yaml
-    - include_tasks: tasks/install-packit.yaml
+    - ansible.builtin.include_tasks: tasks/project-dir.yaml
+    - ansible.builtin.include_tasks: tasks/packit-service-requirements.yaml
+    - ansible.builtin.include_tasks: tasks/install-packit-service.yaml
+    - ansible.builtin.include_tasks: tasks/install-packit.yaml
     - name: Run unit, integration tests
-      command: make check
+      ansible.builtin.command: make check
       args:
         chdir: "{{ reverse_dir }}"
       # Set 'COLOR' to no in the packit-service/Makefile to disable

--- a/files/zuul-tests-session-recording.yaml
+++ b/files/zuul-tests-session-recording.yaml
@@ -2,12 +2,12 @@
 - name: This is a recipe for how to run packit tests
   hosts: all
   tasks:
-    - include_tasks: tasks/project-dir.yaml
-    - include_tasks: tasks/rpm-test-deps.yaml
-    - include_tasks: tasks/install-packit.yaml
-    - include_tasks: tasks/sandcastle.yaml
+    - ansible.builtin.include_tasks: tasks/project-dir.yaml
+    - ansible.builtin.include_tasks: tasks/rpm-test-deps.yaml
+    - ansible.builtin.include_tasks: tasks/install-packit.yaml
+    - ansible.builtin.include_tasks: tasks/sandcastle.yaml
     - name: Run session recorded tests
-      command: make check TEST_TARGET=tests_recording
+      ansible.builtin.command: make check TEST_TARGET=tests_recording
       environment:
         REQURE_MODE: read
       args:

--- a/files/zuul-tests.yaml
+++ b/files/zuul-tests.yaml
@@ -2,11 +2,11 @@
 - name: This is a recipe for how to run packit tests
   hosts: all
   tasks:
-    - include_tasks: tasks/project-dir.yaml
-    - include_tasks: tasks/rpm-test-deps.yaml
-    - include_tasks: tasks/install-packit.yaml
-    - include_tasks: tasks/sandcastle.yaml
+    - ansible.builtin.include_tasks: tasks/project-dir.yaml
+    - ansible.builtin.include_tasks: tasks/rpm-test-deps.yaml
+    - ansible.builtin.include_tasks: tasks/install-packit.yaml
+    - ansible.builtin.include_tasks: tasks/sandcastle.yaml
     - name: Run unit, integration and functional tests
-      command: make check
+      ansible.builtin.command: make check
       args:
         chdir: "{{ project_dir }}"


### PR DESCRIPTION
Both, the [packit/prepare-release](https://github.com/peter-evans/create-pull-request#action-inputs) & [peter-evans/create-pull-request](https://github.com/packit/prepare-release#packitprepare-release) default to using (autogenerated) [secrets.GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) if no token is provided.

That token should be enough because the steps are repo-scoped and [don't trigger any other workflow](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow) since the PR which triggers the 'Create GitHub release' is manually merged by a user.

Seems to work OK - jpopelka/packit#1