### PR TITLE
use-downstream-specfile option

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -610,6 +610,11 @@ class PackitRepositoryBase:
                 logger.error(f"{msg}: {e!r}")
                 raise PackitDownloadFailedException(f"{msg}:\n{e}") from e
 
+    def get_user(self) -> Optional[str]:
+        if self.local_project.git_service:
+            return self.local_project.git_service.user.get_username()
+        return None
+
     def existing_pr(
         self, title: str, description: str, target_branch: str, source_branch: str
     ) -> Optional[PullRequest]:
@@ -625,7 +630,7 @@ class PackitRepositoryBase:
             PullRequest: if one is found otherwise None
         """
         pull_requests = self.local_project.git_project.get_pr_list()
-        current_user = self.local_project.git_service.user.get_username()
+        user = self.get_user()
 
         for pr in pull_requests:
             if (
@@ -633,7 +638,7 @@ class PackitRepositoryBase:
                 and pr.description == description
                 and pr.target_branch == target_branch
                 and pr.source_branch == source_branch
-                and pr.author == current_user
+                and pr.author == user
             ):
                 return pr
         return None

--- a/packit/cli/packit_base.py
+++ b/packit/cli/packit_base.py
@@ -10,7 +10,7 @@ from packit.cli.build import build
 from packit.cli.create_update import create_update
 from packit.cli.init import init
 from packit.cli.prepare_sources import prepare_sources
-from packit.cli.propose_downstream import propose_downstream
+from packit.cli.propose_downstream import propose_downstream, pull_from_upstream
 from packit.cli.push_updates import push_updates
 from packit.cli.source_git import source_git
 from packit.cli.srpm import srpm
@@ -81,6 +81,7 @@ def packit_base(ctx, debug, fas_user, keytab, remote, package_config_path):
 
 
 packit_base.add_command(propose_downstream)
+packit_base.add_command(pull_from_upstream)
 packit_base.add_command(sync_from_downstream)
 packit_base.add_command(build)
 packit_base.add_command(create_update)

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -6,6 +6,7 @@ Update selected component from upstream in Fedora
 """
 
 import logging
+import functools
 import os
 
 import click
@@ -40,68 +41,7 @@ def get_dg_branches(api, dist_git_branch):
     return get_branches(*dg_branches, default_dg_branch=default_dg_branch)
 
 
-@click.command("propose-downstream", context_settings=get_context_settings())
-@click.option(
-    "--dist-git-branch",
-    help="Comma separated list of target branches in dist-git to release into. "
-    "(defaults to all branches)",
-)
-@click.option(
-    "--dist-git-path",
-    help="Path to dist-git repo to work in. "
-    "Otherwise clone the repo in a temporary directory.",
-)
-@click.option(
-    "--local-content",
-    is_flag=True,
-    default=False,
-    help="Do not checkout release tag. Use the current state of the repo. "
-    "This option is set by default for source-git repos",
-)
-@click.option(
-    "--force-new-sources",
-    is_flag=True,
-    default=False,
-    help="Upload the new sources also when the archive is already in the lookaside cache.",
-)
-@click.option(
-    "--pr/--no-pr",
-    default=None,
-    help=(
-        "Create a pull request to downstream repository or push directly. "
-        "If not set, defaults to value set in configuration."
-    ),
-)
-@click.option(
-    "--upstream-ref",
-    default=None,
-    help="Git ref of the last upstream commit in the current branch "
-    "from which packit should generate patches "
-    "(this option implies the repository is source-git).",
-)
-@click.option(
-    "--force",
-    "-f",
-    default=False,
-    is_flag=True,
-    help="Don't discard changes in the git repo by default, unless this is set.",
-)
-@click.option(
-    PACKAGE_SHORT_OPTION,
-    PACKAGE_LONG_OPTION,
-    multiple=True,
-    help=PACKAGE_OPTION_HELP.format(action="sync downstream"),
-)
-@click.argument(
-    "path_or_url",
-    type=LocalProjectParameter(),
-    default=os.path.curdir,
-)
-@click.argument("version", required=False)
-@pass_config
-@cover_packit_exception
-@iterate_packages
-def propose_downstream(
+def sync_release(
     config,
     dist_git_path,
     dist_git_branch,
@@ -112,18 +52,9 @@ def propose_downstream(
     upstream_ref,
     version,
     force,
+    use_downstream_specfile,
     package_config,
 ):
-    """
-    Land a new upstream release in Fedora.
-
-    PATH_OR_URL argument is a local path or a URL to the upstream git repository,
-    it defaults to the current working directory
-
-    VERSION argument is optional, the latest upstream version
-    will be used by default
-    """
-
     api = get_packit_api(
         config=config,
         package_config=package_config,
@@ -148,4 +79,154 @@ def propose_downstream(
             upstream_ref=upstream_ref,
             create_pr=pr,
             force=force,
+            use_downstream_specfile=use_downstream_specfile,
         )
+
+
+def sync_release_common_options(func):
+    @click.option(
+        "--dist-git-branch",
+        help="Comma separated list of target branches in dist-git to release into. "
+        "(defaults to all branches)",
+    )
+    @click.option(
+        "--dist-git-path",
+        help="Path to dist-git repo to work in. "
+        "Otherwise clone the repo in a temporary directory.",
+    )
+    @click.option(
+        "--force-new-sources",
+        is_flag=True,
+        default=False,
+        help="Upload the new sources also when the archive is already in the lookaside cache.",
+    )
+    @click.option(
+        "--pr/--no-pr",
+        default=None,
+        help=(
+            "Create a pull request to downstream repository or push directly. "
+            "If not set, defaults to value set in configuration."
+        ),
+    )
+    @click.option(
+        "--force",
+        "-f",
+        default=False,
+        is_flag=True,
+        help="Don't discard changes in the git repo by default, unless this is set.",
+    )
+    @click.option(
+        PACKAGE_SHORT_OPTION,
+        PACKAGE_LONG_OPTION,
+        multiple=True,
+        help=PACKAGE_OPTION_HELP.format(action="sync downstream"),
+    )
+    @click.argument(
+        "path_or_url",
+        type=LocalProjectParameter(),
+        default=os.path.curdir,
+    )
+    @click.argument("version", required=False)
+    @functools.wraps(func)
+    def wrapper_common_options(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper_common_options
+
+
+@click.command("propose-downstream", context_settings=get_context_settings())
+@sync_release_common_options
+@click.option(
+    "--local-content",
+    is_flag=True,
+    default=False,
+    help="Do not checkout release tag. Use the current state of the repo. "
+    "This option is set by default for source-git repos",
+)
+@click.option(
+    "--upstream-ref",
+    default=None,
+    help="Git ref of the last upstream commit in the current branch "
+    "from which packit should generate patches "
+    "(this option implies the repository is source-git).",
+)
+@pass_config
+@cover_packit_exception
+@iterate_packages
+def propose_downstream(
+    config,
+    dist_git_path,
+    dist_git_branch,
+    force_new_sources,
+    pr,
+    path_or_url,
+    version,
+    local_content,
+    upstream_ref,
+    force,
+    package_config,
+):
+    """
+    Land a new upstream release in Fedora using upstream packit config.
+
+    PATH_OR_URL argument is a local path or a URL to the upstream git repository,
+    it defaults to the current working directory
+
+    VERSION argument is optional, the latest upstream version
+    will be used by default
+    """
+    sync_release(
+        config=config,
+        dist_git_path=dist_git_path,
+        dist_git_branch=dist_git_branch,
+        force_new_sources=force_new_sources,
+        pr=pr,
+        path_or_url=path_or_url,
+        version=version,
+        force=force,
+        local_content=local_content,
+        upstream_ref=upstream_ref,
+        use_downstream_specfile=False,
+        package_config=package_config,
+    )
+
+
+@click.command("pull-from-upstream", context_settings=get_context_settings())
+@sync_release_common_options
+@pass_config
+@cover_packit_exception
+@iterate_packages
+def pull_from_upstream(
+    config,
+    dist_git_path,
+    dist_git_branch,
+    force_new_sources,
+    pr,
+    path_or_url,
+    version,
+    force,
+    package_config,
+):
+    """
+    Land a new upstream release in Fedora using downstream packit config.
+
+    PATH_OR_URL argument is a local path or a URL to the dist-git repository,
+    it defaults to the current working directory
+
+    VERSION argument is optional, the latest upstream version
+    will be used by default
+    """
+    sync_release(
+        config=config,
+        dist_git_path=dist_git_path,
+        dist_git_branch=dist_git_branch,
+        force_new_sources=force_new_sources,
+        pr=pr,
+        path_or_url=path_or_url,
+        version=version,
+        force=force,
+        local_content=False,
+        upstream_ref=None,
+        use_downstream_specfile=True,
+        package_config=package_config,
+    )

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -622,3 +622,10 @@ class DistGit(PackitRepositoryBase):
         return self.downstream_config.packages[
             self.downstream_config._first_package
         ].allowed_gpg_keys
+
+    def get_user(self) -> Optional[str]:
+        user = super().get_user()
+        if user:
+            return user
+        else:
+            return self.fas_user

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -4,11 +4,16 @@
 from importlib.metadata import version
 
 import pytest
+from flexmock import flexmock
 
 from packit.cli.build import build
 from packit.cli.create_update import create_update
 from packit.cli.packit_base import packit_base
 from packit.cli.propose_downstream import propose_downstream
+from packit.cli import propose_downstream as propose_downstream_module
+from packit.config import Config, PackageConfig
+from packit.local_project import LocalProject
+from packit.cli import utils
 from tests.spellbook import call_packit
 
 
@@ -36,3 +41,47 @@ def test_base_subcommand_help(subcommand):
     result = call_packit(packit_base, parameters=[subcommand, "--help"])
     assert result.exit_code == 0
     assert f"Usage: packit {subcommand} [OPTIONS]" in result.output
+
+
+def test_propose_downstream_command():
+    flexmock(utils).should_receive("get_local_package_config").and_return(
+        flexmock().should_receive("get_package_config_views").and_return({}).mock()
+    )
+    flexmock(propose_downstream_module).should_receive("sync_release").with_args(
+        config=Config,
+        dist_git_path=None,
+        dist_git_branch=None,
+        force_new_sources=False,
+        pr=None,
+        path_or_url=LocalProject,
+        version=None,
+        force=False,
+        local_content=False,
+        upstream_ref=None,
+        use_downstream_specfile=False,
+        package_config=PackageConfig,
+    ).and_return()
+    result = call_packit(packit_base, parameters=["propose-downstream", "."])
+    assert result.exit_code == 0
+
+
+def test_pull_from_upstream_command():
+    flexmock(utils).should_receive("get_local_package_config").and_return(
+        flexmock().should_receive("get_package_config_views").and_return({}).mock()
+    )
+    flexmock(propose_downstream_module).should_receive("sync_release").with_args(
+        config=Config,
+        dist_git_path=None,
+        dist_git_branch=None,
+        force_new_sources=False,
+        pr=None,
+        path_or_url=LocalProject,
+        version=None,
+        force=False,
+        local_content=False,
+        upstream_ref=None,
+        use_downstream_specfile=True,
+        package_config=PackageConfig,
+    ).and_return()
+    result = call_packit(packit_base, parameters=["pull-from-upstream", "."])
+    assert result.exit_code == 0


### PR DESCRIPTION
We need this option to be able to test
the pull-from-upstream workflow from the
command line.

Fixes packit#2052

RELEASE NOTES BEGIN

Packit CLI now supports testing the `pull-from-upstream` workflow. 
Use the following command line: 
```
packit pull-from-upstream
```
RELEASE NOTES END