### PR TITLE
fix(image-builder): print request errors

### DIFF
--- a/packit/exceptions.py
+++ b/packit/exceptions.py
@@ -110,3 +110,10 @@ class PackitNotAGitRepoException(PackitGitException):
 
 class PackitBodhiException(PackitException):
     """There was a problem while interacting with Bodhi"""
+
+
+class ImageBuilderError(PackitException):
+    """An error happened during the Image Builder interaction"""
+
+    def __init__(self, errors):
+        self.errors = errors

--- a/packit/vm_image_build.py
+++ b/packit/vm_image_build.py
@@ -13,8 +13,9 @@ import logging
 from typing import Optional, Dict, List, Union
 
 import requests
+from requests import HTTPError
 
-from packit.exceptions import PackitException
+from packit.exceptions import PackitException, ImageBuilderError
 
 logger = logging.getLogger("packit")
 REDHAT_SSO_AUTH_URL = (
@@ -82,7 +83,11 @@ class ImageBuilder:
                 token_is_fresh = True
                 self.refresh_auth()
                 continue
-            response.raise_for_status()
+            try:
+                response.raise_for_status()
+            except HTTPError as ex:
+                logger.error(f"Image Builder Errors: {response.text}")
+                raise ImageBuilderError(errors=response.text) from ex
             return response
 
     def image_builder_request(

--- a/tests/integration/test_using_examples.py
+++ b/tests/integration/test_using_examples.py
@@ -13,8 +13,6 @@ from packit.utils.commands import cwd
 from tests.spellbook import (
     initiate_git_repo,
     get_test_config,
-    # UP_SNAPD,
-    UP_OSBUILD,
     UP_EDD,
     DG_OGR,
     build_srpm,
@@ -24,16 +22,11 @@ from tests.spellbook import (
 
 @pytest.fixture(
     params=[
-        # disabling snapd for now, since it causes issues with the removal of
-        # deprecated options and doesn't seem to be used anymore, will have
-        # a look in a separate PR with resolution to either remove or try to fix
-        # (UP_SNAPD, "2.41", "https://github.com/snapcore/snapd"),
-        (UP_OSBUILD, "2", "https://github.com/osbuild/osbuild"),
         (UP_EDD, "0.3", "https://github.com/psss/edd"),
         (UP_VSFTPD, "3.0.3", "https://github.com/olysonek/vsftpd"),
         (DG_OGR, None, "https://src.fedoraproject.org/rpms/python-ogr"),
     ],
-    ids=["osbuild", "edd", "vsftpd", "ogr"],
+    ids=["edd", "vsftpd", "ogr"],
 )
 def example_repo(request, tmp_path):
     example_path, tag, remote = request.param

--- a/tests_recording/test_data/test_image_builder/TestLocalProject.test_bad_request.yaml
+++ b/tests_recording/test_data/test_image_builder/TestLocalProject.test_bad_request.yaml
@@ -1,0 +1,106 @@
+_requre:
+  DataTypes: 1
+  key_strategy: StorageKeysInspectSimple
+  version_storage_file: 3
+requests.sessions:
+  send:
+    POST:
+      https://console.redhat.com/api/image-builder/v1/compose:
+      - metadata:
+          latency: 0.6750068664550781
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests_recording.test_image_builder
+          - packit.vm_image_build
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            errors:
+            - detail: "request body has an error: doesn't match schema #/components/schemas/ComposeRequest:\
+                \ Error at \"/distribution\": value \"fedora-rawhide\" is not one\
+                \ of the allowed values\nSchema:\n  {\n    \"enum\": [\n      \"rhel-8\"\
+                ,\n      \"rhel-84\",\n      \"rhel-85\",\n      \"rhel-86\",\n  \
+                \    \"rhel-87\",\n      \"rhel-9\",\n      \"rhel-90\",\n      \"\
+                rhel-91\",\n      \"rhel-92\",\n      \"centos-8\",\n      \"centos-9\"\
+                ,\n      \"fedora-35\",\n      \"fedora-36\",\n      \"fedora-37\"\
+                ,\n      \"fedora-38\"\n    ],\n    \"type\": \"string\"\n  }\n\n\
+                Value:\n  \"fedora-rawhide\"\n"
+              title: '400'
+          _next: null
+          elapsed: 0.674167
+          encoding: UTF-8
+          headers:
+            Connection: close
+            Content-Length: '622'
+            Content-Type: application/json; charset=UTF-8
+            Date: Thu, 25 May 2023 08:37:56 GMT
+            Server: openresty
+            Set-Cookie: foo=bar;
+              path=/; HttpOnly; Secure; SameSite=None
+            Strict-Transport-Security: max-age=31536000; includeSubDomains
+            X-Frame-Options: SAMEORIGIN
+            x-content-type-options: nosniff
+            x-rh-edge-cache-status: Miss from child, Miss from parent
+            x-rh-edge-reference-id: 0.9c477b5c.1685003876.627e5004
+            x-rh-edge-request-id: 627e5021
+            x-rh-insights-request-id: f17d03454ab44fd4bc3f495c246062b1
+          raw: !!binary ""
+          reason: Bad Request
+          status_code: 400
+      https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token:
+      - metadata:
+          latency: 0.34032130241394043
+          module_call_list:
+          - unittest.case
+          - requre.record_and_replace
+          - tests_recording.test_image_builder
+          - packit.vm_image_build
+          - requests.sessions
+          - requre.objects
+          - requre.cassette
+          - requests.sessions
+          - send
+        output:
+          __store_indicator: 2
+          _content:
+            access_token: foo
+            expires_in: 900
+            not-before-policy: 0
+            refresh_expires_in: 0
+            refresh_token: bar
+            scope: offline_access
+            session_state: baw
+            token_type: Bearer
+          _next: null
+          elapsed: 0.339693
+          encoding: utf-8
+          headers:
+            Cache-Control: no-store
+            Connection: keep-alive
+            Content-Encoding: gzip
+            Content-Length: '1813'
+            Content-Type: application/json
+            Date: Thu, 25 May 2023 08:37:55 GMT
+            Keep-Alive: timeout=300
+            Pragma: no-cache
+            Set-Cookie: baz=baq;
+              path=/; HttpOnly; Secure; SameSite=None
+            Vary: Accept-Encoding
+            referrer-policy: strict-origin
+            strict-transport-security: max-age=31536000; includeSubDomains
+            x-content-type-options: nosniff
+            x-frame-options: SAMEORIGIN
+            x-rh-edge-cache-status: Miss from child, Miss from parent
+            x-rh-edge-reference-id: 0.9f477b5c.1685003875.3f80d828
+            x-rh-edge-request-id: 3f80d828
+            x-site: prod-spoke-aws-us-east-1
+            x-xss-protection: 1; mode=block
+          raw: !!binary ""
+          reason: OK
+          status_code: 200

--- a/tests_recording/test_image_builder.py
+++ b/tests_recording/test_image_builder.py
@@ -1,8 +1,10 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
+import pytest
 from requre.cassette import DataTypes
 from requre.modules_decorate_all_methods import record_requests_module
 
+from packit.exceptions import ImageBuilderError
 from packit.vm_image_build import ImageBuilder
 from tests_recording.testbase import PackitTest
 
@@ -33,3 +35,8 @@ class TestLocalProject(PackitTest):
             "GET", "composes/e31d475a-1d32-4cac-844e-a6a613f80439"
         ).json()
         assert response_json["image_status"]["status"] == "success"
+
+    def test_bad_request(self):
+        ib = ImageBuilder(refresh_token=self.config.redhat_api_refresh_token)
+        with pytest.raises(ImageBuilderError):
+            ib.create_image("fedora-rawhide", "foo-bar", {}, {}, "")


### PR DESCRIPTION
Fixes #1980

Before
```
$ packit build in-image-builder ttomecek-anaconda-installer-s3-1
2023-05-25 10:11:30.002 utils.py          ERROR  400 Client Error: Bad Request for url: https://console.redhat.com/api/image-builder/v1/compose
Unexpected exception occurred,
please fill an issue here:
https://github.com/packit/packit/issues
```

After:
```
$ packit build in-image-builder ttomecek-anaconda-installer-s3-1
2023-05-25 14:19:57.350 vm_image_build.py ERROR  Image Builder Errors: {"errors":[{"detail":"request body has an error: doesn't match schema 
#/components/schemas/ComposeRequest: Error at \"/distribution\": value \"fedora-rawhide\" is not one of the allowed values\nSchema:\n  {\n    \"enum\": [\n      
\"rhel-8\",\n      \"rhel-84\",\n      \"rhel-85\",\n      \"rhel-86\",\n      \"rhel-87\",\n      \"rhel-9\",\n      \"rhel-90\",\n      
\"rhel-91\",\n      \"rhel-92\",\n      \"centos-8\",\n      \"centos-9\",\n      \"fedora-35\",\n      \"fedora-36\",\n      \"fedora-37\",\n      
\"fedora-38\"\n    ],\n    \"type\": \"string\"\n  }\n\nValue:\n  \"fedora-rawhide\"\n","title":"400"}]}
2023-05-25 14:19:57.350 utils.py          ERROR
```

Since IB pretty-prints json, it can be quite verbose: I don't think that's a problem in CLI.

TODO:

- [x] Write new tests or update the old ones to cover new functionality.

RELEASE NOTES BEGIN
Unsuccessful Image Builder requests now provide error details so you can fix the Image configuration.
RELEASE NOTES END