### PR TITLE
Reload specfile after pre-sync action

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -822,6 +822,8 @@ The first dist-git commit to be synced is '{short_hash}'.
             self.dg.check_last_commit()
 
             self.up.run_action(actions=ActionName.pre_sync)
+            if not use_downstream_specfile:
+                self.up.specfile.reload()
             self.dg.create_branch(
                 dist_git_branch,
                 base=f"remotes/origin/{dist_git_branch}",

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -47,6 +47,7 @@ def test_basic_local_update(
     u, d, api = api_instance
     mock_spec_download_remote_s(d)
     flexmock(api).should_receive("init_kerberos_ticket").at_least().once()
+    flexmock(Specfile).should_call("reload").once()
 
     api.sync_release(dist_git_branch="main", version="0.1.0")
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -156,6 +156,9 @@ def test_sync_release_version_tag_processing(
     api_mock.up.should_receive("get_specfile_version").and_return(
         get_specfile_version_return
     )
+    api_mock.up.should_receive("specfile").and_return(
+        flexmock().should_receive("reload").mock()
+    )
     api_mock.should_receive("_prepare_files_to_sync").with_args(
         synced_files=[], full_version=version, upstream_tag=tag
     )
@@ -169,6 +172,9 @@ def test_sync_release_do_not_create_sync_note(api_mock):
     flexmock(PatchGenerator).should_receive("undo_identical")
     flexmock(pathlib.Path).should_receive("write_text").never()
     api_mock.up.should_receive("get_specfile_version").and_return("0")
+    api_mock.up.should_receive("specfile").and_return(
+        flexmock().should_receive("reload").mock()
+    )
     api_mock.up.package_config.create_sync_note = False
     api_mock.should_receive("push_and_create_pr").and_return(flexmock())
     api_mock.sync_release(version="1.1", dist_git_branch="_")
@@ -178,6 +184,9 @@ def test_sync_release_create_sync_note(api_mock):
     flexmock(PatchGenerator).should_receive("undo_identical")
     flexmock(pathlib.Path).should_receive("write_text").once()
     api_mock.up.should_receive("get_specfile_version").and_return("0")
+    api_mock.up.should_receive("specfile").and_return(
+        flexmock().should_receive("reload").mock()
+    )
     api_mock.should_receive("push_and_create_pr").and_return(flexmock())
     api_mock.sync_release(version="1.1", dist_git_branch="_")
 
@@ -232,6 +241,9 @@ def test_sync_release_sync_files_call(config_mock, upstream_mock, distgit_mock):
     flexmock(PatchGenerator).should_receive("undo_identical")
     flexmock(pathlib.Path).should_receive("write_text").once()
     api.up.should_receive("get_specfile_version").and_return("0")
+    api.up.should_receive("specfile").and_return(
+        flexmock().should_receive("reload").mock()
+    )
     api.should_receive("push_and_create_pr").and_return(flexmock())
     flexmock(ChangelogHelper).should_receive("update_dist_git")
 


### PR DESCRIPTION
TODO:

- [x] Write new tests or update the old ones to cover new functionality.

RELEASE NOTES BEGIN

Packit now correctly reloads upstream specfile after running `pre-sync` action.

RELEASE NOTES END
