### PR TITLE
fix(setup.py): don't bump dev versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ url = https://github.com/packit/packit
 author = Red Hat
 author_email = user-cont-team@redhat.com
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 4 - Beta
     Environment :: Console

--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,4 @@
 
 from setuptools import setup
 
-setup(use_scm_version=True)
+setup(use_scm_version={"version_scheme": "post-release"})


### PR DESCRIPTION
    so the version is always higher when we build our packages in the stable
    project

    The problem:
    $ rpmdev-vercmp 0.65.1.dev7+gbf5a556-1.20221219130111363621.stable.7.gbf5a556   0.65.1-1.20230102134429552639.stable.0.geda9ca7
    0.65.1.dev7+gbf5a556-1.20221219130111363621.stable.7.gbf5a556 > 0.65.1-1.20230102134429552639.stable.0.geda9ca7

    Even though the latter VR was built later, RPM treats it as older.

    The solution:
    $ rpmdev-vercmp 0.65.0.post1+g9c8cbdc.d20230105-1.20221219130111363621.stable.7.gbf5a556 0.65.1-1.20230102134429552639.stable.0.geda9ca7
    0.65.0.post1+g9c8cbdc.d20230105-1.20221219130111363621.stable.7.gbf5a556 < 0.65.1-1.20230102134429552639.stable.0.geda9ca7

    $ rpmdev-vercmp 0.65.1.post1+g9c8cbdc.d20230105-1.20221219130111363621.stable.7.gbf5a556 0.65.1.post2+...
    0.65.1.post1+g9c8cbdc.d20230105-1.20221219130111363621.stable.7.gbf5a556 < 0.65.1.post2+...

    We are going to post-release versioning scheme: the version won't be
    increased after a release so newer builds will always have higher NVR.


RELEASE NOTES BEGIN
N/A
RELEASE NOTES END