### PR TITLE
Fix removing "branches/" prefix from "upstream_ref"

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -746,7 +746,7 @@ class Upstream(PackitRepositoryBase):
 
         tag = self.command_handler.run_command(
             get_current_version_command(
-                ref.lstrip("branches/"),
+                ref.removeprefix("branches/"),
                 refs="all" if ref.startswith("branches/") else "tags",
             ),
             return_output=True,


### PR DESCRIPTION
In case `upstream_ref` contains a branch name (and thus it is supposed to start with `branches/`), then properly use `removeprefix()` to drop the `branches/` prefix.

`lstrip()` literally removes all the characters specified in the parameter string from the beginning of the string until any other character is found, so `upstream_ref=sample-*` will be turned into `upstream_ref=ample-*` (note the missing "s", as it is in `branches/`).

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

RELEASE NOTES BEGIN

Packit now properly respects "upstream_ref" for tags that start with "a", "b", "c", "e", "n", "r", "s".

RELEASE NOTES END
