### PR TITLE
Don't pretty-print package/repo config before/after loading

### DIFF
--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -1,7 +1,6 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
-import json
 import logging
 from pathlib import Path
 from typing import Callable, Optional, List, Dict, Union, Set
@@ -497,9 +496,7 @@ def parse_loaded_config(
     **specfile_search_args,
 ) -> PackageConfig:
     """Tries to parse the config to PackageConfig."""
-    logger.debug(
-        f"Package config before loading:\n{json.dumps(loaded_config, indent=4)}"
-    )
+    logger.debug(f"Package config before loading:\n{loaded_config}")
 
     try:
         return PackageConfig.get_from_dict(
@@ -511,7 +508,7 @@ def parse_loaded_config(
         )
     except Exception as ex:
         logger.error(f"Cannot parse package config. {ex}.")
-        raise PackitConfigException(f"Cannot parse package config: {ex!r}.")
+        raise PackitConfigException(f"Cannot parse package config: {ex!r}.") from ex
 
 
 def get_local_specfile_path(dir: Path, exclude: List[str] = None) -> Optional[str]:

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 import copy
-import json
 from logging import getLogger
 from typing import Dict, Any, Optional, Mapping, Union, List
 
@@ -24,6 +23,7 @@ from packit.config import (
     CommonPackageConfig,
     Deployment,
 )
+from packit.config.aliases import DEPRECATED_TARGET_MAP
 from packit.config.job_config import (
     JobType,
     JobConfig,
@@ -36,7 +36,6 @@ from packit.config.notifications import PullRequestNotificationsConfig
 from packit.config.sources import SourcesItem
 from packit.constants import CHROOT_SPECIFIC_COPR_CONFIGURATION
 from packit.sync import SyncFilesItem
-from packit.config.aliases import DEPRECATED_TARGET_MAP
 
 logger = getLogger(__name__)
 
@@ -558,7 +557,7 @@ class PackageConfigSchema(Schema):
         # in the config.
         data = self.rearrange_packages(data)
         data = self.rearrange_jobs(data)
-        logger.debug(f"Repo config after pre-loading:\n{json.dumps(data, indent=4)}")
+        logger.debug(f"Repo config after pre-loading:\n{data}")
         return data
 
     def rename_deprecated_keys(self, data: dict) -> dict:


### PR DESCRIPTION
When the config is big one has to scroll a lot (esp. in the worker logs) to go through it.

Just a suggestion, feel free to NACK and close if you like it as it is.