### PR TITLE
Fix failures on f39/rawhide

### DIFF
--- a/packit/source_git.py
+++ b/packit/source_git.py
@@ -152,9 +152,16 @@ class SourceGitGenerator:
 
     def get_BUILD_dir(self):
         path = Path(self.dist_git.working_dir)
-        build_dirs = [d for d in (path / "BUILD").iterdir() if d.is_dir()]
+        build_dirs = [
+            d
+            for d in (path / "BUILD").iterdir()
+            # ignore the specparts dir
+            if d.is_dir() and not d.name.endswith("-SPECPARTS")
+        ]
         if len(build_dirs) > 1:
-            raise RuntimeError(f"More than one directory found in {path / 'BUILD'}")
+            raise RuntimeError(
+                f"More than one matching directory found in {path / 'BUILD'}"
+            )
         if not build_dirs:
             raise RuntimeError(f"No subdirectory found in {path / 'BUILD'}")
         return build_dirs[0]

--- a/tests/unit/test_iterate_packages.py
+++ b/tests/unit/test_iterate_packages.py
@@ -311,8 +311,8 @@ def test_iterate_packages_source_git(
     dist_git_is_git_repo,
 ):
     package_config_dict = json.loads(package_config_yaml)
-
     flexmock(PosixPath).should_receive("name").and_return(dist_git)
+    flexmock(PosixPath).should_call("joinpath").with_args(str)
     flexmock(PosixPath).should_receive("joinpath").with_args(".git").and_return(
         flexmock().should_receive("exists").and_return(dist_git_is_git_repo).mock()
     )


### PR DESCRIPTION
There were 2 kinds of failing tests in f39/rawhide:
1. commit -  a real issue with new behaviour in rpmbuild
2. commit - just a flexmocking issue, probably caused by changed behaviour in newer version of Python

See commit messages for more details.

As for the 1. one, if you have suggestions for a better fix, I will be happy.

RELEASE NOTES BEGIN

We have fixed a bug in `packit source-git init` caused by the changed behaviour in the newer version of rpmbuild.

RELEASE NOTES END