### PR TITLE
Use '--match' when looking for the version tag in git

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -317,7 +317,16 @@ class Upstream(PackitRepositoryBase):
         )
 
         try:
-            cmd = ["git", "describe", "--tags", "--abbrev=0"]
+            version_tag_glob = self.package_config.upstream_tag_template.replace(
+                "{version}", "?*"
+            )
+            cmd = [
+                "git",
+                "describe",
+                "--tags",
+                "--abbrev=0",
+                f"--match={version_tag_glob}",
+            ]
             if before:
                 cmd += [f"{before}^"]
             last_tag = run_command(


### PR DESCRIPTION
With this it becomes possible to have earlier tags, which do not match the upstream tag template, ignored, and only the tags matching the pattern considered when determining the current version.

Resolves #1885.

TODO:

- [x] Write new tests or update the old ones to cover new functionality.

RELEASE NOTES BEGIN

'upstream_tag_template' is now also used when looking for the latest version tag in Git. This allows upstream repositories to mix different tag-patterns in the same repository, but consider only one to tell the latest version.

RELEASE NOTES END
