### PR TITLE
Work on a single package at time

### DIFF
--- a/packit/constants.py
+++ b/packit/constants.py
@@ -146,7 +146,7 @@ COPR_SOURCE_SCRIPT = """
 git config --global user.email "hello@packit.dev"
 git config --global user.name "Packit"
 resultdir=$PWD
-packit -d prepare-sources --result-dir "$resultdir" {options}
+packit -d prepare-sources{package} --result-dir "$resultdir" {options}
 
 """
 

--- a/packit/utils/source_script.py
+++ b/packit/utils/source_script.py
@@ -12,6 +12,7 @@ def create_source_script(
     job_config_index: Optional[int] = None,
     update_release: bool = True,
     release_suffix: Optional[str] = None,
+    package: Optional[str] = None,
 ):
     options = []
     if ref:
@@ -31,4 +32,6 @@ def create_source_script(
     options += ["--no-create-symlinks"]
 
     options += [url]
-    return COPR_SOURCE_SCRIPT.format(options=" ".join(options))
+    return COPR_SOURCE_SCRIPT.format(
+        package=f" -p {package}" if package else "", options=" ".join(options)
+    )


### PR DESCRIPTION
When calling packit if working on a monorepo sub-package related job then use job_config.package

Related to packit-service monorepo fixes

Merge before packit/packit-service#2018