### PR TITLE
Do not sign off commits

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -177,8 +177,7 @@ class PackitRepositoryBase:
         self.local_project.git_repo.index.write()
 
         with commit_message_file(main_msg, msg, trailers) as commit_message:
-            # TODO: make -s configurable
-            commit_args = ["-s", "-F", commit_message]
+            commit_args = ["-F", commit_message]
             self.local_project.git_repo.git.commit(*commit_args)
 
     def run_action(self, actions: ActionName, method: Callable = None, *args, **kwargs):


### PR DESCRIPTION
I have no clue why it was added in the first place.

Resolves #1933.

RELEASE NOTES BEGIN

Removed adding the "Signed-off-by" tag to commits created by Packit.

RELEASE NOTES END
