### PR TITLE
Enable building and testing all Fedora versions in PRs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -47,12 +47,12 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      - fedora-stable
+      - fedora-all
       - epel-9
   - job: tests
     trigger: pull_request
     targets:
-      - fedora-stable
+      - fedora-all
       - epel-9
 
   - job: copr_build


### PR DESCRIPTION
Configure Packit to build and test in all Fedora versions in PRs, in order to be in line with how Packit is built in the main an stable branches.