### PR TITLE
Add new option manual_trigger to packit schema

### DIFF
--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -65,6 +65,7 @@ class JobConfig(MultiplePackages):
         trigger: JobConfigTriggerType,
         packages: Dict[str, CommonPackageConfig],
         skip_build: bool = False,
+        manual_trigger: bool = False,
     ):
         super().__init__(packages)
         # Directly manipulating __dict__ is not recommended.
@@ -74,6 +75,7 @@ class JobConfig(MultiplePackages):
         self.__dict__["type"] = type
         self.__dict__["trigger"] = trigger
         self.__dict__["skip_build"] = skip_build
+        self.__dict__["manual_trigger"] = manual_trigger
 
         # Data for a JobConfigView:
         # a JobConfigView is seraialized/deserialized as a JobConfig
@@ -126,6 +128,7 @@ class JobConfigView(JobConfig):
             job_config.trigger,
             job_config_view_packages,
             job_config.skip_build,
+            job_config.manual_trigger,
         )
         self.__dict__["_view_for_package"] = package
 

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -439,6 +439,7 @@ class JobConfigSchema(Schema):
     job = EnumField(JobType, required=True, attribute="type")
     trigger = EnumField(JobConfigTriggerType, required=True)
     skip_build = fields.Boolean()
+    manual_trigger = fields.Boolean()
     packages = fields.Dict(
         keys=fields.String(), values=fields.Nested(CommonConfigSchema())
     )

--- a/tests/unit/test_config/test_package_config.py
+++ b/tests/unit/test_config/test_package_config.py
@@ -1988,6 +1988,7 @@ def test_package_config_specfile_not_present_raise(raw):
                     "trigger": "commit",
                     "targets": ["fedora-stable", "fedora-development"],
                     "skip_build": True,
+                    "manual_trigger": True,
                 }
             ],
         },
@@ -1998,6 +1999,7 @@ def test_package_config_specfile_not_present_raise(raw):
                     "trigger": "commit",
                     "targets": ["fedora-stable", "fedora-development"],
                     "skip_build": True,
+                    "manual_trigger": True,
                 },
                 {
                     "job": "tests",

--- a/tests/unit/test_prepare_sources.py
+++ b/tests/unit/test_prepare_sources.py
@@ -16,6 +16,7 @@ from packit.config import CommonPackageConfig, JobConfig, JobType, JobConfigTrig
                 "job": "copr_build",
                 "trigger": "release",
                 "skip_build": false,
+                "manual_trigger": false,
                 "packages": {
                     "package": {
                         "upstream_package_name": null,


### PR DESCRIPTION
This PR adds new option `manual_trigger` into Packit schema to allow users to trigger Packit jobs manually.

Service integration done in https://github.com/packit/packit-service/pull/2069

- [x] Write new tests or update the old ones to cover new functionality.
- [ ] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes https://github.com/packit/packit-service/issues/1806

RELEASE NOTES BEGIN

Packit now supports automatic ordering of ☕ after all checks pass.

RELEASE NOTES END
