### PR TITLE
validation: Consider globs when validating the files to sync

### DIFF
--- a/packit/config/package_config_validator.py
+++ b/packit/config/package_config_validator.py
@@ -64,7 +64,9 @@ class PackageConfigValidator:
             synced_files_errors = [
                 f
                 for f in iter_srcs(config.files_to_sync)
-                if not (self.project_path / f).exists()
+                if not (
+                    (self.project_path / f).exists() or any(self.project_path.glob(f))
+                )
             ]
 
         output = f"{self.config_file_path.name} does not pass validation:\n"

--- a/tests/integration/test_validate_synced_files.py
+++ b/tests/integration/test_validate_synced_files.py
@@ -15,34 +15,43 @@ from packit.utils.commands import cwd
         (
             ["a.md", "b.md"],
             ["./a_dir"],
-            """
-            {
-                "config_file_path": "packit.json",
-                "dist_git_base_url": "https://packit.dev/",
-                "downstream_package_name": "packit",
-                "upstream_ref": "last_commit",
-                "upstream_package_name": "packit_upstream",
-                "allowed_gpg_keys": ["gpg"],
-                "dist_git_namespace": "awesome",
-                "synced_files": [{ "src": "a.md", "dest": "aaa.md" }, "a_dir"]
-            }
+            """\
+config_file_path: .packit.yaml
+dist_git_base_url: https://packit.dev/
+downstream_package_name: packit
+upstream_ref: last_commit
+upstream_package_name: packit_upstream
+allowed_gpg_keys:
+- gpg
+dist_git_namespace: awesome
+files_to_sync:
+- .packit.yaml
+- packit.spec
+- src: a.md
+  dest: aaa.md
+- a_dir
             """,
-            "packit.json is valid and ready to be used",
+            ".packit.yaml is valid and ready to be used",
         ),
         (
             ["a.md", "b.md"],
             ["./a_dir"],
-            """
-            {
-                "config_file_path": "packit.json",
-                "dist_git_base_url": "https://packit.dev/",
-                "downstream_package_name": "packit",
-                "upstream_ref": "last_commit",
-                "upstream_package_name": "packit_upstream",
-                "allowed_gpg_keys": ["gpg"],
-                "dist_git_namespace": "awesome",
-                "synced_files": ["a.md", "b.md", "c.txt", "a_dir"]
-            }
+            """\
+config_file_path: .packit.yaml
+dist_git_base_url: https://packit.dev/
+downstream_package_name: packit
+upstream_ref: last_commit
+upstream_package_name: packit_upstream
+allowed_gpg_keys:
+- gpg
+dist_git_namespace: awesome
+files_to_sync:
+- .packit.yaml
+- packit.spec
+- a.md
+- b.md
+- c.txt
+- a_dir
             """,
             "The following path is configured to be synced but is not present "
             "in the repository: c.txt",
@@ -50,17 +59,21 @@ from packit.utils.commands import cwd
         (
             ["a.md"],
             [],
-            """
-             {
-                 "config_file_path": "packit.json",
-                 "dist_git_base_url": "https://packit.dev/",
-                 "downstream_package_name": "packit",
-                 "upstream_ref": "last_commit",
-                 "upstream_package_name": "packit_upstream",
-                 "allowed_gpg_keys": ["gpg"],
-                 "dist_git_namespace": "awesome",
-                 "synced_files": ["a.md", "b.md", "c.txt"]
-             }
+            """\
+config_file_path: .packit.yaml
+dist_git_base_url: https://packit.dev/
+downstream_package_name: packit
+upstream_ref: last_commit
+upstream_package_name: packit_upstream
+allowed_gpg_keys:
+- gpg
+dist_git_namespace: awesome
+files_to_sync:
+- .packit.yaml
+- packit.spec
+- a.md
+- b.md
+- c.txt
              """,
             "The following paths are configured to be synced but are not present "
             "in the repository: b.md, c.txt",
@@ -68,17 +81,22 @@ from packit.utils.commands import cwd
         (
             ["a.md", "./a_dir/file"],
             ["./a_dir"],
-            """
-             {
-                 "config_file_path": "packit.json",
-                 "dist_git_base_url": "https://packit.dev/",
-                 "downstream_package_name": "packit",
-                 "upstream_ref": "last_commit",
-                 "upstream_package_name": "packit_upstream",
-                 "allowed_gpg_keys": ["gpg"],
-                 "dist_git_namespace": "awesome",
-                 "synced_files": ["a.md", "b.md", "c.txt", "./a_dir/*"]
-             }
+            """\
+config_file_path: .packit.yaml
+dist_git_base_url: https://packit.dev/
+downstream_package_name: packit
+upstream_ref: last_commit
+upstream_package_name: packit_upstream
+allowed_gpg_keys:
+- gpg
+dist_git_namespace: awesome
+files_to_sync:
+- .packit.yaml
+- packit.spec
+- a.md
+- b.md
+- c.txt
+- ./a_dir/*
              """,
             "The following paths are configured to be synced but are not present "
             "in the repository: b.md, c.txt",
@@ -86,20 +104,46 @@ from packit.utils.commands import cwd
         (
             ["a.md", "b.md"],
             ["./a_dir"],
-            """
-             {
-                 "config_file_path": "packit.json",
-                 "dist_git_base_url": "https://packit.dev/",
-                 "downstream_package_name": "packit",
-                 "upstream_ref": "last_commit",
-                 "upstream_package_name": "packit_upstream",
-                 "allowed_gpg_keys": ["gpg"],
-                 "dist_git_namespace": "awesome",
-                 "synced_files": ["./a_dir/*", "a.md", "b.md", "c.txt"]
-             }
+            """\
+config_file_path: .packit.yaml
+dist_git_base_url: https://packit.dev/
+downstream_package_name: packit
+upstream_ref: last_commit
+upstream_package_name: packit_upstream
+allowed_gpg_keys:
+- gpg
+dist_git_namespace: awesome
+files_to_sync:
+- .packit.yaml
+- packit.spec
+- ./a_dir/*
+- a.md
+- b.md
+- c.txt
              """,
             "The following paths are configured to be synced but are not present "
             "in the repository: ./a_dir/*, c.txt",
+        ),
+        (
+            ["a.md", "b.md"],
+            ["./a_dir"],
+            """\
+config_file_path: .packit.yaml
+dist_git_base_url: https://packit.dev/
+downstream_package_name: packit
+upstream_ref: last_commit
+upstream_package_name: packit_upstream
+allowed_gpg_keys:
+- gpg
+dist_git_namespace: awesome
+files_to_sync:
+- .packit.yaml
+- packit.spec
+- ./a_dir
+- a.md
+- b.md
+             """,
+            ".packit.yaml is valid and ready to be used",
         ),
     ],
     ids=[
@@ -108,13 +152,14 @@ from packit.utils.commands import cwd
         "two_missing",
         "dir_with_globs",
         "empty_dir_with_globs",
+        "empty_dir",
     ],
 )
 def test_validate_paths(
     tmpdir, existing_files, existing_directories, raw_package_config, expected_output
 ):
     with cwd(tmpdir):
-        Path("packit.json").write_text(raw_package_config)
+        Path(".packit.yaml").write_text(raw_package_config)
         Path("packit.spec").write_text("hello")
         for existing_directory in existing_directories:
             Path(existing_directory).mkdir()

--- a/tests/integration/test_validate_synced_files.py
+++ b/tests/integration/test_validate_synced_files.py
@@ -65,11 +65,49 @@ from packit.utils.commands import cwd
             "The following paths are configured to be synced but are not present "
             "in the repository: b.md, c.txt",
         ),
+        (
+            ["a.md", "./a_dir/file"],
+            ["./a_dir"],
+            """
+             {
+                 "config_file_path": "packit.json",
+                 "dist_git_base_url": "https://packit.dev/",
+                 "downstream_package_name": "packit",
+                 "upstream_ref": "last_commit",
+                 "upstream_package_name": "packit_upstream",
+                 "allowed_gpg_keys": ["gpg"],
+                 "dist_git_namespace": "awesome",
+                 "synced_files": ["a.md", "b.md", "c.txt", "./a_dir/*"]
+             }
+             """,
+            "The following paths are configured to be synced but are not present "
+            "in the repository: b.md, c.txt",
+        ),
+        (
+            ["a.md", "b.md"],
+            ["./a_dir"],
+            """
+             {
+                 "config_file_path": "packit.json",
+                 "dist_git_base_url": "https://packit.dev/",
+                 "downstream_package_name": "packit",
+                 "upstream_ref": "last_commit",
+                 "upstream_package_name": "packit_upstream",
+                 "allowed_gpg_keys": ["gpg"],
+                 "dist_git_namespace": "awesome",
+                 "synced_files": ["./a_dir/*", "a.md", "b.md", "c.txt"]
+             }
+             """,
+            "The following paths are configured to be synced but are not present "
+            "in the repository: ./a_dir/*, c.txt",
+        ),
     ],
     ids=[
         "none_missing",
         "one_missing",
         "two_missing",
+        "dir_with_globs",
+        "empty_dir_with_globs",
     ],
 )
 def test_validate_paths(
@@ -78,10 +116,10 @@ def test_validate_paths(
     with cwd(tmpdir):
         Path("packit.json").write_text(raw_package_config)
         Path("packit.spec").write_text("hello")
-        for existing_file in existing_files:
-            Path(existing_file).write_text("")
         for existing_directory in existing_directories:
             Path(existing_directory).mkdir()
+        for existing_file in existing_files:
+            Path(existing_file).write_text("")
 
         output = PackitAPI.validate_package_config(Path("."))
         assert expected_output in output


### PR DESCRIPTION
TODO:

- [x] Write new tests or update the old ones to cover new functionality.

RELEASE NOTES BEGIN

'packit validate-config' now correctly checks glob-patterns in 'files_to_sync'.

RELEASE NOTES END
