### PR TITLE
fix(aliases,bodhi): account for state frozen

### DIFF
--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -229,7 +229,9 @@ def get_aliases() -> Dict[str, List[str]]:
         pages = results.pages
     current_fedora_releases, pending_fedora_releases, epel_releases = [], [], []
 
-    for release in filter(lambda r: r.state in ["current", "pending"], releases):
+    for release in filter(
+        lambda r: r.state in ["current", "pending", "frozen"], releases
+    ):
         if release.id_prefix == "FEDORA" and release.name != "ELN":
             name = release.long_name.lower().replace(" ", "-")
             if release.state == "current":

--- a/tests/unit/test_config_aliases.py
+++ b/tests/unit/test_config_aliases.py
@@ -235,7 +235,7 @@ class TestGetAliases:
                     ("F31", "Fedora 31", "FEDORA", "archived"),
                     ("F32", "Fedora 32", "FEDORA", "current"),
                     ("F33", "Fedora 33", "FEDORA", "current"),
-                    ("F34", "Fedora 34", "FEDORA", "pending"),
+                    ("F34", "Fedora 34", "FEDORA", "frozen"),
                     ("F35", "Fedora 35", "FEDORA", "pending"),
                     ("F31F", "Fedora 31 Flatpaks", "FEDORA-FLATPAK", "current"),
                     ("EPEL-8", "Fedora EPEL 8", "FEDORA-EPEL", "current"),


### PR DESCRIPTION
example for F38:
```
Munch({'name': 'F38', 'long_name': 'Fedora 38', 'version': '38', 'id_prefix':
'FEDORA', 'branch': 'f38', 'dist_tag': 'f38', 'stable_tag': 'f38',
'testing_tag': 'f38-updates-testing', 'candidate_tag': 'f38-updates-candid
ate', 'pending_signing_tag': 'f38-signing-pending', 'pending_testing_tag':
'f38-updates-testing-pending', 'pending_stable_tag': 'f38-updates-pending',
'override_tag': 'f38-override', 'mail_template': 'fedora_errata_template',

'state': 'frozen',

'compose d_by_bodhi': True, 'create_automatic_updates':
False, 'package_manager': 'unspecified', 'testing_repository': None, 'eol':
None})]
```

It seems that bodhi now sets state to 'frozen' for the upcoming release
(after beta?)

TODO:

- [x] Write new tests or update the old ones to cover new functionality.

Related: https://github.com/packit/packit/issues/1860

RELEASE NOTES BEGIN
Aliases logic was updated to account for the upcoming Fedora release (Bodhi now marks such release as `frozen`).
RELEASE NOTES END