### PR TITLE
Allow filtering tags via regex configuration options

### DIFF
--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -183,6 +183,8 @@ class CommonPackageConfig:
         image_customizations: Optional[Dict] = None,
         copr_chroot: Optional[str] = None,
         follow_fedora_branching: bool = False,
+        upstream_tag_include: str = "",
+        upstream_tag_exclude: str = "",
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -238,6 +240,8 @@ class CommonPackageConfig:
         self.issue_repository = issue_repository
         self.release_suffix = release_suffix
         self.update_release = update_release
+        self.upstream_tag_include = upstream_tag_include
+        self.upstream_tag_exclude = upstream_tag_exclude
 
         # from deprecated JobMetadataConfig
         self._targets: Dict[str, Dict[str, Any]]

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -344,6 +344,8 @@ class CommonConfigSchema(Schema):
     issue_repository = fields.String(missing=None)
     release_suffix = fields.String(missing=None)
     update_release = fields.Bool(default=True)
+    upstream_tag_include = fields.String()
+    upstream_tag_exclude = fields.String()
 
     # Former 'metadata' keys
     _targets = TargetsListOrDict(missing=None, data_key="targets")

--- a/packit/utils/changelog_helper.py
+++ b/packit/utils/changelog_helper.py
@@ -102,7 +102,8 @@ class ChangelogHelper:
             ).body
             if self.package_config.copy_upstream_release_description
             else self.up.get_commit_messages(
-                after=self.up.get_last_tag(upstream_tag), before=upstream_tag
+                after=self.up.get_last_tag(before=upstream_tag),
+                before=upstream_tag,
             )
         )
         comment = self.sanitize_entry(comment)

--- a/tests/unit/test_upstream.py
+++ b/tests/unit/test_upstream.py
@@ -496,6 +496,8 @@ def test_get_spec_release(
 def test_fix_spec(
     upstream_mock, update_release, release_suffix, expected_release_suffix
 ):
+    upstream_mock.package_config.upstream_tag_include = None
+    upstream_mock.package_config.upstream_tag_exclude = None
     archive = "an_archive_name"
     current_git_tag_version = "4.5"
     original_release_number_from_spec = "2"


### PR DESCRIPTION
Introduce 2 configuration options, upstream_tag_include and upstream_tag_exclude to allow filtering the tags. This will be used in the service to allow filtering the propose_downstream runs.

Fixes packit/packit-service#2118

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.

RELEASE NOTES BEGIN
2 new configuration options for filtering when getting latest upstream release tag were introduced: `upstream_tag_include` and `upstream_tag_exclude`. They should contain a Python regex that can be used as an argument in `re.match`.

RELEASE NOTES END
