### PR TITLE
Reset Release before adding changelog entry

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -418,8 +418,6 @@ class PackitRepositoryBase:
                 sections.append(Section("changelog", previous_changelog))
         if version is not None:
             self.specfile.version = version
-        if comment is not None:
-            self.specfile.add_changelog_entry(comment)
         if (
             previous_version != self.specfile.expanded_version
             and previous_release == self.specfile.release
@@ -432,6 +430,8 @@ class PackitRepositoryBase:
             # at the cost of upstream and downstream having different
             # Release fields.
             self.specfile.release = "1"
+        if comment is not None:
+            self.specfile.add_changelog_entry(comment)
 
     def refresh_specfile(self):
         self._specfile = None

--- a/tests/unit/test_base_git.py
+++ b/tests/unit/test_base_git.py
@@ -503,6 +503,8 @@ def test_set_spec_content_reset_release(tmp_path, up_release, reset):
     if reset:
         assert dist_git.specfile.release == "1"
         assert dist_git.specfile.raw_release == "1%{?dist}"
+        with dist_git.specfile.sections() as sections:
+            assert "1.1-1" in sections.changelog[0]
     else:
         assert dist_git.specfile.release == up_release
         assert dist_git.specfile.raw_release == f"{up_release}%{{?dist}}"


### PR DESCRIPTION
The changelog entry contains the release number, therefore we need to reset the Release before adding a new entry to the changelog to avoid inconsistencies.

@pcahyna sorry once again, this should fix your problem

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Related to #1801 

RELEASE NOTES BEGIN

Packit now puts the correct release number into the changelog when the `Release` tag is reset during `propose-downstream`.

RELEASE NOTES END
