### PR TITLE
Improve searching for a package config in a remote repo

### DIFF
--- a/packit/cli/source_git_status.py
+++ b/packit/cli/source_git_status.py
@@ -9,6 +9,7 @@ import click
 
 from packit.config import pass_config
 from packit.config import Config, get_local_package_config
+from packit.constants import DISTRO_DIR, SRC_GIT_CONFIG
 from packit.api import PackitAPI
 from packit.local_project import LocalProject
 from packit.cli.utils import cover_packit_exception
@@ -33,7 +34,7 @@ def source_git_status(config: Config, source_git: str, dist_git: str):
     source_git_path = pathlib.Path(source_git).resolve()
     dist_git_path = pathlib.Path(dist_git).resolve()
     package_config = get_local_package_config(
-        source_git_path, package_config_path=config.package_config_path
+        package_config_path=source_git_path / DISTRO_DIR / SRC_GIT_CONFIG
     )
     api = PackitAPI(
         config=config,

--- a/packit/cli/update_dist_git.py
+++ b/packit/cli/update_dist_git.py
@@ -15,6 +15,7 @@ from typing import Optional
 from packit.cli.utils import cover_packit_exception
 from packit.config import pass_config
 from packit.config import Config, get_local_package_config
+from packit.constants import DISTRO_DIR, SRC_GIT_CONFIG
 from packit.api import PackitAPI
 from packit.local_project import LocalProject
 
@@ -124,7 +125,7 @@ def update_dist_git(
     source_git_path = pathlib.Path(source_git).resolve()
     dist_git_path = pathlib.Path(dist_git).resolve()
     package_config = get_local_package_config(
-        source_git_path, package_config_path=config.package_config_path
+        package_config_path=source_git_path / DISTRO_DIR / SRC_GIT_CONFIG
     )
     api = PackitAPI(
         config=config,

--- a/packit/cli/update_source_git.py
+++ b/packit/cli/update_source_git.py
@@ -12,6 +12,7 @@ import click
 
 from packit.config import pass_config
 from packit.config import Config, get_local_package_config
+from packit.constants import DISTRO_DIR, SRC_GIT_CONFIG
 from packit.api import PackitAPI
 from packit.local_project import LocalProject
 from packit.cli.utils import cover_packit_exception
@@ -91,7 +92,7 @@ def update_source_git(
     source_git_path = pathlib.Path(source_git).resolve()
     dist_git_path = pathlib.Path(dist_git).resolve()
     package_config = get_local_package_config(
-        source_git_path, package_config_path=config.package_config_path
+        package_config_path=source_git_path / DISTRO_DIR / SRC_GIT_CONFIG
     )
     api = PackitAPI(
         config=config,

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -235,21 +235,12 @@ def get_local_package_config(
     )
 
 
-def get_package_config_from_repo(
+def find_remote_packit_yaml(
     project: GitProject,
     ref: Optional[str] = None,
-) -> Optional[PackageConfig]:
-    """Search for the package config in a remote repo, load it and return
-    the package configuration object.
+) -> Optional[str]:
+    package_config_path = None
 
-    Args:
-        project: ogr Git-project object.  ref: Optional ref at which
-        the config should be searched for.
-
-    Returns:
-        PackageConfig object constructed from the config file found in
-        the repo.
-    """
     try:
         candidates = set(project.get_files(ref=ref, recursive=False))
     except GithubAppNotInstalledError:
@@ -260,7 +251,7 @@ def get_package_config_from_repo(
         return None
 
     try:
-        config_file_name = (candidates & CONFIG_FILE_NAMES).pop()
+        package_config_path = (candidates & CONFIG_FILE_NAMES).pop()
     except KeyError:
         logger.warning(
             f"No config file ({CONFIG_FILE_NAMES}) found on ref {ref!r} "
@@ -269,17 +260,43 @@ def get_package_config_from_repo(
         return None
 
     logger.debug(
-        f"Found a config file {config_file_name!r} "
+        f"Found a config file {package_config_path!r} "
         f"on ref {ref!r} "
         f"of the {project.full_repo_name!r} repository."
     )
+    return package_config_path
 
-    config_file_content = project.get_file_content(path=config_file_name, ref=ref)
+
+def get_package_config_from_repo(
+    project: GitProject,
+    ref: Optional[str] = None,
+    package_config_path: Optional[str] = None,
+) -> Optional[PackageConfig]:
+    """Search for the package config in a remote repo, load it and return
+    the package configuration object.
+
+    Args:
+        project: ogr Git-project object.
+        ref: Optional ref at which the config should be searched for.
+        package_config_path: path of the package config, relative to the repo root.
+            Load and parse this when specified instead of searching for one.
+
+    Returns:
+        PackageConfig object constructed from the config file found in
+        the repo.
+    """
+    if not (
+        package_config_path := package_config_path
+        or find_remote_packit_yaml(project, ref)
+    ):
+        return None
+
+    config_file_content = project.get_file_content(path=package_config_path, ref=ref)
     loaded_config = load_packit_yaml(raw_text=config_file_content)
 
     return parse_loaded_config(
         loaded_config=loaded_config,
-        config_file_path=config_file_name,
+        config_file_path=package_config_path,
         repo_name=project.repo,
         search_specfile=get_specfile_path_from_repo,
         project=project,

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -202,7 +202,7 @@ def get_local_package_config(
     repo_name: Optional[str] = None,
     try_local_dir_first: bool = False,
     try_local_dir_last: bool = False,
-    package_config_path: Optional[str] = None,
+    package_config_path: Optional[Union[Path, str]] = None,
 ) -> PackageConfig:
     """
     find packit.yaml in provided dirs, load it and return PackageConfig

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -8,7 +8,6 @@ DG_PR_COMMENT_KEY_SG_COMMIT = "Source-git commit"
 DISTRO_DIR = ".distro"
 SRC_GIT_CONFIG = "source-git.yaml"
 CONFIG_FILE_NAMES = [
-    f"{DISTRO_DIR}/{SRC_GIT_CONFIG}",
     ".packit.yaml",
     ".packit.yml",
     ".packit.json",

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -7,14 +7,14 @@ DG_PR_COMMENT_KEY_SG_COMMIT = "Source-git commit"
 # we store downstream content in source-git in this subdir
 DISTRO_DIR = ".distro"
 SRC_GIT_CONFIG = "source-git.yaml"
-CONFIG_FILE_NAMES = [
+CONFIG_FILE_NAMES = {
     ".packit.yaml",
     ".packit.yml",
     ".packit.json",
     "packit.yaml",
     "packit.yml",
     "packit.json",
-]
+}
 
 # local branch name when checking out a PR before we merge it with the target branch
 LP_TEMP_PR_CHECKOUT_NAME = "pr-changes"

--- a/packit/exceptions.py
+++ b/packit/exceptions.py
@@ -3,8 +3,6 @@
 
 from typing import Union, Any, Tuple, Dict
 
-from deprecated import deprecated
-
 
 def ensure_str(inp: Union[bytes, str]) -> str:
     """decode bytes on input or just return the string"""
@@ -64,11 +62,6 @@ class PackitCoprSettingsException(PackitException):
 
 class PackitInvalidConfigException(PackitConfigException):
     """provided configuration file is not valid"""
-
-
-@deprecated(reason="Use the PackitFailedToCreateSRPMException instead.")
-class FailedCreateSRPM(PackitException):
-    """Failed to create SRPM"""
 
 
 class PackitSRPMException(PackitException):

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -451,7 +451,7 @@ class JobConfigSchema(Schema):
         return data
 
     @validates_schema
-    def specfile_path_defined(self, data, **_):
+    def specfile_path_defined(self, data: dict, **_):
         """Check if a 'specfile_path' is specified for each package
 
         The only time 'specfile_path' is not required, is when the job is a

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -310,7 +310,9 @@ def mock_api_for_source_git(
 ):
     with cwd(sourcegit):
         c = get_test_config()
-        pc = get_local_package_config(str(sourcegit))
+        pc = get_local_package_config(
+            package_config_path=sourcegit / ".distro" / "source-git.yaml"
+        )
         pc.upstream_project_url = str(sourcegit)
         return PackitAPI(c, pc, up_local_project, dist_git_clone_path=str(distgit))
 


### PR DESCRIPTION
Instead of looping through the list of possible package-config file
names and trying to load them one by one, get the list of files in the
repo root and take one which matches one of the expected config file
names.

This way the number of API calls required to load a config file (or find
out that there is no such file) is reduced from
len(CONFIG_FILE_NAMES) to one.

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.

Related to packit/packit-service#1765

RELEASE NOTES BEGIN

Packit does fewer API calls when searching for the package configuration file in remote repositories.

RELEASE NOTES END
