### PR TITLE
[WIP - DO NOT MERGE] New aliases: centos-stream-all, centos-stream+epel-next-all

### DIFF
--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -13,6 +13,8 @@ from packit.utils.commands import run_command
 from packit.utils.decorators import fallback_return_value
 
 ALIASES: Dict[str, List[str]] = {
+    "centos-stream-all": ["centos-stream-8", "centos-stream-9"],
+    "centos-stream+epel-next-all": ["centos-stream+epel-next-8", "centos-stream+epel-next-9"],
     "fedora-all": ["fedora-36", "fedora-37", "fedora-38", "fedora-rawhide"],
     "fedora-stable": ["fedora-36", "fedora-37"],
     "fedora-development": ["fedora-rawhide", "fedora-38"],


### PR DESCRIPTION
Fixes: #1999

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

RELEASE NOTES BEGIN

Packit now supports automatic ordering of ☕ after all checks pass.

RELEASE NOTES END
