### PR TITLE
Always preserve `%autorelease` if it is used in dist-git

### DIFF
--- a/files/local-tests-requirements.yaml
+++ b/files/local-tests-requirements.yaml
@@ -5,6 +5,7 @@
     - ansible.builtin.include_tasks: tasks/project-dir.yaml
     - ansible.builtin.include_tasks: tasks/rpm-test-deps.yaml
     - ansible.builtin.include_tasks: tasks/ogr.yaml
+    - ansible.builtin.include_tasks: tasks/specfile.yaml
     - ansible.builtin.include_tasks: tasks/sandcastle.yaml
     - ansible.builtin.include_tasks: tasks/centpkg.yaml
     # To (re-)generate tests_recording/test_data/

--- a/plans/full.fmf
+++ b/plans/full.fmf
@@ -1,6 +1,13 @@
 summary: Unit, integration & functional tests.
 discover+:
   filter: tier:1
+prepare:
+  # enable packit-dev Copr repo to get the latest builds of ogr and specfile
+  - how: install
+    copr: packit/packit-dev
+  # make sure the Copr repo has higher priority than TF Tag Repository
+  - how: shell
+    script: dnf -y config-manager --save --setopt="*:packit:packit-dev.priority=5"
 adjust:
   - when: "distro == rhel-9 or distro == centos-9 or distro == centos-stream-9"
     because: "flexmock and deepdiff are not in EPEL 9: https://bugzilla.redhat.com/show_bug.cgi?id=2120251"


### PR DESCRIPTION
Fixes #1944.

Please see comments in the code and the added test cases to understand the logic, hopefully it makes sense.

RELEASE NOTES BEGIN

Detection of `%autorelease` usage in dist-git spec file during `propose-downstream` and `pull-from-upstream` has been improved and Packit will always preserve it.

RELEASE NOTES END
