### PR TITLE
Use up-to-date version of flexmock from PyPI

### DIFF
--- a/files/tasks/packit-service-requirements.yaml
+++ b/files/tasks/packit-service-requirements.yaml
@@ -40,3 +40,9 @@
     src: "{{ reverse_dir}}/files/packit-service.yaml"
     dest: "{{ ansible_user_dir }}/.config/packit-service.yaml"
     state: link
+
+- name: Get up-to-date version of flexmock from PyPI
+  ansible.builtin.pip:
+    name: flexmock
+    state: latest
+  become: true


### PR DESCRIPTION
To match the version used in service tests

Signed-off-by: Frantisek Lachman <flachman@redhat.com>
