### PR TITLE
feat(copr): enable configuring chroot-specific options

### DIFF
--- a/packit/constants.py
+++ b/packit/constants.py
@@ -161,3 +161,9 @@ REPO_NOT_PRISTINE_HINT = (
 )
 
 KOJI_BASEURL = "https://koji.fedoraproject.org/kojihub"
+
+CHROOT_SPECIFIC_COPR_CONFIGURATION = (
+    "additional_packages",
+    "additional_repos",
+    "additional_modules",
+)

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -33,6 +33,7 @@ from packit.config.job_config import (
 from packit.config.notifications import NotificationsConfig
 from packit.config.notifications import PullRequestNotificationsConfig
 from packit.config.sources import SourcesItem
+from packit.constants import CHROOT_SPECIFIC_COPR_CONFIGURATION
 from packit.sync import SyncFilesItem
 from packit.config.aliases import DEPRECATED_TARGET_MAP
 
@@ -196,10 +197,11 @@ class TargetsListOrDict(fields.Field):
             or not all(isinstance(v, dict) for v in value.values())
         ):
             return False
-        # check the 'attributes', e.g. {'distros': ['centos-7']}
+        # check the 'attributes', e.g. {'distros': ['centos-7']} or
+        # {"additional_modules": ["ruby:2.7,", "nodejs:12,",...], "additional_packages": []}
         for attr in value.values():
             for key, value in attr.items():
-                if key != "distros":
+                if key not in ("distros",) + CHROOT_SPECIFIC_COPR_CONFIGURATION:
                     raise ValidationError(f"Unknown key {key!r} in {attr!r}")
                 if isinstance(value, list) and all(
                     isinstance(distro, str) for distro in value

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -458,6 +458,7 @@ def test_deserialize_and_serialize_job_config(config_in, config_out, validation_
         ({"targets": {}}, True),
         ({"targets": ["this", "is", "list"]}, True),
         ({"targets": {"a": {}, "b": {"distros": ["rhel-7"]}}}, True),
+        ({"targets": {"a": {}, "b": {"additional_modules": []}}}, True),
         ({"targets": {"a": {}, "b": {"unknown": ["rhel-7"]}}}, False),
         ({"targets": {"a": {}, "b": {"distros": "not a list"}}}, False),
         ({"targets": {"this", "is", "set"}}, False),


### PR DESCRIPTION
namely, all the `additional_*`

Detailed and well written ask from @evgeni:

https://github.com/packit/packit/issues/1429#issuecomment-1373209874

Fixes #1429

I thought about the design what exactly should we pass from p-s to `create_copr_project_if_not_exists`.
The problem is that job_config causes a circular dependency (aliases require copr_helper).

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`. https://github.com/packit/packit.dev/pull/583
- [ ] once approved, pass `targets_dict` to the copr_helper method in a new p-s PR https://github.com/packit/packit-service/pull/1833

RELEASE NOTES BEGIN
Target-specific configuration for Copr builds can now be defined and Packit will set it for the appropriate Copr chroots.
RELEASE NOTES END