### PR TITLE
fix: SyncFilesItem.drop_src

### DIFF
--- a/packit/sync.py
+++ b/packit/sync.py
@@ -4,7 +4,7 @@
 """
 Functions and classes dealing with syncing files between repositories
 """
-
+import copy
 import os
 import glob
 import logging
@@ -174,7 +174,11 @@ class SyncFilesItem:
             Otherwise returns None.
         """
         new_src = [s for s in self.src if not criteria(s, src)]
-        return SyncFilesItem(new_src, self.dest) if new_src else None
+        if new_src:
+            self_copy = copy.copy(self)
+            self_copy.src = new_src
+            return self_copy
+        return None
 
 
 def iter_srcs(synced_files: Sequence[SyncFilesItem]) -> Iterator[str]:

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -62,6 +62,15 @@ def test_check_subpath(subpath, path, trailing_slash, result):
             {"src": "a", "criteria": lambda x, y: Path(x).name == y},
             SyncFilesItem(["src/b"], "dest"),
         ),
+        (
+            SyncFilesItem(
+                ["src/a"], "dest", filters=["dummy filter"], mkpath=True, delete=True
+            ),
+            {"src": "c"},
+            SyncFilesItem(
+                ["src/a"], "dest", filters=["dummy filter"], mkpath=True, delete=True
+            ),
+        ),
     ],
 )
 def test_drop_src(item, drop, result):


### PR DESCRIPTION
It should be returning a complete copy

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.

This one needs a proper test probably around `PackitAPI.update_dist_git`, but not sure how to make the relevant test there.

Fixes #1975 

RELEASE NOTES BEGIN

Fix files_to_sync filters not being applied properly

RELEASE NOTES END
