### PR TITLE
fix(chroot-conf): utilize addtional_modules as a string

### DIFF
--- a/packit/constants.py
+++ b/packit/constants.py
@@ -162,8 +162,10 @@ REPO_NOT_PRISTINE_HINT = (
 
 KOJI_BASEURL = "https://koji.fedoraproject.org/kojihub"
 
-CHROOT_SPECIFIC_COPR_CONFIGURATION = (
-    "additional_packages",
-    "additional_repos",
-    "additional_modules",
-)
+# key name -> default
+CHROOT_SPECIFIC_COPR_CONFIGURATION = {
+    "additional_packages": [],
+    "additional_repos": [],
+    # modules default to string because Copr stores it as string in the DB
+    "additional_modules": "",
+}

--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -103,7 +103,7 @@ class CoprHelper:
                 chroot_names = get_build_targets(target)
                 for chroot_name in chroot_names:
                     if set(chroot_configuration.keys()).intersection(
-                        CHROOT_SPECIFIC_COPR_CONFIGURATION
+                        CHROOT_SPECIFIC_COPR_CONFIGURATION.keys()
                     ):
                         logger.info(
                             f"There is chroot-specific configuration for {chroot_name}"
@@ -117,12 +117,11 @@ class CoprHelper:
                             )
                         )
                         update_dict = {}
-                        for c in CHROOT_SPECIFIC_COPR_CONFIGURATION:
-                            # all 3 options have a default of `[]`
+                        for c, default in CHROOT_SPECIFIC_COPR_CONFIGURATION.items():
                             if copr_chroot_configuration.get(
-                                c, []
-                            ) != chroot_configuration.get(c, []):
-                                update_dict[c] = chroot_configuration.get(c, [])
+                                c, default
+                            ) != chroot_configuration.get(c, default):
+                                update_dict[c] = chroot_configuration.get(c, default)
                         if update_dict:
                             logger.info(
                                 f"Update {owner}/{project} {chroot_name}: {update_dict}"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -458,7 +458,23 @@ def test_deserialize_and_serialize_job_config(config_in, config_out, validation_
         ({"targets": {}}, True),
         ({"targets": ["this", "is", "list"]}, True),
         ({"targets": {"a": {}, "b": {"distros": ["rhel-7"]}}}, True),
-        ({"targets": {"a": {}, "b": {"additional_modules": []}}}, True),
+        ({"targets": {"a": {}, "b": {"additional_modules": ""}}}, True),
+        (
+            {
+                "targets": {
+                    "a": {},
+                    "b": {
+                        "additional_modules": "asd:1.2",
+                        "additional_repos": ["http://foo.bar/"],
+                    },
+                }
+            },
+            True,
+        ),
+        (
+            {"targets": {"b": {"additional_modules": None, "additional_repos": False}}},
+            False,
+        ),
         ({"targets": {"a": {}, "b": {"unknown": ["rhel-7"]}}}, False),
         ({"targets": {"a": {}, "b": {"distros": "not a list"}}}, False),
         ({"targets": {"this", "is", "set"}}, False),

--- a/tests/unit/test_copr_helper.py
+++ b/tests/unit/test_copr_helper.py
@@ -72,9 +72,14 @@ class TestCoprHelper:
                 },
             ),
             (
-                {"fedora-rawhide": {"additional_modules": ["r"], "distros": ["z"]}},
                 {
-                    "additional_modules": ["r"],
+                    "fedora-rawhide": {
+                        "additional_modules": "httpd:2.4,nodejs:12",
+                        "distros": ["z"],
+                    }
+                },
+                {
+                    "additional_modules": "httpd:2.4,nodejs:12",
                 },
             ),
         ],
@@ -93,7 +98,7 @@ class TestCoprHelper:
         if expect_call_args:
             project_proxy_mock.should_receive("get").and_return(
                 {
-                    "additional_modules": [],
+                    "additional_modules": "",
                     "additional_packages": [],
                     "additional_repos": [],
                     "comps_name": None,


### PR DESCRIPTION
not a list as the API used to imply

Related: https://github.com/fedora-copr/copr/pull/2465

The PR above fixes Copr's side

TODO:

- [x] Write new tests or update the old ones to cover new functionality.

RELEASE NOTES BEGIN

When configuring Copr chroot (target in Packit terminology) specific configuration, make sure to specify additional_modules as a string: module names separated with a comma, example: "httpd:2.4,python:4".

RELEASE NOTES END