### PR TITLE
Always use the subpackage name as suffix

### DIFF
--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -145,7 +145,7 @@ class JobConfigView(JobConfig):
         original_identifier = super().__getattr__("identifier")
         if original_identifier is None:
             return self._view_for_package
-        return original_identifier
+        return original_identifier + ":" + self._view_for_package
 
 
 def get_default_jobs() -> List[Dict]:

--- a/tests/unit/test_config/test_config.py
+++ b/tests/unit/test_config/test_config.py
@@ -294,7 +294,7 @@ def test_koji_build_allowlist(raw, expected, allowed_pr_authors, allowed_committ
                     },
                     "package_b": {
                         "downstream_package_name": "package_b",
-                        "identifier": "identifier_for_package_b",
+                        "identifier": "an_identifier",
                         "paths": ["."],
                         "specfile_path": "package_b.spec",
                         "files_to_sync": ["package_b.spec", ".packit.yaml"],
@@ -331,7 +331,7 @@ def test_koji_build_allowlist(raw, expected, allowed_pr_authors, allowed_committ
                 ["package_b"],
                 ["package_c"],
             ],
-            ["package_a", "identifier_for_package_b", None],
+            ["package_a", "an_identifier:package_b", None],
         ),
     ],
 )


### PR DESCRIPTION
Should fix the check statuses label for all jobs
