### PR TITLE
better wording when packit cannot parse YAML file

### DIFF
--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -194,7 +194,19 @@ def load_packit_yaml(
         return safe_load(raw_text) or {}
     except YAMLError as ex:
         logger.error(f"Cannot load package config {config_file_path}.")
-        raise PackitConfigException(f"Cannot load package config: {ex!r}.")
+        if hasattr(ex, "problem_mark"):
+            msg = (
+                "  parser says\n"
+                + str(ex.problem_mark)
+                + "\n  "
+                + str(ex.problem)  # type: ignore
+            )  # type: ignore
+            if ex.context is not None:  # type: ignore
+                msg += f" {str(ex.context)}"  # type: ignore
+            logger.error(msg)
+        else:
+            logger.error(f"parser says: {ex!r}.")
+        raise PackitConfigException("Please correct data and retry.")
 
 
 def get_local_package_config(


### PR DESCRIPTION
Previously it printed:
```
2023-02-23 16:23:13.305 package_config.py ERROR  Cannot load package config /tmp/fedora-upgrade/.packit.yaml.
2023-02-23 16:23:13.305 utils.py          ERROR  Cannot load package config: ScannerError('while scanning for the next token', None, "found character '\\t' that cannot start any token", <yaml.error.Mark object at 0x7f3310e2a190>).
```
Now it prints:
```
2023-02-23 17:25:59.950 package_config.py ERROR  Cannot load package config /tmp/fedora-upgrade/.packit.yaml.
2023-02-23 17:25:59.950 package_config.py ERROR    parser says
  in "<unicode string>", line 12, column 1:
              - fedora-stable
    ^
  found character '\t' that cannot start any token while scanning for the next token
2023-02-23 17:25:59.950 utils.py          ERROR  Please correct data and retry.
```
TODO:

- [-] Write new tests or update the old ones to cover new functionality.
- [-] Update doc-strings where appropriate.
- [-] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->


RELEASE NOTES BEGIN
Command `packit validate-config` now provides details about errors when it cannot parse the config file.
RELEASE NOTES END
