### PR TITLE
fix(dg): mention branch in the PR title

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -873,7 +873,8 @@ The first dist-git commit to be synced is '{short_hash}'.
             pr = None
             if create_pr:
                 pr = self.push_and_create_pr(
-                    pr_title=title or f"Update to upstream release {version}",
+                    pr_title=title
+                    or f"Update {dist_git_branch} to upstream release {version}",
                     pr_description=description,
                     git_branch=dist_git_branch,
                     repo=self.dg,


### PR DESCRIPTION
When creating a PR against the dist-git, include dist-git branch, so it is easier to filter through in the mail client.

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #1989

RELEASE NOTES BEGIN
Packit now includes dist-git branch in the title of the PRs for `propose-downstream` and `pull-from-upstream`.
RELEASE NOTES END
