### PR TITLE
Do not buildrequire test dependencies on rawhide

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -1,5 +1,5 @@
 # Testing dependencies: deepdiff, flexmock are missing on EPEL 9. Cannot use testing environment
-%if 0%{?el9}
+%if 0%{?el9} || 0%{?fedora} >= 39
 %bcond_with tests
 %else
 %bcond_without tests


### PR DESCRIPTION
python-deepdiff is currently broken on rawhide, and since `%check` is not yet used, it is safe not to require test dependencies.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2220058