### PR TITLE
Make get_package_config_for() work with no job_config

### DIFF
--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -206,7 +206,7 @@ class PackageConfig(MultiplePackages):
         """Set a dictionary of package name -> PackageConfigView
         every PackageConfigView holds just one package (the named one)
         and its associated jobs.
-        A Monorepo PackageConfig will be splitted in many of them.
+        A Monorepo PackageConfig will be split in many of them.
 
         NOTE: not using a property because of the custom __setattr__
         """
@@ -219,7 +219,7 @@ class PackageConfig(MultiplePackages):
         a multiple packages config.
         """
         package_config_views = self.get_package_config_views()
-        if not package_config_views:
+        if not package_config_views or not job_config:
             # the package config views were not initialized
             # we can continue if this is not a monorepo
             if len(self.packages) == 1:


### PR DESCRIPTION
There are places in packit-service/hardly worker
- https://github.com/packit/packit-service/blob/63831f0a3a320498fd7037af1c83827a36c68c3f/packit_service/worker/jobs.py#L174
- https://github.com/packit/packit-service/blob/63831f0a3a320498fd7037af1c83827a36c68c3f/packit_service/worker/jobs.py#L185
- https://github.com/packit/hardly/blob/d3952bcb7d06cd63bd72ac66e95528085c30eed8/hardly/jobs.py#L51

where we call the [JobHandler.get_signature()](https://github.com/packit/packit-service/blob/63831f0a3a320498fd7037af1c83827a36c68c3f/packit_service/worker/handlers/abstract.py#L354) with the `job` argument being `None`. The `get_signature()` then passes it to the `PackageConfig.get_package_config_for()`, which fails when it tries to access the job.

With this change, it returns itself (if there's just one package).

@majamassarini  I don't know whether this is the right place to fix it.