### PR TITLE
Add monorepo support to all commands

### DIFF
--- a/packit/cli/builds/copr_build.py
+++ b/packit/cli/builds/copr_build.py
@@ -8,11 +8,20 @@ from typing import Optional, List
 import click
 
 from packit.cli.types import LocalProjectParameter
-from packit.cli.utils import cover_packit_exception, get_packit_api
-from packit.config import pass_config, get_context_settings, PackageConfig
+from packit.cli.utils import cover_packit_exception, iterate_packages, get_packit_api
+from packit.config import (
+    pass_config,
+    get_context_settings,
+    PackageConfig,
+)
 from packit.config.aliases import DEPRECATED_TARGET_MAP
 from packit.utils import sanitize_branch_name
 from packit.utils.changelog_helper import ChangelogHelper
+from packit.constants import (
+    PACKAGE_LONG_OPTION,
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_OPTION_HELP,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -105,9 +114,16 @@ logger = logging.getLogger(__name__)
     default=False,
     is_flag=True,
 )
+@click.option(
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_LONG_OPTION,
+    multiple=True,
+    help=PACKAGE_OPTION_HELP.format(action="build"),
+)
 @click.argument("path_or_url", type=LocalProjectParameter(), default=os.path.curdir)
 @pass_config
 @cover_packit_exception
+@iterate_packages
 def copr(
     config,
     wait,
@@ -124,6 +140,7 @@ def copr(
     enable_net,
     release_suffix,
     default_release_suffix,
+    package_config,
     path_or_url,
     module_hotfixes,
 ):
@@ -133,7 +150,9 @@ def copr(
     PATH_OR_URL argument is a local path or a URL to the upstream git repository,
     it defaults to the current working directory.
     """
-    api = get_packit_api(config=config, local_project=path_or_url)
+    api = get_packit_api(
+        config=config, package_config=package_config, local_project=path_or_url
+    )
     release_suffix = ChangelogHelper.resolve_release_suffix(
         api.package_config, release_suffix, default_release_suffix
     )

--- a/packit/cli/builds/in_image_builder.py
+++ b/packit/cli/builds/in_image_builder.py
@@ -8,8 +8,13 @@ from os import getcwd
 import click
 
 from packit.cli.types import LocalProjectParameter
-from packit.cli.utils import cover_packit_exception, get_packit_api
+from packit.cli.utils import cover_packit_exception, iterate_packages, get_packit_api
 from packit.config import pass_config, JobType
+from packit.constants import (
+    PACKAGE_LONG_OPTION,
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_OPTION_HELP,
+)
 
 logger = logging.getLogger("packit")
 
@@ -24,14 +29,22 @@ logger = logging.getLogger("packit")
 )
 @click.option("--wait/--no-wait", default=False, help="Wait for the build to finish")
 @click.argument("image_name", default=None, type=click.STRING)
+@click.option(
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_LONG_OPTION,
+    multiple=True,
+    help=PACKAGE_OPTION_HELP.format(action="build"),
+)
 @click.argument("path_or_url", type=LocalProjectParameter(), default=getcwd())
 @pass_config
 @cover_packit_exception
+@iterate_packages
 def in_image_builder(
     config,
     wait,
     image_name,
     job_config_index,
+    package_config,
     path_or_url,
 ):
     """
@@ -56,6 +69,7 @@ def in_image_builder(
     """
     api = get_packit_api(
         config=config,
+        package_config=package_config,
         local_project=path_or_url,
         job_config_index=job_config_index,
         job_type=JobType.vm_image_build,

--- a/packit/cli/builds/local_build.py
+++ b/packit/cli/builds/local_build.py
@@ -7,9 +7,14 @@ import os
 import click
 
 from packit.cli.types import LocalProjectParameter
-from packit.cli.utils import cover_packit_exception, get_packit_api
+from packit.cli.utils import cover_packit_exception, iterate_packages, get_packit_api
 from packit.config import pass_config, get_context_settings
 from packit.utils.changelog_helper import ChangelogHelper
+from packit.constants import (
+    PACKAGE_LONG_OPTION,
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_OPTION_HELP,
+)
 
 logger = logging.getLogger("packit")
 
@@ -68,6 +73,12 @@ def log_rpms(rpms):
         "release_suffix is specified in the configuration."
     ),
 )
+@click.option(
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_LONG_OPTION,
+    multiple=True,
+    help=PACKAGE_OPTION_HELP.format(action="build"),
+)
 @click.argument(
     "path_or_url",
     type=LocalProjectParameter(),
@@ -75,14 +86,24 @@ def log_rpms(rpms):
 )
 @pass_config
 @cover_packit_exception
-def local(config, upstream_ref, release_suffix, default_release_suffix, path_or_url):
+@iterate_packages
+def local(
+    config,
+    upstream_ref,
+    release_suffix,
+    default_release_suffix,
+    package_config,
+    path_or_url,
+):
     """
     Create RPMs using content of the upstream repository.
 
     PATH_OR_URL argument is a local path or a URL to the upstream git repository,
     it defaults to the current working directory
     """
-    api = get_packit_api(config=config, local_project=path_or_url)
+    api = get_packit_api(
+        config=config, package_config=package_config, local_project=path_or_url
+    )
 
     rpms = (
         build_rpms_from_srpm(api, config.srpm_path)

--- a/packit/cli/builds/mock_build.py
+++ b/packit/cli/builds/mock_build.py
@@ -7,9 +7,14 @@ import os
 import click
 
 from packit.cli.types import LocalProjectParameter
-from packit.cli.utils import cover_packit_exception, get_packit_api
+from packit.cli.utils import cover_packit_exception, iterate_packages, get_packit_api
 from packit.config import pass_config, get_context_settings
 from packit.utils.changelog_helper import ChangelogHelper
+from packit.constants import (
+    PACKAGE_LONG_OPTION,
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_OPTION_HELP,
+)
 
 logger = logging.getLogger("packit")
 
@@ -47,6 +52,12 @@ logger = logging.getLogger("packit")
         "treated as full path to the mock configuration."
     ),
 )
+@click.option(
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_LONG_OPTION,
+    multiple=True,
+    help=PACKAGE_OPTION_HELP.format(action="build"),
+)
 @click.argument(
     "path_or_url",
     type=LocalProjectParameter(),
@@ -54,8 +65,15 @@ logger = logging.getLogger("packit")
 )
 @pass_config
 @cover_packit_exception
+@iterate_packages
 def mock(
-    config, upstream_ref, release_suffix, default_release_suffix, root, path_or_url
+    config,
+    upstream_ref,
+    release_suffix,
+    default_release_suffix,
+    root,
+    package_config,
+    path_or_url,
 ):
     """
     Build RPMs in mock using content of the upstream repository.
@@ -63,7 +81,9 @@ def mock(
     PATH_OR_URL argument is a local path or a URL to the upstream git repository,
     it defaults to the current working directory.
     """
-    api = get_packit_api(config=config, local_project=path_or_url)
+    api = get_packit_api(
+        config=config, package_config=package_config, local_project=path_or_url
+    )
     release_suffix = ChangelogHelper.resolve_release_suffix(
         api.package_config, release_suffix, default_release_suffix
     )

--- a/packit/cli/create_update.py
+++ b/packit/cli/create_update.py
@@ -7,11 +7,16 @@ import os
 import click
 
 from packit.cli.types import LocalProjectParameter
-from packit.cli.utils import cover_packit_exception, get_packit_api
+from packit.cli.utils import cover_packit_exception, iterate_packages, get_packit_api
 from packit.config import pass_config, get_context_settings
 from packit.config.aliases import get_branches
 from packit.constants import DEFAULT_BODHI_NOTE
 from packit.exceptions import PackitException
+from packit.constants import (
+    PACKAGE_LONG_OPTION,
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_OPTION_HELP,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -75,9 +80,16 @@ class BugzillaIDs(click.ParamType):
     default=None,
     type=BugzillaIDs(),
 )
+@click.option(
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_LONG_OPTION,
+    multiple=True,
+    help=PACKAGE_OPTION_HELP.format(action="update"),
+)
 @click.argument("path_or_url", type=LocalProjectParameter(), default=os.path.curdir)
 @pass_config
 @cover_packit_exception
+@iterate_packages
 def create_update(
     config,
     dist_git_branch,
@@ -86,6 +98,7 @@ def create_update(
     update_notes,
     update_type,
     resolve_bugzillas,
+    package_config,
     path_or_url,
 ):
     """
@@ -103,7 +116,10 @@ def create_update(
     it defaults to the current working directory
     """
     api = get_packit_api(
-        config=config, dist_git_path=dist_git_path, local_project=path_or_url
+        config=config,
+        package_config=package_config,
+        dist_git_path=dist_git_path,
+        local_project=path_or_url,
     )
     default_dg_branch = api.dg.local_project.git_project.default_branch
     dist_git_branch = dist_git_branch or default_dg_branch

--- a/packit/cli/prepare_sources.py
+++ b/packit/cli/prepare_sources.py
@@ -158,12 +158,13 @@ def prepare_sources(
     """
 
     if not result_dir:
-        if package_config and package_config.is_sub_package:
-            path = package_config.paths[0].strip("./\\")
-            result_dir = Path.cwd().joinpath(f"prepare_sources_result_{path}")
-        else:
-            result_dir = Path.cwd().joinpath("prepare_sources_result")
-        logger.debug(f"Setting result_dir to the default one: {result_dir}")
+        path = package_config.paths[0].strip("./\\")
+        result_dir = (
+            Path.cwd().joinpath(f"prepare_sources_result_{path}")
+            if path
+            else Path.cwd().joinpath("prepare_sources_result")
+        )
+        logger.debug(f"Setting result_dir to: {result_dir}")
     api = get_packit_api(
         config=config,
         package_config=package_config,

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -11,9 +11,14 @@ import os
 import click
 
 from packit.cli.types import LocalProjectParameter
-from packit.cli.utils import cover_packit_exception, get_packit_api
+from packit.cli.utils import cover_packit_exception, iterate_packages, get_packit_api
 from packit.config import pass_config, get_context_settings, PackageConfig
 from packit.config.aliases import get_branches
+from packit.constants import (
+    PACKAGE_LONG_OPTION,
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_OPTION_HELP,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +86,12 @@ def get_dg_branches(api, dist_git_branch):
     is_flag=True,
     help="Don't discard changes in the git repo by default, unless this is set.",
 )
+@click.option(
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_LONG_OPTION,
+    multiple=True,
+    help=PACKAGE_OPTION_HELP.format(action="sync downstream"),
+)
 @click.argument(
     "path_or_url",
     type=LocalProjectParameter(),
@@ -89,6 +100,7 @@ def get_dg_branches(api, dist_git_branch):
 @click.argument("version", required=False)
 @pass_config
 @cover_packit_exception
+@iterate_packages
 def propose_downstream(
     config,
     dist_git_path,
@@ -100,6 +112,7 @@ def propose_downstream(
     upstream_ref,
     version,
     force,
+    package_config,
 ):
     """
     Land a new upstream release in Fedora.
@@ -112,7 +125,10 @@ def propose_downstream(
     """
 
     api = get_packit_api(
-        config=config, dist_git_path=dist_git_path, local_project=path_or_url
+        config=config,
+        package_config=package_config,
+        dist_git_path=dist_git_path,
+        local_project=path_or_url,
     )
     if pr is None:
         pr = api.package_config.create_pr

--- a/packit/cli/source_git_status.py
+++ b/packit/cli/source_git_status.py
@@ -8,11 +8,10 @@ import pathlib
 import click
 
 from packit.config import pass_config
-from packit.config import Config, get_local_package_config
-from packit.constants import DISTRO_DIR, SRC_GIT_CONFIG
+from packit.config import Config, PackageConfig
 from packit.api import PackitAPI
 from packit.local_project import LocalProjectBuilder, CALCULATE
-from packit.cli.utils import cover_packit_exception
+from packit.cli.utils import cover_packit_exception, iterate_packages_source_git
 
 
 @click.command("status")
@@ -20,7 +19,10 @@ from packit.cli.utils import cover_packit_exception
 @click.argument("dist-git", type=click.Path(exists=True, file_okay=False))
 @pass_config
 @cover_packit_exception
-def source_git_status(config: Config, source_git: str, dist_git: str):
+@iterate_packages_source_git
+def source_git_status(
+    config: Config, package_config: PackageConfig, source_git: str, dist_git: str
+):
     """Tell the synchronization status of a source-git and a dist-git repo.
 
     This command checks the commit history in the provided source-git
@@ -33,9 +35,6 @@ def source_git_status(config: Config, source_git: str, dist_git: str):
     """
     source_git_path = pathlib.Path(source_git).resolve()
     dist_git_path = pathlib.Path(dist_git).resolve()
-    package_config = get_local_package_config(
-        package_config_path=source_git_path / DISTRO_DIR / SRC_GIT_CONFIG
-    )
     builder = LocalProjectBuilder(offline=True)
     api = PackitAPI(
         config=config,

--- a/packit/cli/srpm.py
+++ b/packit/cli/srpm.py
@@ -7,9 +7,14 @@ import os
 import click
 
 from packit.cli.types import LocalProjectParameter
-from packit.cli.utils import cover_packit_exception, get_packit_api
+from packit.cli.utils import cover_packit_exception, iterate_packages, get_packit_api
 from packit.config import pass_config, get_context_settings
 from packit.utils.changelog_helper import ChangelogHelper
+from packit.constants import (
+    PACKAGE_LONG_OPTION,
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_OPTION_HELP,
+)
 
 logger = logging.getLogger("packit")
 
@@ -54,6 +59,12 @@ logger = logging.getLogger("packit")
         "release_suffix is specified in the configuration."
     ),
 )
+@click.option(
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_LONG_OPTION,
+    multiple=True,
+    help=PACKAGE_OPTION_HELP.format(action="source build"),
+)
 @click.argument(
     "path_or_url",
     type=LocalProjectParameter(),
@@ -61,6 +72,7 @@ logger = logging.getLogger("packit")
 )
 @pass_config
 @cover_packit_exception
+@iterate_packages
 def srpm(
     config,
     output,
@@ -70,6 +82,7 @@ def srpm(
     bump,
     release_suffix,
     default_release_suffix,
+    package_config,
 ):
     """
     Create new SRPM (.src.rpm file) using content of the upstream repository.
@@ -77,7 +90,9 @@ def srpm(
     PATH_OR_URL argument is a local path or a URL to the upstream git repository,
     it defaults to the current working directory
     """
-    api = get_packit_api(config=config, local_project=path_or_url)
+    api = get_packit_api(
+        config=config, package_config=package_config, local_project=path_or_url
+    )
     if bump is not None:
         if update_release is not None:
             raise click.UsageError(

--- a/packit/cli/status.py
+++ b/packit/cli/status.py
@@ -11,18 +11,29 @@ import os
 import click
 
 from packit.cli.types import LocalProjectParameter
-from packit.cli.utils import cover_packit_exception
-from packit.cli.utils import get_packit_api
+from packit.cli.utils import cover_packit_exception, iterate_packages, get_packit_api
 from packit.config import pass_config, get_context_settings
+from packit.constants import (
+    PACKAGE_LONG_OPTION,
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_OPTION_HELP,
+)
 
 logger = logging.getLogger(__name__)
 
 
 @click.command("status", context_settings=get_context_settings())
+@click.option(
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_LONG_OPTION,
+    multiple=True,
+    help=PACKAGE_OPTION_HELP.format(action="update"),
+)
 @click.argument("path_or_url", type=LocalProjectParameter(), default=os.path.curdir)
 @pass_config
 @cover_packit_exception
-def status(config, path_or_url):
+@iterate_packages
+def status(config, path_or_url, package_config):
     """
     Display status.
 
@@ -35,5 +46,7 @@ def status(config, path_or_url):
     - latest updates in Bodhi
     """
 
-    api = get_packit_api(config=config, local_project=path_or_url)
+    api = get_packit_api(
+        config=config, package_config=package_config, local_project=path_or_url
+    )
     api.status()

--- a/packit/cli/update_dist_git.py
+++ b/packit/cli/update_dist_git.py
@@ -12,10 +12,8 @@ import click
 
 from typing import Optional
 
-from packit.cli.utils import cover_packit_exception
-from packit.config import pass_config
-from packit.config import Config, get_local_package_config
-from packit.constants import DISTRO_DIR, SRC_GIT_CONFIG
+from packit.cli.utils import cover_packit_exception, iterate_packages_source_git
+from packit.config import Config, PackageConfig, pass_config
 from packit.api import PackitAPI
 from packit.local_project import LocalProjectBuilder, CALCULATE
 
@@ -68,8 +66,10 @@ from packit.local_project import LocalProjectBuilder, CALCULATE
 @click.argument("dist-git", type=click.Path(exists=True, file_okay=False))
 @pass_config
 @cover_packit_exception
+@iterate_packages_source_git
 def update_dist_git(
     config: Config,
+    package_config: PackageConfig,
     source_git: str,
     dist_git: str,
     upstream_ref: Optional[str],
@@ -124,9 +124,6 @@ def update_dist_git(
 
     source_git_path = pathlib.Path(source_git).resolve()
     dist_git_path = pathlib.Path(dist_git).resolve()
-    package_config = get_local_package_config(
-        package_config_path=source_git_path / DISTRO_DIR / SRC_GIT_CONFIG
-    )
     builder = LocalProjectBuilder(offline=True)
     api = PackitAPI(
         config=config,

--- a/packit/cli/update_source_git.py
+++ b/packit/cli/update_source_git.py
@@ -10,12 +10,10 @@ import pathlib
 
 import click
 
-from packit.config import pass_config
-from packit.config import Config, get_local_package_config
-from packit.constants import DISTRO_DIR, SRC_GIT_CONFIG
+from packit.cli.utils import cover_packit_exception, iterate_packages_source_git
+from packit.config import Config, PackageConfig, pass_config
 from packit.api import PackitAPI
 from packit.local_project import LocalProjectBuilder, CALCULATE
-from packit.cli.utils import cover_packit_exception
 
 
 @click.command("update-source-git")
@@ -32,8 +30,10 @@ from packit.cli.utils import cover_packit_exception
 @click.argument("revision-range", required=False)
 @pass_config
 @cover_packit_exception
+@iterate_packages_source_git
 def update_source_git(
     config: Config,
+    package_config: PackageConfig,
     source_git: str,
     dist_git: str,
     revision_range: str,
@@ -91,9 +91,6 @@ def update_source_git(
 
     source_git_path = pathlib.Path(source_git).resolve()
     dist_git_path = pathlib.Path(dist_git).resolve()
-    package_config = get_local_package_config(
-        package_config_path=source_git_path / DISTRO_DIR / SRC_GIT_CONFIG
-    )
     builder = LocalProjectBuilder(offline=True)
     api = PackitAPI(
         config=config,

--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -207,7 +207,7 @@ def iterate_packages_source_git(func):
         # probably, if dist-git is not a git repo,
         # we would like to cycle over multiple dist-git repos
         elif (
-            dist_git_path.is_dir
+            dist_git_path.is_dir()
             and not dist_git_path.joinpath(".git").exists()
             and not found_func
         ):

--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -120,7 +120,18 @@ def iterate_packages(func):
             try_local_dir_last=True,
             package_config_path=config.package_config_path,
         )
+        packages_config_views_names = set(
+            packages_config.get_package_config_views().keys()
+        )
         if kwargs.get("package"):
+            if not_defined_packages := set(kwargs["package"]).difference(
+                packages_config_views_names
+            ):
+                logger.error(
+                    "Packages %s are not defined in packit configuration.",
+                    not_defined_packages,
+                )
+                return None
             for package in kwargs["package"]:
                 decorated_func_kwargs["config"] = copy.deepcopy(
                     config

--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -246,27 +246,6 @@ def iterate_packages_source_git(func):
     return covered_func
 
 
-def checkout_package_workdir(
-    package_config: Optional[Union[PackageConfig, MultiplePackages]],
-    local_project: LocalProject,
-) -> LocalProject:
-    """If local_project is related to a sub-package in a Monorepo
-    then fix working dir to point to the sub-package given path.
-
-    Returns:
-        A LocalProject with a working dir moved to
-        the sub-package path, if a monorepo sub-package,
-        otherwise the same local project object.
-    """
-    if hasattr(package_config, "paths") and package_config.paths and local_project:
-        new_local_project = copy.deepcopy(local_project)
-        new_local_project.working_dir = new_local_project.working_dir.joinpath(
-            package_config.paths[0]
-        )
-        return new_local_project
-    return local_project
-
-
 def get_packit_api(
     config: Config,
     local_project: LocalProject,
@@ -310,9 +289,7 @@ def get_packit_api(
             config=config,
             package_config=package_config,
             upstream_local_project=None,
-            downstream_local_project=checkout_package_workdir(
-                package_config, local_project
-            ),
+            downstream_local_project=local_project,
             dist_git_clone_path=dist_git_path,
         )
 
@@ -359,10 +336,8 @@ def get_packit_api(
     return PackitAPI(
         config=config,
         package_config=package_config,
-        upstream_local_project=checkout_package_workdir(package_config, lp_upstream),
-        downstream_local_project=checkout_package_workdir(
-            package_config, lp_downstream
-        ),
+        upstream_local_project=lp_upstream,
+        downstream_local_project=lp_downstream,
         dist_git_clone_path=dist_git_path,
     )
 

--- a/packit/config/__init__.py
+++ b/packit/config/__init__.py
@@ -10,6 +10,7 @@ from packit.config.config import (
 )
 from packit.config.job_config import (
     JobConfig,
+    JobConfigView,
     JobConfigTriggerType,
     JobType,
 )
@@ -30,6 +31,7 @@ __all__ = [
     Config.__name__,
     Deployment.__name__,
     JobConfig.__name__,
+    JobConfigView.__name__,
     JobConfigTriggerType.__name__,
     JobType.__name__,
     MultiplePackages.__name__,

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -274,6 +274,21 @@ class CommonPackageConfig:
         self.image_customizations = image_customizations
         self.copr_chroot = copr_chroot
 
+        self._is_monorepo_sub_package = False
+
+    @property
+    def is_sub_package(self) -> bool:
+        """This config belongs to a monorepo subpackage?
+        By default it does not.
+        """
+        return self._is_monorepo_sub_package
+
+    @is_sub_package.setter
+    def is_sub_package(self, value: bool):
+        """Set config to belong/not belong to a monorepo subpackage.
+        The PackageConfig class knows it and can set this."""
+        self._is_monorepo_sub_package = value
+
     @property
     def targets_dict(self):
         return self._targets
@@ -444,7 +459,7 @@ class MultiplePackages:
             )
 
     def __setattr__(self, name, value):
-        if name in self.__dict__:
+        if name in self.__dict__ or "packages" not in self.__dict__:
             super().__setattr__(name, value)
         elif len(self.__getattribute__("packages")) == 1:
             package = self.__getattribute__("packages")[

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -105,6 +105,44 @@ class JobConfig(MultiplePackages):
         return s.dump(self) == s.dump(other)
 
 
+class JobConfigView(JobConfig):
+    def __init__(self, job_config: JobConfig, package: str):
+        self._view_for_package = package
+        self._job_config_packages = job_config.packages
+        job_config_view_packages = {package: job_config.packages[package]}
+        super().__init__(
+            job_config.type,
+            job_config.trigger,
+            job_config_view_packages,
+            job_config.skip_build,
+        )
+
+    def __eq__(self, other: object):
+        if not isinstance(other, JobConfigView):
+            if isinstance(other, JobConfig):
+                return False
+            raise PackitConfigException(
+                "Provided object is not a JobConfigView instance."
+            )
+        # required to avoid cyclical imports
+        from packit.schema import JobConfigSchema
+
+        s = JobConfigSchema()
+        # Compare the serialized objects.
+        return s.dump(self) == s.dump(other)
+
+    @property
+    def identifier(self):
+        """
+        Decorate any identifier attribute with the
+        reference to the package.
+        """
+        original_identifier = super().__getattr__("identifier")
+        if original_identifier is None:
+            return self._view_for_package
+        return original_identifier
+
+
 def get_default_jobs() -> List[Dict]:
     """
     this returns a list of dicts so it can be properly parsed and defaults would be set

--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -117,6 +117,11 @@ class JobConfigView(JobConfig):
             job_config.skip_build,
         )
 
+    @property
+    def package(self) -> str:
+        """The name for the package related with this JobConfigView?"""
+        return self._view_for_package
+
     def __eq__(self, other: object):
         if not isinstance(other, JobConfigView):
             if isinstance(other, JobConfig):

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -14,7 +14,11 @@ from ogr.exceptions import (
 from yaml import safe_load, YAMLError
 
 from packit.config.common_package_config import CommonPackageConfig, MultiplePackages
-from packit.config.job_config import JobConfig, JobType
+from packit.config.job_config import (
+    JobConfig,
+    JobConfigView,
+    JobType,
+)
 from packit.constants import CONFIG_FILE_NAMES
 from packit.exceptions import PackitConfigException
 
@@ -35,6 +39,8 @@ class PackageConfig(MultiplePackages):
         packages: Dict[str, CommonPackageConfig],
         jobs: Optional[List[JobConfig]] = None,
     ):
+        self._job_views: List[Union[JobConfig, JobConfigView]] = []
+        self._package_config_views: Dict[str, "PackageConfigView"] = {}
         super().__init__(packages)
         # Directly manipulating __dict__ is not recommended.
         # It is done here to avoid triggering __setattr__ and
@@ -52,21 +58,13 @@ class PackageConfig(MultiplePackages):
         return f"PackageConfig: {s.dumps(self)}"
 
     @classmethod
-    def get_from_dict(
+    def set_defaults(
         cls,
         raw_dict: dict,
-        config_file_path: Optional[str] = None,
         repo_name: Optional[str] = None,
         search_specfile: Optional[Callable[..., Optional[str]]] = None,
         **specfile_search_args,
-    ) -> "PackageConfig":
-        # required to avoid cyclical imports
-        from packit.schema import PackageConfigSchema
-
-        # we need to process defaults first so they get propagated to JobConfigs
-
-        raw_dict.setdefault("config_file_path", config_file_path)
-
+    ) -> None:
         if not raw_dict.get("specfile_path"):
             default_specfile_path = None
             # we default to <downstream_package_name>.spec
@@ -84,7 +82,53 @@ class PackageConfig(MultiplePackages):
             raw_dict.setdefault("upstream_package_name", repo_name)
             raw_dict.setdefault("downstream_package_name", repo_name)
 
+    @classmethod
+    def get_from_dict(
+        cls,
+        raw_dict: dict,
+        config_file_path: Optional[str] = None,
+        repo_name: Optional[str] = None,
+        search_specfile: Optional[Callable[..., Optional[str]]] = None,
+        **specfile_search_args,
+    ) -> "PackageConfig":
+        # required to avoid cyclical imports
+        from packit.schema import PackageConfigSchema
+
+        # we need to process defaults first so they get propagated to JobConfigs
+        raw_dict.setdefault("config_file_path", config_file_path)
+
+        if packages := raw_dict.get("packages", None):
+            for package in packages.values():
+                up_url_key = "upstream_project_url"
+                if up_url_key in raw_dict:
+                    # propagate it to any monorepo sub-package
+                    package[up_url_key] = raw_dict[up_url_key]
+                cls.set_defaults(
+                    package, repo_name, search_specfile, **specfile_search_args
+                )
+        else:
+            cls.set_defaults(
+                raw_dict, repo_name, search_specfile, **specfile_search_args
+            )
+
         package_config = PackageConfigSchema().load(raw_dict)
+
+        package_config_views: Dict[str, "PackageConfigView"] = {}
+        # only package_config knows it through the raw_dict
+        is_monorepo = "package" in raw_dict
+        for name, package in package_config.packages.items():
+            # inject is_sub_package info,
+            package.is_sub_package = is_monorepo
+            # filter out job data for this package
+            jobs = [
+                job
+                for job in package_config.get_job_views()
+                if name in job.packages.keys()
+            ]
+            package_config_views[name] = PackageConfigView(
+                packages={name: package}, jobs=jobs
+            )
+        package_config.set_package_config_views(package_config_views)
 
         return package_config
 
@@ -128,6 +172,64 @@ class PackageConfig(MultiplePackages):
         logger.debug(f"our configuration:\n{serialized_self}")
         logger.debug(f"the other configuration:\n{serialized_other}")
         return serialized_self == serialized_other
+
+    def get_job_views(self) -> List[Union[JobConfig, JobConfigView]]:
+        """Get jobs views on a single package.
+        If a JobConfig reference more than a package, then
+        split it in many JobConfigView(s) one for any package
+        """
+        if self._job_views:
+            return self._job_views
+
+        for job in self.jobs:
+            if len(job.packages) > 1:
+                for name in job.packages:
+                    job_view = JobConfigView(job, name)
+                    self._job_views.append(job_view)
+            else:
+                self._job_views.append(job)
+        return self._job_views
+
+    def get_package_config_views(self) -> Dict[str, "PackageConfigView"]:
+        """Return a dictionary of package name -> PackageConfigView
+        every PackageConfigView holds just one package (the named one)
+        and its associated jobs.
+        A Monorepo PackageConfig will be splitted in many of them.
+
+        NOTE: not using a property because of the custom __getattr__
+        """
+        return self._package_config_views
+
+    def set_package_config_views(self, value: Dict[str, "PackageConfigView"]):
+        """Set a dictionary of package name -> PackageConfigView
+        every PackageConfigView holds just one package (the named one)
+        and its associated jobs.
+        A Monorepo PackageConfig will be splitted in many of them.
+
+        NOTE: not using a property because of the custom __setattr__
+        """
+        self._package_config_views = value
+
+
+class PackageConfigView(PackageConfig):
+    """A PackageConfig which holds:
+    - one single package config (no more than one CommonPackageConfig object)
+    - only jobs related with the given package config
+
+    The PackageConfig is responsible to build this object
+    filtering out all the data related to a single package
+    """
+
+    def __init__(
+        self,
+        packages: Dict[str, CommonPackageConfig],
+        jobs: Optional[List[JobConfig]] = None,
+    ):
+        if len(packages) > 1:
+            logger.error(
+                "The PackageConfigView class deals with just one single package"
+            )
+        super().__init__(packages, jobs)
 
 
 def find_packit_yaml(

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -210,6 +210,26 @@ class PackageConfig(MultiplePackages):
         """
         self._package_config_views = value
 
+    def get_package_config_for(
+        self, job_config: Union[JobConfigView, JobConfig]
+    ) -> Union["PackageConfigView", "PackageConfig"]:
+        """Select the PackageConfigView for the given JobConfig in
+        a multiple packages config.
+        """
+        package_config_views = self.get_package_config_views()
+        if not package_config_views:
+            # the package config views were not initialized
+            # we can continue if this is not a monorepo
+            if len(self.packages) == 1:
+                return self
+        else:
+            if not isinstance(job_config, JobConfigView):
+                # the job config should have just one package,
+                # choose that one
+                return package_config_views[next(iter(job_config.packages.keys()))]
+
+        return package_config_views[job_config.package]
+
 
 class PackageConfigView(PackageConfig):
     """A PackageConfig which holds:

--- a/packit/config/package_config_validator.py
+++ b/packit/config/package_config_validator.py
@@ -61,13 +61,15 @@ class PackageConfigValidator:
 
         synced_files_errors = []
         if config:
-            synced_files_errors = [
-                f
-                for f in iter_srcs(config.files_to_sync)
-                if not (
-                    (self.project_path / f).exists() or any(self.project_path.glob(f))
-                )
-            ]
+            for package_config in config.get_package_config_views().values():
+                synced_files_errors = [
+                    f
+                    for f in iter_srcs(package_config.files_to_sync)
+                    if not (
+                        (self.project_path / package_config.paths[0] / f).exists()
+                        or any(self.project_path.glob(f))
+                    )
+                ]  # right now we use just the first path in a monorepo package
 
         output = f"{self.config_file_path.name} does not pass validation:\n"
 

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -174,5 +174,6 @@ PACKAGE_SHORT_OPTION = "-p"
 PACKAGE_OPTION_HELP = (
     "Package to {action}, if more than one available, "
     "like in a monorepo configuration. "
+    "Use it multiple times to select multiple packages."
     "Defaults to all the packages listed inside the config."
 )

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -168,3 +168,11 @@ CHROOT_SPECIFIC_COPR_CONFIGURATION = {
     # modules default to string because Copr stores it as string in the DB
     "additional_modules": "",
 }
+
+PACKAGE_LONG_OPTION = "--package"
+PACKAGE_SHORT_OPTION = "-p"
+PACKAGE_OPTION_HELP = (
+    "Package to {action}, if more than one available, "
+    "like in a monorepo configuration. "
+    "Defaults to all the packages listed inside the config."
+)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -61,6 +61,7 @@ def package_config_mock():
         actions=[],
         patch_generation_ignore_paths=[],
         patch_generation_patch_id_digits=4,
+        is_sub_package=False,
     )
     mock.should_receive("get_all_files_to_sync").and_return([])
     return mock

--- a/tests/unit/test_config/test_config.py
+++ b/tests/unit/test_config/test_config.py
@@ -338,7 +338,7 @@ def test_koji_build_allowlist(raw, expected, allowed_pr_authors, allowed_committ
 def test_job_config_views(raw, expected_packages_keys, identifiers):
     pkg_config = PackageConfig.get_from_dict(raw_dict=raw)
     job_views = pkg_config.get_job_views()
-    for (job_config_view, keys, identifier) in zip(
+    for job_config_view, keys, identifier in zip(
         job_views, expected_packages_keys, identifiers
     ):
         assert job_config_view.identifier == identifier

--- a/tests/unit/test_config/test_config.py
+++ b/tests/unit/test_config/test_config.py
@@ -343,6 +343,7 @@ def test_job_config_views(raw, expected_packages_keys, identifiers):
     ):
         assert job_config_view.identifier == identifier
         assert set(job_config_view.packages.keys()) == set(keys)
+        assert pkg_config.get_package_config_for(job_config_view)
 
 
 def test_get_user_config(tmp_path):

--- a/tests/unit/test_config/test_config.py
+++ b/tests/unit/test_config/test_config.py
@@ -9,6 +9,7 @@ from marshmallow import ValidationError
 from ogr import GithubService, PagureService
 
 from packit.config import (
+    PackageConfig,
     CommonPackageConfig,
     Config,
     JobConfig,
@@ -275,6 +276,73 @@ def test_koji_build_allowlist(raw, expected, allowed_pr_authors, allowed_committ
     assert job_config == expected
     assert job_config.allowed_pr_authors == allowed_pr_authors
     assert job_config.allowed_committers == allowed_committers
+
+
+@pytest.mark.parametrize(
+    "raw,expected_packages_keys,identifiers",
+    [
+        pytest.param(
+            {
+                "upstream_project_url": "https://github.com/namespace/package",
+                "packages": {
+                    "package_a": {
+                        "downstream_package_name": "package_a",
+                        "paths": ["."],
+                        "specfile_path": "package_a.spec",
+                        "files_to_sync": ["package_a.spec", ".packit.yaml"],
+                        "upstream_package_name": "package",
+                    },
+                    "package_b": {
+                        "downstream_package_name": "package_b",
+                        "identifier": "identifier_for_package_b",
+                        "paths": ["."],
+                        "specfile_path": "package_b.spec",
+                        "files_to_sync": ["package_b.spec", ".packit.yaml"],
+                        "upstream_package_name": "package",
+                    },
+                    "package_c": {
+                        "downstream_package_name": "package_c",
+                        "paths": ["."],
+                        "specfile_path": "package_c.spec",
+                        "files_to_sync": ["package_c.spec", ".packit.yaml"],
+                        "upstream_package_name": "package_c",
+                    },
+                },
+                "jobs": [
+                    {
+                        "job": "propose_downstream",
+                        "trigger": "release",
+                        "packages": {
+                            "package_a": {"specfile_path": "a/package.spec"},
+                            "package_b": {"specfile_path": "b/package.spec"},
+                        },
+                    },
+                    {
+                        "job": "propose_downstream",
+                        "trigger": "release",
+                        "packages": {
+                            "package_c": {"specfile_path": "c/package.spec"},
+                        },
+                    },
+                ],
+            },
+            [
+                ["package_a"],
+                ["package_b"],
+                ["package_c"],
+            ],
+            ["package_a", "identifier_for_package_b", None],
+        ),
+    ],
+)
+def test_job_config_views(raw, expected_packages_keys, identifiers):
+    pkg_config = PackageConfig.get_from_dict(raw_dict=raw)
+    job_views = pkg_config.get_job_views()
+    for (job_config_view, keys, identifier) in zip(
+        job_views, expected_packages_keys, identifiers
+    ):
+        assert job_config_view.identifier == identifier
+        assert set(job_config_view.packages.keys()) == set(keys)
 
 
 def test_get_user_config(tmp_path):

--- a/tests/unit/test_iterate_packages.py
+++ b/tests/unit/test_iterate_packages.py
@@ -1,0 +1,321 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+import json
+import pytest
+from pathlib import PosixPath
+from flexmock import flexmock
+from click.testing import CliRunner
+
+from packit.config import (
+    package_config,
+)
+from packit.api import PackitAPI
+from packit.cli.packit_base import packit_base
+from packit.cli.builds import koji_build
+from packit.distgit import DistGit
+
+DEFAULT_CONFIG_YAML = """
+    {
+        "specfile_path": "python-teamcity-messages.spec",
+        "files_to_sync": ["python-teamcity-messages.spec", ".packit.yaml"],
+        "upstream_package_name": "teamcity-messages",
+        "downstream_package_name": "python-teamcity-messages",
+        "upstream_project_url": "https://github.com/majamassarini/teamcity-messages",
+        "upstream_tag_template": "v{version}",
+        "jobs": [
+            {
+                "job": "copr_build",
+                "trigger": "commit",
+                "targets": ["fedora-rawhide", "fedora-stable"]
+            },
+            {
+                "job": "propose_downstream",
+                "trigger": "release",
+                "dist_git_branches": ["fedora-rawhide", "fedora-stable"]
+            },
+            {
+                "job": "koji_build",
+                "trigger": "commit",
+                "allowed_pr_authors": ["packit"],
+                "dist_git_branches": ["fedora-rawhide", "fedora-stable"]
+            },
+            {
+                "job": "bodhi_update",
+                "trigger": "commit",
+                "dist_git_branches": ["fedora-rawhide", "fedora-stable"]
+            }
+        ]
+    }
+    """
+
+
+MONOREPO_COPR_PACKIT_YAML = """
+    {
+        "upstream_project_url": "https://github.com/fedora-copr/copr.git",
+        "packages": {
+            "python": {
+                "downstream_package_name": "python-copr",
+                "upstream_package_name": "copr",
+                "paths": ["./python"],
+                "specfile_path": "python-copr.spec",
+                "files_to_sync": ["python-copr.spec"]
+            },
+            "cli": {
+                "downstream_package_name": "copr-cli",
+                "upstream_package_name": "copr-cli",
+                "paths": ["./cli"],
+                "specfile_path": "copr-cli.spec",
+                "files_to_sync": ["copr-cli.spec"]
+            },
+            "frontend": {
+                "downstream_package_name": "copr-frontend",
+                "upstream_package_name": "copr-frontend",
+                "paths": ["./frontend"],
+                "specfile_path": "copr-frontend.spec",
+                "files_to_sync": ["copr-frontend.spec"]
+            }
+        },
+        "jobs": [
+            {
+                "job": "copr_build",
+                "packages": ["cli", "python"],
+                "trigger": "pull_request",
+                "targets": "fedora-37",
+                "owner": "mmassari",
+                "project": "knx-stack"
+            },
+            {
+                "job": "vm_image_build",
+                "packages": ["cli", "python"],
+                "trigger": "pull_request",
+                "copr_chroot": "fedora-37-x86_64",
+                "owner": "mmassari",
+                "project": "knx-stack",
+                "image_customizations": {
+                    "packages": ["python-copr", "copr-cli"],
+                    "image_distribution": "fedora-37",
+                    "image_request": {
+                        "architecture": "x86_64",
+                        "image_type": "aws",
+                        "upload_request": {
+                            "type": "aws",
+                            "options": {}
+                        }
+                    }
+                }
+            }
+        ]
+    }
+    """
+
+
+@pytest.mark.parametrize(
+    "package_config_yaml,mock_api_calls,how_many_times,options",
+    [
+        pytest.param(
+            DEFAULT_CONFIG_YAML,
+            [("run_copr_build", ("build_id", "repo_url")), ("watch_copr_build", None)],
+            1,
+            ["build", "in-copr", "."],
+            id="default package config copr build",
+        ),
+        pytest.param(
+            MONOREPO_COPR_PACKIT_YAML,
+            [("run_copr_build", ("build_id", "repo_url")), ("watch_copr_build", None)],
+            2,
+            ["build", "in-copr", "--package=python", "--package=cli"],
+            id="monorepo build in copr for python and cli copr packages",
+        ),
+        pytest.param(
+            MONOREPO_COPR_PACKIT_YAML,
+            [("run_copr_build", ("build_id", "repo_url")), ("watch_copr_build", None)],
+            3,
+            ["build", "in-copr", "."],
+            id="monorepo copr build for all copr packages",
+        ),
+        pytest.param(
+            DEFAULT_CONFIG_YAML,
+            [("submit_vm_image_build", "build_id")],
+            0,  # there is no image builder job definition
+            ["build", "in-image-builder", "--no-wait", "."],
+            id="default package config image build",
+        ),
+        pytest.param(
+            MONOREPO_COPR_PACKIT_YAML,
+            [("submit_vm_image_build", "build_id")],
+            2,
+            [
+                "build",
+                "in-image-builder",
+                "--no-wait",
+                "--package=python",
+                "--package=cli",
+                ".",
+            ],
+            id="monorepo build in image builder for python and cli copr packages",
+        ),
+        pytest.param(
+            MONOREPO_COPR_PACKIT_YAML,
+            [("submit_vm_image_build", "build_id")],
+            2,  # there is no image builder job definition for frontend package (will fail)
+            ["build", "in-image-builder", "--no-wait", "."],
+            id="monorepo build in image builder for all copr packages",
+        ),
+        pytest.param(
+            DEFAULT_CONFIG_YAML,
+            [("create_srpm", "srpm_path")],
+            1,
+            ["srpm", "."],
+            id="default package config srpm build",
+        ),
+        pytest.param(
+            MONOREPO_COPR_PACKIT_YAML,
+            [("create_srpm", "srpm_path")],
+            2,
+            ["srpm", "--package=cli", "--package=frontend"],
+            id="monorepo srpm build for frontend and cli copr packages",
+        ),
+        pytest.param(
+            MONOREPO_COPR_PACKIT_YAML,
+            [("create_srpm", "srpm_path")],
+            3,
+            ["srpm", "."],
+            id="monorepo srpm build for all copr packages",
+        ),
+    ],
+)
+def test_iterate_packages(package_config_yaml, mock_api_calls, how_many_times, options):
+    package_config_dict = json.loads(package_config_yaml)
+
+    flexmock(package_config).should_receive("find_packit_yaml").and_return(
+        flexmock(name=".packit.yaml", parent="/some/dir/")
+    )
+    flexmock(package_config).should_receive("load_packit_yaml").and_return(
+        package_config_dict
+    )
+    # otherwise _dg and _local_project objects will be created
+    # by debugger threads and you are not able to debug them
+    flexmock(PackitAPI).should_receive("__repr__").and_return("")
+    flexmock(DistGit).should_receive("__repr__").and_return("")
+    flexmock(koji_build).should_receive("get_branches").and_return("rawhide")
+    flexmock(PackitAPI).should_receive("init_kerberos_ticket").and_return()
+    for call, result in mock_api_calls:
+        flexmock(PackitAPI).should_receive(call).and_return(result).times(
+            how_many_times
+        )
+
+    runner = CliRunner()
+    runner.invoke(packit_base, options)
+
+
+@pytest.mark.parametrize(
+    "package_config_yaml,mock_api_calls,how_many_times,options,dist_git,dist_git_is_git_repo",
+    [
+        pytest.param(
+            DEFAULT_CONFIG_YAML,
+            [("sync_status_string", None)],
+            1,
+            [
+                "source-git",
+                "status",
+                ".",
+                ".",
+            ],  # fake dist-git dir for click safety checks
+            "python-teamcity-messages",  # mocked dist-git value
+            True,
+            id="source git status for a default config",
+        ),
+        pytest.param(
+            DEFAULT_CONFIG_YAML,
+            [("sync_status_string", None)],
+            1,
+            [
+                "source-git",
+                "status",
+                ".",
+                ".",
+            ],  # fake dist-git dir for click safety checks
+            "teamcity-messages",  # mocked dist-git value
+            True,
+            id="source git status for a default config with no matching dist-git repo name",
+        ),
+        pytest.param(
+            DEFAULT_CONFIG_YAML,
+            [("sync_status_string", None)],
+            0,
+            [
+                "source-git",
+                "status",
+                ".",
+                ".",
+            ],  # fake dist-git dir for click safety checks
+            "teamcity-messages",  # mocked dist-git value
+            False,
+            id="source git status for a default config with no matching dist-git dir",
+        ),
+        pytest.param(
+            MONOREPO_COPR_PACKIT_YAML,
+            [("sync_status_string", None)],
+            1,
+            [
+                "source-git",
+                "status",
+                ".",
+                ".",
+            ],  # fake dist-git dir for click safety checks
+            "copr-cli",  # mocked dist-git value
+            True,
+            id="source git status for monorepo copr package copr-cli",
+        ),
+        pytest.param(
+            MONOREPO_COPR_PACKIT_YAML,
+            [("sync_status_string", None)],
+            1,
+            [
+                "source-git",
+                "status",
+                ".",
+                ".",
+            ],  # fake dist-git dir for click safety checks
+            "rpms",  # mocked dist-git value
+            False,
+            id="source git status for all the monorepo copr packages",
+        ),
+    ],
+)
+def test_iterate_packages_source_git(
+    package_config_yaml,
+    mock_api_calls,
+    how_many_times,
+    options,
+    dist_git,
+    dist_git_is_git_repo,
+):
+    package_config_dict = json.loads(package_config_yaml)
+
+    flexmock(PosixPath).should_receive("name").and_return(dist_git)
+    flexmock(PosixPath).should_receive("joinpath").with_args(".git").and_return(
+        flexmock().should_receive("exists").and_return(dist_git_is_git_repo).mock()
+    )
+    flexmock(PosixPath).should_receive("glob").and_return(
+        [
+            flexmock(is_dir=lambda: True, name="copr-cli")
+            .should_receive("joinpath")
+            .and_return(flexmock().should_receive("exists").and_return(True).mock())
+            .mock()
+        ]
+    )
+
+    flexmock(package_config).should_receive("load_packit_yaml").and_return(
+        package_config_dict
+    )
+    # otherwise _dg and _local_project objects will be created
+    # by debugger threads and you are not able to debug them
+    flexmock(PackitAPI).should_receive("__repr__").and_return("")
+    for call, result in mock_api_calls:
+        flexmock(PackitAPI).should_receive(call).and_return(result).times(
+            how_many_times
+        )
+
+    runner = CliRunner()
+    runner.invoke(packit_base, options)

--- a/tests/unit/test_iterate_packages.py
+++ b/tests/unit/test_iterate_packages.py
@@ -9,10 +9,12 @@ from click.testing import CliRunner
 from packit.config import (
     package_config,
 )
+from packit.local_project import LocalProject
 from packit.api import PackitAPI
 from packit.cli.packit_base import packit_base
 from packit.cli.builds import koji_build
 from packit.distgit import DistGit
+
 
 DEFAULT_CONFIG_YAML = """
     {
@@ -202,6 +204,13 @@ def test_iterate_packages(package_config_yaml, mock_api_calls, how_many_times, o
     )
     flexmock(package_config).should_receive("load_packit_yaml").and_return(
         package_config_dict
+    )
+    flexmock(LocalProject).should_receive("git_repo").and_return(
+        flexmock(
+            remotes=[],
+            active_branch=flexmock(name="an active branch"),
+            head=flexmock(is_detached=False),
+        )
     )
     # otherwise _dg and _local_project objects will be created
     # by debugger threads and you are not able to debug them

--- a/tests/unit/test_iterate_packages.py
+++ b/tests/unit/test_iterate_packages.py
@@ -129,6 +129,16 @@ MONOREPO_COPR_PACKIT_YAML = """
         pytest.param(
             MONOREPO_COPR_PACKIT_YAML,
             [("run_copr_build", ("build_id", "repo_url")), ("watch_copr_build", None)],
+            0,
+            ["build", "in-copr", "--package=python", "--package=unknown"],
+            id=(
+                "monorepo build in copr fails before any action is taken "
+                "if a package does not exist"
+            ),
+        ),
+        pytest.param(
+            MONOREPO_COPR_PACKIT_YAML,
+            [("run_copr_build", ("build_id", "repo_url")), ("watch_copr_build", None)],
             3,
             ["build", "in-copr", "."],
             id="monorepo copr build for all copr packages",

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -1,0 +1,131 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+import json
+import pytest
+from flexmock import flexmock
+from click.testing import CliRunner
+
+from packit.config import (
+    package_config,
+)
+from packit.api import PackitAPI
+from packit.cli.packit_base import packit_base
+from packit.cli.builds import koji_build
+from packit.distgit import DistGit
+
+DEFAULT_CONFIG_YAML = """
+    {
+        "specfile_path": "python-teamcity-messages.spec",
+        "files_to_sync": ["python-teamcity-messages.spec", ".packit.yaml"],
+        "upstream_package_name": "teamcity-messages",
+        "downstream_package_name": "python-teamcity-messages",
+        "upstream_project_url": "https://github.com/majamassarini/teamcity-messages",
+        "upstream_tag_template": "v{version}",
+        "jobs": [
+            {
+                "job": "copr_build",
+                "trigger": "commit",
+                "targets": ["fedora-rawhide", "fedora-stable"]
+            },
+            {
+                "job": "propose_downstream",
+                "trigger": "release",
+                "dist_git_branches": ["fedora-rawhide", "fedora-stable"]
+            },
+            {
+                "job": "koji_build",
+                "trigger": "commit",
+                "allowed_pr_authors": ["packit"],
+                "dist_git_branches": ["fedora-rawhide", "fedora-stable"]
+            },
+            {
+                "job": "bodhi_update",
+                "trigger": "commit",
+                "dist_git_branches": ["fedora-rawhide", "fedora-stable"]
+            }
+        ]
+    }
+    """
+
+
+MONOREPO_CONFIG_YAML = """
+    {
+        "upstream_project_url": "https://github.com/majamassarini/teamcity-messages",
+        "packages": {
+            "python-teamcity-messages": {
+                "downstream_package_name": "python-teamcity-messages",
+                "paths": ["."],
+                "specfile_path": "python-teamcity-messages.spec",
+                "files_to_sync": ["python-teamcity-messages.spec", ".packit.yaml"],
+                "upstream_package_name": "teamcity-messages",
+                "upstream_tag_template": "v{version}"
+            },
+            "python-teamcity-messages-fake": {
+                "downstream_package_name": "python-teamcity-messages-fake",
+                "paths": ["."],
+                "specfile_path": "python-teamcity-messages.spec",
+                "files_to_sync": ["python-teamcity-messages.spec", ".packit.yaml"],
+                "upstream_package_name": "teamcity-messages",
+                "upstream_tag_template": "v{version}"
+            }
+        },
+        "jobs": [
+            {
+                "job": "copr_build",
+                "trigger": "commit",
+                "targets": ["fedora-rawhide", "fedora-stable"],
+                "packages": ["python-teamcity-messages-fake"]
+            },
+            {
+                "job": "propose_downstream",
+                "trigger": "release",
+                "dist_git_branches": ["fedora-rawhide", "fedora-stable"],
+                "packages": ["python-teamcity-messages-fake"]
+            },
+            {
+                "job": "koji_build",
+                "trigger": "commit",
+                "allowed_pr_authors": ["packit"],
+                "dist_git_branches": ["fedora-rawhide", "fedora-stable"],
+                "packages": ["python-teamcity-messages-fake"]
+            },
+            {
+                "job": "bodhi_update",
+                "trigger": "commit",
+                "dist_git_branches": ["fedora-rawhide", "fedora-stable"],
+                "packages": ["python-teamcity-messages-fake"]
+            }
+        ]
+    }
+    """
+
+
+@pytest.mark.parametrize(
+    "package_config_yaml,how_many_builds",
+    [
+        pytest.param(DEFAULT_CONFIG_YAML, 1, id="default package config"),
+        pytest.param(MONOREPO_CONFIG_YAML, 2, id="monorepo package config"),
+    ],
+)
+def test_koji_build(package_config_yaml, how_many_builds):
+    package_config_dict = json.loads(package_config_yaml)
+
+    flexmock(package_config).should_receive("find_packit_yaml").and_return(
+        flexmock(name=".packit.yaml", parent="/some/dir/teamcity-messages")
+    )
+    flexmock(package_config).should_receive("load_packit_yaml").and_return(
+        package_config_dict
+    )
+    # otherwise _dg and _local_project objects will be created
+    # by debugger threads and you are not able to debug them
+    flexmock(PackitAPI).should_receive("__repr__").and_return("")
+    flexmock(DistGit).should_receive("__repr__").and_return("")
+    flexmock(koji_build).should_receive("get_branches").and_return("rawhide")
+    flexmock(PackitAPI).should_receive("init_kerberos_ticket").and_return()
+    if how_many_builds == 1:
+        flexmock(PackitAPI).should_receive("build").and_return().once()
+    elif how_many_builds == 2:
+        flexmock(PackitAPI).should_receive("build").and_return().twice()
+
+    runner = CliRunner()
+    runner.invoke(packit_base, ["build", "in-koji"])

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -8,6 +8,7 @@ from click.testing import CliRunner
 from packit.config import (
     package_config,
 )
+from packit.local_project import LocalProject
 from packit.api import PackitAPI
 from packit.cli.packit_base import packit_base
 from packit.cli.builds import koji_build
@@ -115,6 +116,13 @@ def test_koji_build(package_config_yaml, how_many_builds):
     )
     flexmock(package_config).should_receive("load_packit_yaml").and_return(
         package_config_dict
+    )
+    flexmock(LocalProject).should_receive("git_repo").and_return(
+        flexmock(
+            remotes=[],
+            active_branch=flexmock(name="an active branch"),
+            head=flexmock(is_detached=False),
+        )
     )
     # otherwise _dg and _local_project objects will be created
     # by debugger threads and you are not able to debug them


### PR DESCRIPTION
###  TODO:

- [x] Refactorize source git related commands -> there is no `--dist-git-storage` option yet, the `DIST_GIT` given directory is checked: if it contains a git repo match it otherwise loop the subdir to match subpackages by name.
- [x] Add some more unit tests
- [x] Test new packit code in a packit-service job call (real not just unit and integration tests)

### Notes for reviewers

#### Copr configuration used for test purpose
```yaml
packit_instances: ["stg"]
upstream_project_url: https://github.com/fedora-copr/copr.git

packages:

  python:
    downstream_package_name: python-copr
    upstream_package_name: copr
    paths: 
      - ./python
    specfile_path: python-copr.spec
    files_to_sync: 
      - python-copr.spec

  cli:
    downstream_package_name: copr-cli
    upstream_package_name: copr-cli
    paths: 
      - ./cli
    specfile_path: copr-cli.spec
    files_to_sync: 
      - copr-cli.spec

  frontend:
    downstream_package_name: copr-frontend
    upstream_package_name: copr-frontend
    paths: 
      - ./frontend
    specfile_path: copr-frontend.spec
    files_to_sync: 
      - copr-frontend.spec

jobs:
  - job: copr_build
    packages:
      - cli
      - python
    trigger: pull_request
    targets: fedora-37
    owner: mmassari
    project: knx-stack
  - job: vm_image_build
    packages:
      - cli
    trigger: pull_request
    copr_chroot: fedora-37-x86_64
    owner: mmassari
    project: knx-stack
    image_customizations:
      packages: [python-copr, copr-cli]
    image_distribution: fedora-37
    image_request:
      architecture: x86_64
      image_type: aws
      upload_request:
        type: aws
        options: {}
```

#### Open questions:

 - [x] I assume `paths` is just a single string for every package and I use it to change the `workdir` associated with the subpackage -> with @csomh we decided to live it as it is now, we need to further investigate the llvm use case scenario
 - [x] I don't know how to find the `upstream version` for any single monorepo sub-package, `git describe` will always return the same tag,  the last one, not necessary associated with the sub-package. Now I am printing a warning.
 - [x] Do we want a new `CommonPackageConfig` like class which also knows if it belongs to a monorepo or not and which also knows its related jobs? For now I am injecting data to the old class... At the end I created a `PackageConfigView` class: which has a runtime constraint to have just one `CommonPackageConfig` object and its related jobs.

Fixes #1849

RELEASE NOTES BEGIN
Packit now supports monorepo configuration in CLI
RELEASE NOTES END
