### PR TITLE
Revert "Do not buildrequire test dependencies on rawhide"

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -1,5 +1,5 @@
 # Testing dependencies: deepdiff, flexmock are missing on EPEL 9. Cannot use testing environment
-%if 0%{?el9} || 0%{?fedora} >= 39
+%if 0%{?el9}
 %bcond_with tests
 %else
 %bcond_without tests


### PR DESCRIPTION
This reverts commit 22b8bfa7af810e8c75cfdab8edcfb208b1442d53.

python-deepdiff has been built in rawhide:
https://koji.fedoraproject.org/koji/buildinfo?buildID=2250764