### PR TITLE
fix(dg): get allowed GPG keys from first package

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -593,6 +593,14 @@ class DistGit(PackitRepositoryBase):
         return result["alias"]
 
     def get_allowed_gpg_keys_from_downstream_config(self) -> Optional[List[str]]:
-        if self.downstream_config:
-            return self.downstream_config.allowed_gpg_keys
-        return None
+        if not self.downstream_config:
+            return None
+
+        # SAFETY: Taking first package instead of specific package should be
+        # safe, since we have put a requirement on »one« ‹upstream_project_url›
+        # per Packit config, i.e. even if we're dealing with a monorepo, there
+        # is only »one« upstream. If there is one upstream, there is only one
+        # set of GPG keys that can be allowed.
+        return self.downstream_config.packages[
+            self.downstream_config._first_package
+        ].allowed_gpg_keys

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -64,6 +64,11 @@ def package_config_mock():
         is_sub_package=False,
     )
     mock.should_receive("get_all_files_to_sync").and_return([])
+
+    # simulate ‹MultiplePackages›
+    mock._first_package = "default"
+    mock.packages = {"default": mock}
+
     return mock
 
 


### PR DESCRIPTION
This is an MVP solution for the issue with monorepo Packit config on the downstream.

GPG keys were probably forgotten during the monorepo refactoring, since there is actually not much reason to have monorepos configured on downstream.

SAFETY: Taking first package instead of specific package should be safe, since we have put a requirement on »one« ‹upstream_project_url› per Packit config, i.e. even if we're dealing with a monorepo, there is only »one« upstream. If there is one upstream, there is only one set of GPG keys that can be allowed.

TODO:
- [x] Reconsider the backreferences for monorepo configs…
  - [x] Open an issue to address this.
    #2039
- [ ] _I'll bet my cotton socks_ on someone releasing to Fedora and EPEL from different branches with different ACLs.