### PR TITLE
fix: specify User-Agent when downloading sources

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -1,7 +1,9 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+import os
 import shlex
+from importlib.metadata import version
 from logging import getLogger
 from pathlib import Path
 from typing import Optional, Callable, List, Iterable, Dict, Tuple
@@ -483,6 +485,11 @@ class PackitRepositoryBase:
         Raises:
             PackitDownloadFailedException if download fails for any reason.
         """
+        user_agent = (
+            os.getenv("PACKIT_USER_AGENT")
+            or f"packit/{version('packitos')} (hello+cli@packit.dev)"
+        )
+
         sourcelist = []
         # Fetch all sources defined in packit.yaml -> sources
         for source in self.package_config.sources:
@@ -515,7 +522,9 @@ class PackitRepositoryBase:
             if source_path.is_file():
                 continue
             try:
-                with requests.get(url, stream=True) as response:
+                with requests.get(
+                    url, headers={"User-Agent": user_agent}, stream=True
+                ) as response:
                     response.raise_for_status()
                     with open(source_path, "wb") as f:
                         for chunk in response.iter_content(chunk_size=8192):


### PR DESCRIPTION
When downloading sources from the remote, remote may have a protection against crawlers, etc. and deny generic user agent provided by the requests.

Specify explicitly user agent with a reference to the Packit.

Related to packit/packit-service#1948

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Related to packit/packit-service#1948
