### PR TITLE
chore(bodhi): utilize upstream bodhi functionality

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -31,7 +31,7 @@ BuildRequires:  python3-requests-kerberos
 BuildRequires:  python3dist(setuptools)
 BuildRequires:  python3dist(setuptools-scm)
 BuildRequires:  python3dist(setuptools-scm-git-archive)
-BuildRequires:  python3-bodhi-client
+BuildRequires:  python3-bodhi-client >= 7.0.0
 BuildRequires:  python3-cachetools
 BuildRequires:  python3-fedora
 %if 0%{?rhel}

--- a/packit/api.py
+++ b/packit/api.py
@@ -1595,14 +1595,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         """Push selected bodhi update from testing to stable."""
         from bodhi.client.bindings import UpdateNotFound
 
-        bodhi_client = get_bodhi_client(
-            fas_username=self.config.fas_user,
-            fas_password=self.config.fas_password,
-            kerberos_realm=self.config.kerberos_realm,
-        )
-        # only use Kerberos when fas_user and kerberos_realm are set
-        if self.config.fas_user and self.config.kerberos_realm:
-            bodhi_client.login_with_kerberos()
+        bodhi_client = get_bodhi_client()
         # make sure we have the credentials
         bodhi_client.ensure_auth()
         try:

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -515,14 +515,7 @@ class DistGit(PackitRepositoryBase):
             f"About to create a Bodhi update of type {update_type!r} from {dist_git_branch!r}"
         )
 
-        bodhi_client = get_bodhi_client(
-            fas_username=self.config.fas_user,
-            fas_password=self.config.fas_password,
-            kerberos_realm=self.config.kerberos_realm,
-        )
-        # only use Kerberos when fas_user and kerberos_realm are set
-        if self.config.fas_user and self.config.kerberos_realm:
-            bodhi_client.login_with_kerberos()
+        bodhi_client = get_bodhi_client()
         # make sure we have the credentials
         bodhi_client.ensure_auth()
 

--- a/packit/utils/bodhi.py
+++ b/packit/utils/bodhi.py
@@ -3,141 +3,18 @@
 """
 Initialise the Bodhi client.
 
-Bodhi 5 will prompt for username and password
-if the values are not set and the session is not cached.
-(The session is stored as `~/.fedora/openidbaseclient-sessions.cache`.)
-
-When username and password is configured, we are not caching the session
-to avoid any caching issues (mainly for the service).
-
-Bodhi 6 prints a URL which you need to open in browser and paste 'code=XXX...' into
+Bodhi 6+ prints a URL which you need to open in browser and paste 'code=XXX...' into
 terminal which the bodhi-client will save to `~/.config/bodhi/client.json`.
 Bodhi 6 does not use username, password nor keytab.
 """
-import inspect
-import logging
 import os
-import re
-from typing import Optional
 
-import requests
 from bodhi.client.bindings import BodhiClient
-from requests_kerberos import HTTPKerberosAuth, OPTIONAL
-
-from packit.exceptions import PackitException
-
-logger = logging.getLogger(__name__)
 
 
-class OurBodhiClient(BodhiClient):
-    """compat layer for bodhi 5 and 6 clients"""
-
-    def __init__(
-        self,
-        fas_username: Optional[str] = None,
-        fas_password: str = None,
-        kerberos_realm: str = None,
-    ):
-        """
-        Args:
-            fas_username: username for FAS
-              Bodhi 5 - used for authentication
-              Bodhi 6 - used to construct Kerberos principal
-            fas_password: password for FAS
-            kerberos_realm: Kerberos realm (after @), used for Bodhi 6
-        """
-        self.kerberos_realm = kerberos_realm
-        self.fas_username = fas_username
-        # https://docs.python.org/3/library/inspect.html#inspect.signature
-        signature = inspect.signature(BodhiClient)
-        try:
-            # bodhi 5
-            self.is_bodhi_6 = not bool(signature.parameters["username"])
-        except KeyError:
-            # bodhi 6
-            self.is_bodhi_6 = True
-            super().__init__()
-            # in our openshift deployment, ~/.config is not writable, but $HOME is
-            # so let's put the token there
-            # TODO: implement once bodhi 6.1 will be out:
-            #       https://github.com/fedora-infra/bodhi/pull/4603
-            if not os.access(self.oidc.storage.path, os.W_OK):
-                self.oidc.storage.path = os.path.join(
-                    os.environ["HOME"], "bodhi-client.json"
-                )
-        else:
-            # bodhi 5
-            logger.debug(
-                f'Initialisation of the Bodhi client: FAS user {fas_username or "not configured"}; '
-                f'password {"provided" if fas_password else "not configured"}'
-            )
-            super().__init__(
-                username=fas_username,
-                password=fas_password,
-                cache_session=not bool(fas_username and fas_password),
-                retries=3,
-            )
-
-    def ensure_auth(self):
-        """clear existing authentication data and obtain new"""
-        if self.is_bodhi_6:
-            # DO NOT TRY to be smart here: let all the authentication up to bodhi
-            super().ensure_auth()
-        else:
-            self._session.cookies.clear()
-            self.csrf_token = None
-
-    def login_with_kerberos(self):
-        """Login to the OIDC provider using local TGT.
-
-        We are planning to "donate" this method to bodhi-client :)
-        It will stay here until that contribution is accepted, released and available
-
-        How to test:
-        1. obtain a TGT via `kinit` command for your FAS account
-        2. `bodhi = OurBodhiClient(fas_username="YOUR_FAS", kerberos_realm="FEDORAPROJECT.ORG")`
-        3. `bodhi.login_with_kerberos()`
-        4. A file with tokens should exist: `~/.config/bodhi/client.json`
-
-        Raises:
-            PackitException if there is a problem during the auth process
-        """
-        logger.info("Obtain OIDC authentication token via Kerberos.")
-        authorization_endpoint = self.oidc.metadata["authorization_endpoint"]
-        uri, state_ = self.oidc.client.create_authorization_url(authorization_endpoint)
-        response = requests.get(
-            uri,
-            auth=HTTPKerberosAuth(
-                principal=f"{self.fas_username}@{self.kerberos_realm}",
-                # I honestly don't know what the mutual_auth is in kerberos context
-                # but required is not working with id.fedoraproject.org
-                mutual_authentication=OPTIONAL,
-            ),
-        )
-        response.raise_for_status()
-        try:
-            value = re.findall(
-                r"<title>\s*(code=[\w\-_=;&]+)\s*</title>", response.text
-            )[0]
-        except IndexError:
-            # should we logger.debug(response.text)?
-            raise PackitException(
-                f'Unable to locate OIDC code in the response from "{uri}".'
-            )
-        self.oidc.auth_callback(f"?{value}")
-        if not self.oidc.tokens:
-            raise PackitException(
-                "Unable to obtain API token during OIDC authentication."
-            )
-
-
-def get_bodhi_client(
-    fas_username: Optional[str] = None,
-    fas_password: str = None,
-    kerberos_realm: str = None,
-) -> OurBodhiClient:
+def get_bodhi_client() -> BodhiClient:
     """
-    Provide an instance of OurBodhiClient
+    Provide an instance of BodhiClient
 
     Note for tests:
     * Don't mock the Bodhi instantiation via
@@ -146,8 +23,6 @@ def get_bodhi_client(
     * Mock this function instead -- for example:
       `flexmock(aliases).should_receive("get_bodhi_client").and_return(bodhi_instance_mock)`
     """
-    return OurBodhiClient(
-        fas_username=fas_username,
-        fas_password=fas_password,
-        kerberos_realm=kerberos_realm,
+    return BodhiClient(
+        oidc_storage_path=os.path.join(os.environ["HOME"], "bodhi-client.json")
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
     setuptools
     specfile
     tabulate
-    bodhi-client
+    bodhi-client >= 7.0.0
     koji
     rpkg
     cachetools

--- a/tests/integration/test_push_updates.py
+++ b/tests/integration/test_push_updates.py
@@ -5,8 +5,6 @@ import pytest
 from flexmock import flexmock
 from munch import Munch
 
-from packit.utils.bodhi import OurBodhiClient
-
 
 @pytest.fixture()
 def query_response():
@@ -406,9 +404,8 @@ def test_push_updates(
     ).and_return(request_response).once()
 
     flexmock(
-        OurBodhiClient,
+        BodhiClient,
         ensure_auth=lambda: None,  # this is where the browser/OIDC fun happens
-        login_with_kerberos=lambda: None,
     )
 
     api.push_updates()

--- a/tests/unit/test_login_with_kerberos.py
+++ b/tests/unit/test_login_with_kerberos.py
@@ -1,20 +1,12 @@
-import pytest
 from flexmock import flexmock
 from requests import Session
 
-from packit.utils.bodhi import OurBodhiClient
+from bodhi.client.oidcclient import OIDCClient
+from packit.utils.bodhi import get_bodhi_client
 
 
-@pytest.mark.skipif(
-    condition=not OurBodhiClient().is_bodhi_6, reason="Bodhi 6 code only"
-)
 def test_login_with_kerberos():
-    # cannot be imported on bodhi <= 5
-    from bodhi.client.oidcclient import OIDCClient
-
-    bodhi = OurBodhiClient(
-        fas_username="probably_packit", kerberos_realm="FEDORAPROJECT.ORG"
-    )
+    bodhi = get_bodhi_client()
     bodhi.oidc._tokens = {"access_token": "token"}
     the_code = (
         "code=d37deb2e-5463-1234-1234-ba70c75d74f4_5EH4MhV3Lj2ld1HapvvMM_r4Vy-eFX6R"
@@ -27,4 +19,4 @@ def test_login_with_kerberos():
         )
     )
     flexmock(OIDCClient).should_receive("auth_callback").with_args(f"?{the_code}")
-    bodhi.login_with_kerberos()
+    bodhi.oidc.login_with_kerberos("foobar")

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1,15 +1,14 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
-
+from bodhi.client.bindings import BodhiClient
 from flexmock import flexmock
 
 from packit.status import Status
-from packit.utils.bodhi import OurBodhiClient
 
 
 def test_status_updates(config_mock, package_config_mock, upstream_mock, distgit_mock):
     flexmock(
-        OurBodhiClient,
+        BodhiClient,
         query=lambda packages, page: {
             "updates": [
                 {


### PR DESCRIPTION
...over the one we had in Packit and contributed back. It's available as
of bodhi 7.0.0 release.

Fixes #1638

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.

RELEASE NOTES BEGIN

Packit now requires bodhi in version 7.0.0 at minimum.

RELEASE NOTES END