### PR TITLE
Fix source git trailer not exists

### DIFF
--- a/packit/cli/builds/koji_build.py
+++ b/packit/cli/builds/koji_build.py
@@ -110,7 +110,15 @@ def koji(
     branches_to_build = get_branches(
         *dist_git_branch.split(","), default_dg_branch=default_dg_branch
     )
-    click.echo(f"Building from the following branches: {', '.join(branches_to_build)}")
+    package = (
+        package_config.downstream_package_name
+        if package_config.downstream_package_name
+        else package_config.upstream_package_name
+    )
+    click.echo(
+        f"Building from the following branches: {', '.join(branches_to_build)}, "
+        f"for package {package}"
+    )
 
     if koji_target is None:
         targets_to_build = {None}

--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -235,7 +235,13 @@ def iterate_packages_source_git(func):
                         )  # reset working variables like srpm_path
                         decorated_func_kwargs["dist_git"] = str(repo_dir)
                         decorated_func_kwargs["package_config"] = package
-                        func(*args, **decorated_func_kwargs)
+                        try:
+                            func(*args, **decorated_func_kwargs)
+                        except PackitException as ex:
+                            if "git trailer does not exist" in str(ex):
+                                pass
+                            else:
+                                raise ex
                         found_func = True
 
         if not found_func:


### PR DESCRIPTION
RELEASE NOTES BEGIN
`packit source-git` related commands can skip dist-git repos, where the git trailer is not found, when looking for the right dist-git dir where to work.
RELEASE NOTES END
