### PR TITLE
Enable adding instructions on local checkout for sync release PRs

### DIFF
--- a/packit/constants.py
+++ b/packit/constants.py
@@ -177,3 +177,12 @@ PACKAGE_OPTION_HELP = (
     "Use it multiple times to select multiple packages."
     "Defaults to all the packages listed inside the config."
 )
+
+SYNC_RELEASE_PR_INSTRUCTIONS = (
+    "If you need to do any change in this pull request, you need to locally fetch the "
+    "source branch of it and push it (with a fix) to your fork "
+    "(as it is not possible to push to the branch created in the Packit’s fork):\n"
+    "```\ngit fetch https://src.fedoraproject.org/forks/{user}/rpms/{package}.git "
+    "refs/heads/*:refs/remotes/{user}/*\n"
+    "git checkout {user}/{branch}\n```\n"
+)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -72,6 +72,7 @@ def config_mock():
     conf = Config()
     conf._pagure_user_token = "test"
     conf._github_token = "test"
+    conf.fas_user = "packit"
     return conf
 
 
@@ -100,6 +101,7 @@ def local_project_mock(git_project_mock, git_repo_mock):
         git_repo=git_repo_mock,
         checkout_release=lambda *_: None,
         commit_hexsha="_",
+        repo_name="package",
     )
 
 


### PR DESCRIPTION
Fixes #1915

TODO:
- [ ] set the argument in the service code

RELEASE NOTES BEGIN
N/A

RELEASE NOTES END
