### PR TITLE
PackitAPI.sync_push() checkouts dist-git branch as well

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -879,6 +879,7 @@ The first dist-git commit to be synced is '{short_hash}'.
 
     def sync_push(
         self,
+        dist_git_branch: Optional[str] = None,
         source_git_branch: Optional[str] = None,
         create_pr: bool = True,
         title: Optional[str] = None,
@@ -889,6 +890,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         When dist-git is updated then update the source-git repository by opening a PR.
 
         Args:
+            dist_git_branch: Dist-git branch, defaults to repo's default branch.
             source_git_branch: Branch in source-git, defaults to repo's default branch.
             create_pr: Create a pull request if set to True.
             force: Ignore changes in the git index.
@@ -916,11 +918,16 @@ The first dist-git commit to be synced is '{short_hash}'.
                 " will not discard the changes. Use --force to bypass."
             )
 
+        dist_git_branch = (
+            dist_git_branch or self.dg.local_project.git_project.default_branch
+        )
         source_git_branch = (
             source_git_branch or self.up.local_project.git_project.default_branch
         )
+
         pr = None
         try:
+            self.dg.checkout_branch(dist_git_branch)
             self.up.checkout_branch(source_git_branch)
             self.update_source_git()
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -129,6 +129,7 @@ def mock_remote_functionality(distgit: Path, upstream: Path):
         fork_create=lambda: None,
         get_fork=lambda: PagureProject("", "", PagureService()),
         create_pr=mocked_create_pr,
+        default_branch="main",
     )
     flexmock(
         GithubProject,


### PR DESCRIPTION
The called `update_source_git()` expects the dist-git repo to be already switched to the branch we want to sync from.

Required for packit/hardly#92
