### PR TITLE
Enable the check for changelog entries count in test_update_distgit_unsafe_commit_messages

### DIFF
--- a/tests/integration/test_changelog_helper.py
+++ b/tests/integration/test_changelog_helper.py
@@ -130,6 +130,7 @@ def test_update_distgit_unsafe_commit_messages(upstream, distgit_instance):
         upstream_tag="0.1.0", full_version="0.1.0"
     )
 
-    # FIXME: this doesn't currently work because of a RPM bug
-    # make sure only one changelog entry has been added
-    # assert len(downstream.specfile.rpm_spec.sourceHeader[rpm.RPMTAG_CHANGELOGTEXT]) == 2
+    # make sure only one changelog entry (as seen by RPM) has been added
+    downstream.specfile.macros.append(("_changelog_trimage", "0"))
+    downstream.specfile.macros.append(("_changelog_trimtime", "0"))
+    assert len(downstream.specfile.rpm_spec.sourceHeader[rpm.RPMTAG_CHANGELOGTEXT]) == 2


### PR DESCRIPTION
There is a `%_changelog_trimage` macro that limits the age of processed changelog entries and is defined to be 2 years in Fedora:
https://src.fedoraproject.org/rpms/redhat-rpm-config/blob/rawhide/f/macros#_393

There is also a `%_changelog_trimtime` macro that also limits the age of processed changelog entries and is defined to be 2 years in EL 9:
https://gitlab.com/redhat/centos-stream/rpms/redhat-rpm-config/-/blob/f14ea70dac7c0aeab840cda017d2891c488d8e25/macros#L345
    
Redefine both of them to zero so that all entries are processed and the check can be enabled.

Related to #1841.