### PR TITLE
Support %autorelease in `set_specfile_content()`

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -423,6 +423,7 @@ class PackitRepositoryBase:
         if (
             previous_version != self.specfile.expanded_version
             and previous_release == self.specfile.release
+            and self.specfile.release != "%autorelease"
         ):
             # This may occur if the upstream forgets to reset release after
             # bumping the version, or if the specfile is not maintained in


### PR DESCRIPTION
Fixes #1879.

RELEASE NOTES BEGIN

Packit now preserves `%autorelease` during `propose_downstream` and `pull_from_upstream`.

RELEASE NOTES END
