### PR TITLE
Sanitize newlines in changelog entries

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -431,7 +431,7 @@ class PackitRepositoryBase:
             # Release fields.
             self.specfile.release = "1"
         if comment is not None:
-            self.specfile.add_changelog_entry(comment)
+            self.specfile.add_changelog_entry(comment.splitlines())
 
     def refresh_specfile(self):
         self._specfile = None


### PR DESCRIPTION
`Specfile.add_changelog_entry()` accepts a list of lines, so providing that rather than a string will ensure that the resulting changelog entry will always have the same line endings, no matter the source.

This should prevent unwanted diff chunks with mixed line endings in propose-downstream PRs, like here:
https://src.fedoraproject.org/rpms/python-specfile/pull-request/120#_6__20-21

Fixes: #1807