### PR TITLE
PackageConfigValidator now raises exception if validate() fails

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1740,7 +1740,18 @@ The first dist-git commit to be synced is '{short_hash}'.
 
     @staticmethod
     def validate_package_config(working_dir: Path) -> str:
-        """validate .packit.yaml on the provided path and return human readable report"""
+        """Validate package config.
+
+        Args:
+            working_dir: Directory with the package config.
+
+        Returns:
+            String that the config is valid.
+
+        Raises:
+            PackitConfigException: when the config is not valid
+        """
+
         config_path = find_packit_yaml(
             working_dir,
             try_local_dir_last=True,

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -271,7 +271,7 @@ def find_packit_yaml(
         try_local_dir_last: If set to `True` check the current working directory
             last.
 
-            Defautls to `False`.
+            Defaults to `False`.
 
     Returns:
         Path to the config.

--- a/packit/config/package_config_validator.py
+++ b/packit/config/package_config_validator.py
@@ -31,7 +31,14 @@ class PackageConfigValidator:
         self.project_path = project_path
 
     def validate(self) -> str:
-        """Create output for PackageConfig validation."""
+        """Validate PackageConfig.
+
+        Returns:
+            String that the config is valid.
+
+        Raises:
+            PackitConfigException: when the config is not valid
+        """
         schema_errors: Union[List[Any], Dict[Any, Any]] = None
         config = None
         try:
@@ -44,8 +51,6 @@ class PackageConfigValidator:
             )
         except ValidationError as e:
             schema_errors = e.messages
-        except PackitConfigException as e:
-            return str(e)
 
         specfile_path = self.content.get("specfile_path", None)
         if specfile_path and not (self.project_path / specfile_path).is_file():
@@ -97,7 +102,7 @@ class PackageConfigValidator:
             )
 
         if schema_errors or synced_files_errors:
-            return output
+            raise PackitConfigException(output)
         else:
             return f"{self.config_file_path.name} is valid and ready to be used"
 
@@ -109,11 +114,8 @@ class PackageConfigValidator:
         level: int = 1,
     ) -> str:
         if isinstance(errors, list):
-            field_output = f"{field_category} {field_name}: {errors[0]}\n"
-            return field_output
-
-        field_output = self.validate_get_field_item_output(errors, field_name, level)
-        return field_output
+            return f"{field_category} {field_name}: {errors[0]}\n"
+        return self.validate_get_field_item_output(errors, field_name, level)
 
     def validate_get_field_item_output(
         self, errors: dict, field_name: str, level: int

--- a/tests/functional/test_validate_config.py
+++ b/tests/functional/test_validate_config.py
@@ -6,11 +6,11 @@ Functional tests the validate-config command
 """
 
 from packit.utils.commands import cwd
-from tests.functional.spellbook import call_real_packit
+from tests.functional.spellbook import call_real_packit_and_return_exit_code
 
 
 def test_srpm_command_for_path(upstream_or_distgit_path, tmp_path):
     with cwd(tmp_path):
-        call_real_packit(
+        call_real_packit_and_return_exit_code(
             parameters=["--debug", "validate-config", str(upstream_or_distgit_path)]
         )


### PR DESCRIPTION
Previously, there was no simple flag/way how to know whether the validation failed or passed.
In both cases, we just returned a string
- in case of failed validation: with errors
- in case of successful validation: with a success string 

As a consequence, the return value of 'packit config-validation' was always 0.

With this change, the return value of 'packit config-validation' is 2 in case of failed validation.

TODO:

- [x] Write new tests or update the old ones to cover the new functionality.
- [x] Update doc-strings where appropriate.
