### PR TITLE
Sanitize changelog entry when updating dist-git spec file

### DIFF
--- a/tests/integration/test_changelog_helper.py
+++ b/tests/integration/test_changelog_helper.py
@@ -114,3 +114,22 @@ def test_do_not_update_distgit_with_autochangelog(
 
     with downstream._specfile.sections() as sections:
         assert "%autochangelog" in sections.changelog
+
+
+def test_update_distgit_unsafe_commit_messages(upstream, distgit_instance):
+    _, downstream = distgit_instance
+    package_config = upstream.package_config
+    flexmock(upstream).should_receive("get_commit_messages").and_return(
+        "* 100% of tests now pass\n"
+        "* got rid of all shell (%(...)) and expression (%[...]) expansions\n"
+        "* removed all %global macros\n"
+        "* cleaned up %install section\n"
+    )
+
+    ChangelogHelper(upstream, downstream, package_config).update_dist_git(
+        upstream_tag="0.1.0", full_version="0.1.0"
+    )
+
+    # FIXME: this doesn't currently work because of a RPM bug
+    # make sure only one changelog entry has been added
+    # assert len(downstream.specfile.rpm_spec.sourceHeader[rpm.RPMTAG_CHANGELOGTEXT]) == 2

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -27,6 +27,7 @@ from packit.utils.source_script import create_source_script
 from packit.utils.upstream_version import requests, get_upstream_version
 from packit.utils.lookaside import configparser, pyrpkg, get_lookaside_sources
 from packit.utils.koji_helper import KojiHelper
+from packit.utils.changelog_helper import ChangelogHelper
 
 
 @pytest.mark.parametrize(
@@ -844,3 +845,21 @@ def test_koji_helper_get_candidate_tag(branch, tag):
 )
 def test_koji_helper_get_stable_tags(tag, stable_tags):
     assert KojiHelper.get_stable_tags(tag) == stable_tags
+
+
+@pytest.mark.parametrize(
+    "original, sanitized",
+    [
+        ("- 100% of tests now pass", "- 100% of tests now pass"),
+        ("- removed all %global macros", "- removed all %%global macros"),
+        ("- cleaned up %install section", "- cleaned up %%install section"),
+        (
+            "- got rid of all shell (%(...)) and expression (%[...]) expansions",
+            "- got rid of all shell (%%(...)) and expression (%%[...]) expansions",
+        ),
+        ("- first item\n* second item", "- first item\n * second item"),
+        ("* first item\n* second item", " * first item\n * second item"),
+    ],
+)
+def test_changelog_helper_sanitize_entry(original, sanitized):
+    assert ChangelogHelper.sanitize_entry(original) == sanitized


### PR DESCRIPTION
Fixes #1731.

---

It's clear how to escape macros, but what do you think about "escaping" asterisks? Asterisk is only a problem if it is the first character of a line (and sometimes even that is fine, but better safe than sorry), so I decided to just precede it with a space in such case. I think it's less intrusive than replacing it with a different character.


While writing tests I've encountered a bug in RPM, it needs a bit more debugging before I can report or fix it.

RELEASE NOTES BEGIN

Packit now sanitizes changelog messages in order not to break spec file parsing.

RELEASE NOTES END
