### PR TITLE
Improve build copr experience

### DIFF
--- a/packit/cli/builds/copr_build.py
+++ b/packit/cli/builds/copr_build.py
@@ -132,6 +132,9 @@ def copr(
 
     PATH_OR_URL argument is a local path or a URL to the upstream git repository,
     it defaults to the current working directory.
+
+    Copr configuration needs to be set before usage. 
+    https://docs.pagure.org/copr.copr/user_documentation.html#quick-start
     """
     api = get_packit_api(config=config, local_project=path_or_url)
     release_suffix = ChangelogHelper.resolve_release_suffix(

--- a/packit/cli/builds/copr_build.py
+++ b/packit/cli/builds/copr_build.py
@@ -133,7 +133,7 @@ def copr(
     PATH_OR_URL argument is a local path or a URL to the upstream git repository,
     it defaults to the current working directory.
 
-    Copr configuration needs to be set before usage. 
+    Copr configuration needs to be set before usage.
     https://docs.pagure.org/copr.copr/user_documentation.html#quick-start
     """
     api = get_packit_api(config=config, local_project=path_or_url)

--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -242,7 +242,8 @@ class CoprHelper:
                             f"when using Packit CLI."
                         )
                 raise PackitCoprSettingsException(
-                    f"Copr project update failed for '{owner}/{project}' project.",
+                    f"Copr project update failed for '{owner}/{project}' project."
+                    "because the Copr token is missing, invalid or expired",
                     fields_to_change=fields_to_change,
                 ) from ex
 


### PR DESCRIPTION
TODO:

- [x] Document in build in-copr --help that people need to set up the Copr config, ideally link to https://docs.pagure.org/copr.copr/user_documentation.html#quick-start
- [x] Also document this in packit.dev
- [x]  Let the error message bubble to the stderr that a Copr project could not be updated because
the Copr token is missing, invalid or expired

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes  #1762

Related to https://github.com/packit/packit.dev/pull/593

Merge before/after

RELEASE NOTES BEGIN

- Running `build in-copr --help` now tells users that the Copr configuration should be set before usage.
- Error message now tells users that Copr project could not be updated because
the Copr token is missing, invalid or expired


RELEASE NOTES END
