### PR TITLE
Sync release -  improvements for pull

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -787,13 +787,7 @@ The first dist-git commit to be synced is '{short_hash}'.
                 self.up.local_project.checkout_release(upstream_tag)
             self.up.run_action(actions=ActionName.post_upstream_clone)
 
-            if use_downstream_specfile:
-                logger.info(
-                    "Using the downstream specfile instead of the upstream one."
-                )
-                self.up.set_specfile(self.dg.specfile)
-
-            else:
+            if not use_downstream_specfile:
                 spec_ver = self.up.get_specfile_version()
                 if version_imported.parse(version) > version_imported.parse(spec_ver):
                     logger.warning(f"Version {spec_ver!r} in spec file is outdated.")
@@ -811,6 +805,12 @@ The first dist-git commit to be synced is '{short_hash}'.
             logger.info(f"Using {dist_git_branch!r} dist-git branch.")
             self.dg.update_branch(dist_git_branch)
             self.dg.checkout_branch(dist_git_branch)
+
+            if use_downstream_specfile:
+                logger.info(
+                    "Using the downstream specfile instead of the upstream one."
+                )
+                self.up.set_specfile(self.dg.specfile)
 
             if create_pr:
                 local_pr_branch = (

--- a/packit/api.py
+++ b/packit/api.py
@@ -1081,8 +1081,9 @@ The first dist-git commit to be synced is '{short_hash}'.
     ) -> PullRequest:
         # the branch may already be up, let's push forcefully
         repo.push_to_fork(repo.local_project.ref, force=True)
-
-        pr = repo.existing_pr(pr_title, pr_description.rstrip(), git_branch)
+        pr = repo.existing_pr(
+            pr_title, pr_description.rstrip(), git_branch, repo.local_project.ref
+        )
         if pr is None:
             pr = repo.create_pull(
                 pr_title,

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -532,7 +532,7 @@ class PackitRepositoryBase:
                 raise PackitDownloadFailedException(f"{msg}:\n{e}") from e
 
     def existing_pr(
-        self, title: str, description: str, branch: str
+        self, title: str, description: str, target_branch: str, source_branch: str
     ) -> Optional[PullRequest]:
         """Look for an already created PR with the same:
         title, description and branch name
@@ -552,7 +552,8 @@ class PackitRepositoryBase:
             if (
                 pr.title == title
                 and pr.description == description
-                and pr.target_branch == branch
+                and pr.target_branch == target_branch
+                and pr.source_branch == source_branch
                 and pr.author == current_user
             ):
                 return pr

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -89,6 +89,23 @@ def test_basic_local_update_use_downstream_specfile(
     assert "0.0.0" in changelog
     assert "0.1.0" in changelog
 
+    # do this second time to see whether the specfile is updated correctly
+    api.sync_release(
+        dist_git_branch="main", version="0.1.0", use_downstream_specfile=True
+    )
+
+    assert (d / TARBALL_NAME).is_file()
+    spec = Specfile(d / "beer.spec")
+    assert spec.expanded_version == "0.1.0"
+    assert (d / "README.packit").is_file()
+    # assert that we have changelog entries for both versions
+    with spec.sections() as sections:
+        changelog = "\n".join(sections.changelog)
+    assert "0.0.0" in changelog
+    assert "0.1.0" in changelog
+
+    assert changelog.count("0.1.0") == 1
+
 
 def test_basic_local_update_with_multiple_sources(
     cwd_upstream, api_instance, mock_remote_functionality_upstream

--- a/tests/unit/test_dg.py
+++ b/tests/unit/test_dg.py
@@ -10,16 +10,18 @@ from packit.local_project import LocalProject
 
 
 @pytest.mark.parametrize(
-    "title, description, branch, prs, exists",
+    "title, description, branch, source_branch, prs, exists",
     [
         (
             "Update",
             "Upstream tag: 0.4.0\nUpstream commit: 6957453b",
             "f31",
+            "f31-update",
             [
                 flexmock(
                     title="Update",
                     target_branch="f31",
+                    source_branch="f31-update",
                     description="Upstream tag: 0.4.0\nUpstream commit: 6957453b",
                     author="packit",
                 )
@@ -30,10 +32,12 @@ from packit.local_project import LocalProject
             "Update",
             "Upstream tag: 0.4.0\nUpstream commit: 6957453b",
             "f31",
+            "f31-update",
             [
                 flexmock(
                     title="Update",
                     target_branch="f31",
+                    source_branch="f31-update",
                     description="Upstream tag: 0.4.0\nUpstream commit: 8957453b",
                     author="packit",
                 )
@@ -44,10 +48,12 @@ from packit.local_project import LocalProject
             "Update",
             "Upstream tag: 0.4.0\nUpstream commit: 6957453b",
             "f32",
+            "f31-update",
             [
                 flexmock(
                     title="Update",
                     target_branch="f31",
+                    source_branch="f31-update",
                     description="Upstream tag: 0.4.0\nUpstream commit: 6957453b",
                     author="packit",
                 )
@@ -58,19 +64,37 @@ from packit.local_project import LocalProject
             "Update",
             "Upstream tag: 0.4.0\nUpstream commit: 6957453b",
             "f31",
+            "f31-update",
             [
                 flexmock(
                     title="Update",
                     target_branch="f31",
                     description="Upstream tag: 0.4.0\nUpstream commit: 6957453b",
                     author="packit-stg",
+                    source_branch="f31-update",
+                )
+            ],
+            False,
+        ),
+        (
+            "Update",
+            "Upstream tag: 0.4.0\nUpstream commit: 6957453b",
+            "f31",
+            "f32-update",
+            [
+                flexmock(
+                    title="Update",
+                    target_branch="f31",
+                    source_branch="f31-update",
+                    description="Upstream tag: 0.4.0\nUpstream commit: 6957453b",
+                    author="packit",
                 )
             ],
             False,
         ),
     ],
 )
-def test_existing_pr(title, description, branch, prs, exists):
+def test_existing_pr(title, description, branch, source_branch, prs, exists):
     user_mock = flexmock().should_receive("get_username").and_return("packit").mock()
     local_project = LocalProject(
         git_project=flexmock(service="something", get_pr_list=lambda: prs),
@@ -84,7 +108,7 @@ def test_existing_pr(title, description, branch, prs, exists):
         ),
         local_project=local_project,
     )
-    pr = distgit.existing_pr(title, description, branch)
+    pr = distgit.existing_pr(title, description, branch, source_branch)
     if exists:
         assert pr is not None
     else:


### PR DESCRIPTION
Pull-from-upstream finally in action: https://src.fedoraproject.org/fork/packit-stg/rpms/python-specfile/c/580fddc01336518418cf98e5d202614249d62536?branch=0.11.1-f37-update-pull_from_upstream

But there were 2 issues: since we had already PRs from propose-downstream, the check for existing PR caused the PRs were not created (but the branches with `-pull_from_upstream` suffix were created and updated). 

The second issue was that the specfile was synced correctly only for the first branch run- runs for each next branch were using the previous specfile: e.g. https://src.fedoraproject.org/fork/packit-stg/rpms/python-specfile/c/937262afa09978a46936ad0c18e29639044462d0?branch=0.11.1-epel9-update-pull_from_upstream - therefore the duplicated most recent entries.

RELEASE NOTES BEGIN
N/A

RELEASE NOTES END
