### PR TITLE
Reset release when version in upstream spec is not up-to-date

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -419,10 +419,15 @@ class PackitRepositoryBase:
         if version is not None:
             self.specfile.version = version
         if (
-            previous_version != self.specfile.expanded_version
+            # version in upstream spec doesn't match the desired version
+            # -> ignore release from upstream spec and reset it to 1
+            specfile.expanded_version != self.specfile.expanded_version
+            # previous version in dist-git spec doesn't match the desired version
+            # and previous release in dist-git spec matches release in upstream spec
+            # -> reset release to 1
+            or previous_version != self.specfile.expanded_version
             and previous_release == self.specfile.release
-            and self.specfile.release != "%autorelease"
-        ):
+        ) and self.specfile.release != "%autorelease":
             # This may occur if the upstream forgets to reset release after
             # bumping the version, or if the specfile is not maintained in
             # upstream at all (e.g. post-upstream-clone that uses wget to

--- a/tests/unit/test_base_git.py
+++ b/tests/unit/test_base_git.py
@@ -458,15 +458,23 @@ def test_set_spec_content(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "dg_raw_release,up_raw_release,expected_dg_release",
+    "dg_raw_version,dg_raw_release,up_raw_version,up_raw_release,expected_dg_release",
     [
-        ("2%{?dist}", "2%{?dist}", "1"),
-        ("2%{?dist}", "3%{?dist}", "3"),
-        ("%autorelease", "%autorelease", "%autorelease"),
+        ("1.0", "2%{?dist}", "1.0", "2%{?dist}", "1"),
+        ("1.0", "2%{?dist}", "1.0", "3%{?dist}", "1"),
+        ("1.0", "2%{?dist}", "1.1", "2%{?dist}", "1"),
+        ("1.0", "2%{?dist}", "1.1", "3%{?dist}", "3"),
+        ("1.0", "%autorelease", "1.0", "%autorelease", "%autorelease"),
+        ("1.0", "%autorelease", "1.1", "%autorelease", "%autorelease"),
     ],
 )
 def test_set_spec_content_reset_release(
-    tmp_path, dg_raw_release, up_raw_release, expected_dg_release
+    tmp_path,
+    dg_raw_version,
+    dg_raw_release,
+    up_raw_version,
+    up_raw_release,
+    expected_dg_release,
 ):
     def changelog(release):
         # %autorelease implies %autochangelog
@@ -479,7 +487,7 @@ def test_set_spec_content_reset_release(
 
     distgit_spec_contents = (
         "Name: bring-me-to-the-life\n"
-        "Version: 1.0\n"
+        f"Version: {dg_raw_version}\n"
         f"Release: {dg_raw_release}\n"
         "Source0: foo.bar\n"
         "License: GPLv3+\n"
@@ -492,7 +500,7 @@ def test_set_spec_content_reset_release(
 
     upstream_spec_contents = (
         "Name: bring-me-to-the-life\n"
-        "Version: 1.0\n"
+        f"Version: {up_raw_version}\n"
         f"Release: {up_raw_release}\n"
         "Source0: foo.bor\n"
         "License: MIT\n"


### PR DESCRIPTION
Fixes #1932.

---

What happened with [noggin-messages](https://github.com/fedora-infra/noggin-messages):

- the spec file was downloaded in `post-upstream-clone` from the `main` branch of Fedora dist-git
- in `rawhide`, the VR was `1.0.2-5`
- in `f37`, the VR was `1.0.2-4`
- `propose_downstream` bumped the version to `1.0.3` (based on `get-current-version`) and:
  - in `rawhide` reset the release, because release in upstream specfile was the same as release in dist-git specfile (because it was the same file)
  - in `f37` didn't reset the release, because release in upstream specfile (taken from `rawhide`/`main`) was higher than release in dist-git specfile
- the resulting VR in `f37` was `1.0.3-5`, while in `rawhide` it was `1.0.3-1` => violation of Fedora versioning policies

---

RELEASE NOTES BEGIN

Packit now resets `Release` field in dist-git spec file to 1 when the version in upstream spec file is not up-to-date with the release that triggered `propose_downstream`.

RELEASE NOTES END
