### PR TITLE
Temporarily lock deepdiff version to fix CI failures

### DIFF
--- a/files/tasks/rpm-test-deps.yaml
+++ b/files/tasks/rpm-test-deps.yaml
@@ -28,7 +28,9 @@
       - pytest-cov
       - pytest-timeout
       - flexmock
-      - deepdiff
+      # the version lock can be removed once this is resolved:
+      # https://github.com/seperman/deepdiff/issues/416
+      - deepdiff==6.3.1
     state: latest
   when: ansible_facts['distribution'] != 'Fedora'
   become: true

--- a/plans/full.fmf
+++ b/plans/full.fmf
@@ -15,4 +15,6 @@ adjust:
       - how: install
         package: python3-pip
       - how: shell
-        script: pip3 install flexmock deepdiff
+        # the version lock on deepdiff can be removed once this is resolved:
+        # https://github.com/seperman/deepdiff/issues/416
+        script: pip3 install flexmock deepdiff==6.3.1


### PR DESCRIPTION
See: https://github.com/seperman/deepdiff/issues/416