### PR TITLE
OBS build support

### DIFF
--- a/.github/workflows/obs-build-smoke-test.yml
+++ b/.github/workflows/obs-build-smoke-test.yml
@@ -1,0 +1,40 @@
+name: build in-obs smoke test
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+  workflow_dispatch:
+
+jobs:
+  build-packit-in-obs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - name: Create osc config
+        env:
+          OBS_USERNAME: ${{ secrets.OBS_USERNAME }}
+          OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}
+
+        run: |
+          mkdir -p $HOME/.config/osc/
+          cat << EOF > $HOME/.config/osc/oscrc
+          [general]
+          apiurl=https://api.opensuse.org
+          [https://api.opensuse.org]
+          user=$OBS_USERNAME
+          pass=$OBS_PASSWORD
+          credentials_mgr_class=osc.credentials.PlaintextConfigFileCredentialsManager
+          EOF
+
+      - name: build_packit
+        run: |
+          sudo apt-get install -y libkrb5-dev rpm python3-rpm
+          pip install rpm hatch
+          python -m pip install build
+          pip3 install --user --editable .
+          packit build in-obs --targets fedora-rawhide-aarch64,fedora-rawhide-x86_64,opensuse-leap-15.6-x86_64,opensuse-tumbleweed-x86_64,opensuse-tumbleweed-aarch64 --no-wait

--- a/packit/api.py
+++ b/packit/api.py
@@ -81,7 +81,7 @@ from packit.source_git import SourceGitGenerator
 from packit.status import Status
 from packit.sync import SyncFilesItem, sync_files
 from packit.upstream import GitUpstream, NonGitUpstream, Upstream
-from packit.utils import commands
+from packit.utils import commands, obs_helper
 from packit.utils.bodhi import get_bodhi_client
 from packit.utils.changelog_helper import ChangelogHelper
 from packit.utils.extensions import assert_existence
@@ -2316,6 +2316,37 @@ The first dist-git commit to be synced is '{short_hash}'.
             return None
 
         return cmd_result.stdout
+
+    def run_obs_build(
+        self,
+        build_dir: str,
+        package_name: str,
+        project_name: str,
+        upstream_ref: Optional[str],
+        wait: bool = False,
+    ):
+        """
+        Commit a build to the Open Build Service
+        """
+
+        # Initialise project directory
+        package_dir = obs_helper.init_obs_project(
+            build_dir,
+            package_name,
+            project_name,
+        )
+        logger.info(f"build: dir: {build_dir}")
+        srpm = self.create_srpm(upstream_ref=upstream_ref, release_suffix="0")
+
+        # Commit srpm to OBS
+        obs_helper.commit_srpm_and_get_build_results(
+            srpm,
+            project_name,
+            package_name,
+            package_dir,
+            upstream_ref,
+            wait,
+        )
 
     def push_bodhi_update(self, update_alias: str):
         """Push selected bodhi update from testing to stable."""

--- a/packit/cli/build.py
+++ b/packit/cli/build.py
@@ -12,6 +12,7 @@ from packit.cli.builds.in_image_builder import in_image_builder
 from packit.cli.builds.koji_build import koji
 from packit.cli.builds.local_build import local
 from packit.cli.builds.mock_build import mock
+from packit.cli.builds.obs_build import obs
 
 logger = logging.getLogger(__name__)
 
@@ -34,3 +35,4 @@ build.add_command(koji)
 build.add_command(local)
 build.add_command(mock)
 build.add_command(in_image_builder)
+build.add_command(obs)

--- a/packit/cli/builds/obs_build.py
+++ b/packit/cli/builds/obs_build.py
@@ -1,0 +1,102 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+import os.path
+from tempfile import TemporaryDirectory
+from typing import Optional
+
+import click
+
+from packit.cli.types import LocalProjectParameter
+from packit.cli.utils import cover_packit_exception, get_packit_api, iterate_packages
+from packit.config import get_context_settings, pass_config
+from packit.config.config import Config
+from packit.config.package_config import PackageConfig
+from packit.constants import (
+    PACKAGE_LONG_OPTION,
+    PACKAGE_OPTION_HELP,
+    PACKAGE_SHORT_OPTION,
+)
+from packit.utils import obs_helper
+
+logger = logging.getLogger(__name__)
+
+
+@click.command("in-obs", context_settings=get_context_settings())
+@click.option(
+    "--owner",
+    help="OBS user, owner of the project. (defaults to the username from the oscrc)",
+)
+@click.option(
+    "--project",
+    help="Project name to build in. It will be created if does not exist."
+    " It defaults to home:$owner:packit:$pkg",
+)
+@click.option(
+    "--targets",
+    help="Comma separated list of chroots to build in. (defaults to 'fedora-rawhide-x86_64')",
+    default="fedora-rawhide-x86_64",
+)
+@click.option(
+    "--description",
+    help="Description of the project to build in.",
+    default=None,
+)
+@click.option(
+    "--upstream-ref",
+    default=None,
+    help="Git ref of the last upstream commit in the current branch "
+    "from which packit should generate patches "
+    "(this option implies the repository is source-git).",
+)
+@click.option("--wait/--no-wait", default=True, help="Wait for the build to finish")
+@click.option(
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_LONG_OPTION,
+    multiple=True,
+    help=PACKAGE_OPTION_HELP.format(action="build"),
+)
+@click.argument("path_or_url", type=LocalProjectParameter(), default=os.path.curdir)
+@pass_config
+@cover_packit_exception
+@iterate_packages
+def obs(
+    config: Config,
+    owner: Optional[str],
+    project: str,
+    targets: str,
+    description: Optional[str],
+    upstream_ref: Optional[str],
+    wait: bool,
+    package_config: PackageConfig,
+    path_or_url,
+) -> None:
+    """
+    Build selected project in OBS
+
+    Before Running this command, your opensuse user account and password needs to be
+    configured in osc configuration file ~/.config/osc/oscrc. This can be done by running `osc`.
+    """
+    api = get_packit_api(
+        config=config,
+        package_config=package_config,
+        local_project=path_or_url,
+    )
+
+    project_name, package_name = obs_helper.create_obs_project(
+        owner=owner,
+        package_config=package_config,
+        project=project,
+        targets=targets,
+        description=description,
+    )
+
+    with TemporaryDirectory() as tmp_dir:
+        api.run_obs_build(
+            build_dir=tmp_dir,
+            package_name=package_name,
+            project_name=project_name,
+            wait=wait,
+            upstream_ref=upstream_ref,
+        )

--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -234,14 +234,14 @@ def get_koji_targets(*name: str, default=DEFAULT_VERSION) -> set[str]:
         if sys_and_version == "fedora-rawhide":
             targets.add("rawhide")
         elif sys_and_version.startswith("fedora"):
-            sys, version = sys_and_version.rsplit("-", maxsplit=1)
+            _, version = sys_and_version.rsplit("-", maxsplit=1)
             targets.add(f"f{version}")
         elif sys_and_version.startswith("el") and sys_and_version[2:].isnumeric():
             targets.add(f"epel{sys_and_version[2:]}")
         elif sys_and_version.startswith("epel"):
             split = sys_and_version.rsplit("-", maxsplit=1)
             if len(split) == 2:
-                sys, version = split
+                _, version = split
                 if version.isnumeric():
                     targets.add(f"epel{version}")
                     continue

--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -70,7 +70,7 @@ def get_build_targets(*name: str, default: str = DEFAULT_VERSION) -> set[str]:
     names = list(name) or [default]
     possible_sys_and_versions: set[str] = set()
     for one_name in names:
-        name_split = one_name.rsplit("-", maxsplit=2)
+        name_split = one_name.rsplit("-", maxsplit=3)
         l_name_split = len(name_split)
 
         if l_name_split < 2:  # only one part
@@ -90,7 +90,8 @@ def get_build_targets(*name: str, default: str = DEFAULT_VERSION) -> set[str]:
             architecture = "x86_64"  # use the x86_64 as a default
 
         else:  # "name-version-architecture"
-            sys_name, version, architecture = name_split
+            sys_name, architecture = name_split[0], name_split[-1]
+            version = "-".join(name_split[1:-1])
             if architecture not in ARCHITECTURE_LIST:
                 # we don't know the architecture => probably wrongly parsed
                 # (e.g. "opensuse-leap-15.0")

--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -37,7 +37,7 @@ DEFAULT_VERSION = "fedora-stable"
 logger = logging.getLogger(__name__)
 
 
-def get_versions(*name: str, default=DEFAULT_VERSION) -> set[str]:
+def get_versions(*name: str, default: str = DEFAULT_VERSION) -> set[str]:
     """
     Expand the aliases to the name(s).
 

--- a/packit/utils/obs_helper.py
+++ b/packit/utils/obs_helper.py
@@ -1,0 +1,444 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+import os
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from osc import conf, core
+
+from packit.config import PackageConfig
+from packit.config.aliases import DEPRECATED_TARGET_MAP
+
+logger = logging.getLogger(__name__)
+
+_API_URL = "https://api.opensuse.org"
+
+
+@dataclass(frozen=True)
+class XmlPathEntry:
+    """Representation of a path entry in the XML repository configuration of
+    OBS.
+
+
+    """
+
+    project: str
+    repository: str
+
+
+@dataclass(frozen=True)
+class OBSRepository:
+    """Minimal representation of a repository on OBS that is part of the project
+    meta configuration:
+
+    .. code-block:: xml
+
+       <repository name="images">
+         <path project="openSUSE:Factory" repository="containerfile"/>
+         <path project="openSUSE:Factory" repository="standard"/>
+         <arch>x86_64</arch>
+       </repository>
+
+    """
+
+    name: str
+    arch: list[str]
+    path: list[XmlPathEntry]
+
+
+def target_to_path(target: str) -> list[XmlPathEntry]:
+    """Converts a packit target name like ``fedora-rawhide-x86_64`` or
+    ``opensuse-leap-15.5`` to a list of xml path entries of the respective
+    projects on OBS. This function relies on the project setup on
+    build.opensuse.org and is not directly re-usable on other OBS instances.
+
+    """
+
+    target_split = target.split("-")
+    version, arch = target_split[-2:]
+    distro = "-".join(target_split[:-2])
+
+    if distro == "fedora":
+        if version == "rawhide":
+            return [XmlPathEntry(project="Fedora:Rawhide", repository="standard")]
+        return [
+            XmlPathEntry(project=f"Fedora:{version}", repository="standard"),
+            XmlPathEntry(project=f"Fedora:{version}", repository="update"),
+        ]
+
+    if distro == "epel":
+        if version == "9":
+            return [
+                XmlPathEntry(project=f"Fedora:EPEL:{version}", repository="stream"),
+            ]
+        if version in ("8", "7"):
+            return [
+                XmlPathEntry(project=f"Fedora:EPEL:{version}", repository="CentOS"),
+            ]
+
+    if distro == "opensuse-leap":
+        return [
+            XmlPathEntry(project=f"openSUSE:Leap:{version}", repository="standard"),
+        ]
+
+    if distro == "opensuse":
+        if arch == "x86_64":
+            return [XmlPathEntry(project="openSUSE:Factory", repository="snapshot")]
+        if arch in ("s390x", "aarch64", "ppc64le"):
+            postfix = {"s390x": "zSystem", "aarch64": "ARM", "ppc64le": "PowerPC"}[arch]
+            return [
+                XmlPathEntry(
+                    project=f"openSUSE:Factory:{postfix}",
+                    repository="standard",
+                ),
+            ]
+
+    raise ValueError(f"No preset available for {distro=}, {version=}, {arch=}")
+
+
+def targets_to_project_meta(
+    targets: list[str],
+    owner: str,
+    project_name: str,
+    description: Optional[str] = None,
+) -> ET.Element:
+    """Converts the list of packit targets (like `fedora-rawhide-x86_64`) to a project
+    meta xml configuration for the respective project in OBS.
+
+    """
+    repos: list[OBSRepository] = []
+    for target in targets:
+        path = target_to_path(target)
+        arch = target.split("-")[-1]
+        name = target
+        added = False
+
+        for ind, repo in enumerate(repos):
+            if repo.path == path:
+                repos[ind] = OBSRepository(
+                    name=f"{repo.name}-{arch}",
+                    path=path,
+                    arch=[*repo.arch, arch],
+                )
+                added = True
+
+        if not added:
+            repos.append(OBSRepository(name=name, path=path, arch=[arch]))
+
+    root = ET.Element("project")
+    root.attrib["name"] = project_name
+
+    (title_elem := ET.Element("title")).text = "Packit project"
+    (descr_elem := ET.Element("description")).text = description or ""
+    (person_elem := ET.Element("person")).attrib["userid"] = owner
+    person_elem.attrib["role"] = "maintainer"
+
+    for elem in (title_elem, descr_elem, person_elem):
+        root.append(elem)
+
+    for repo in repos:
+        (repo_elem := ET.Element("repository")).attrib["name"] = repo.name
+
+        for path_entry in repo.path:
+            (path_elem := ET.Element("path")).attrib["project"] = path_entry.project
+            path_elem.attrib["repository"] = path_entry.repository
+            repo_elem.append(path_elem)
+
+        for arch in repo.arch:
+            (arch_elem := ET.Element("arch")).text = arch
+            repo_elem.append(arch_elem)
+
+        root.append(repo_elem)
+
+    return root
+
+
+def parse_changelog_subject(line: str) -> tuple[list[str], list[str], str, str]:
+    date: list[str]
+    author: list[str] = []
+    email: str = ""
+    version: str = ""
+
+    toks = [tok.strip() for tok in line.split(" ") if tok.strip()]
+
+    toks.pop(0)  # Remove leading "*"
+    date = toks[:4]
+
+    del toks[:4]
+    for index, element in enumerate(toks):
+        if not element.startswith("<"):
+            author.append(element)
+        else:
+            email += element
+            del toks[: index + 1]
+            break
+
+    if toks and toks[0] == "-":
+        toks.pop(0)
+
+    if toks:
+        version = toks[0]
+
+    return date, author, email, version
+
+
+def format_changelog(changelog_str: str) -> str:
+    """Converts spec changelog to OBS .changes format"""
+    output: list[str] = []
+    changelog_time = "12:00:00 UTC"
+    changelog = changelog_str.splitlines()
+
+    version_pattern = re.compile(r"-\s[0-9]+[\.\-]*")  # Precompile regex
+
+    for line in changelog:
+        if not line.strip():
+            continue
+        if line.strip().startswith("*"):
+            if output:
+                output[-1] += "\n"
+
+            date, author, email, version = parse_changelog_subject(line)
+            date.insert(3, changelog_time)
+
+            output.append("-" * 68)  # Set demarcator
+            output.append(f"{' '.join(date)} - {' '.join(author)} {email}\n")
+            if version:
+                output.append(f"- {version}")
+        else:
+            if version_pattern.match(line):  # Match version line
+                output.append(line)
+            else:
+                output.append(f"  {line}")
+
+    return "\n".join(output)
+
+
+def create_changes_file(package_dir: Path) -> None:
+    """
+    Creates a changelog file by copying the changelog section from the spec file.
+    Sets release to 0 since obs handles release numbers
+
+    Args:
+        package_dir (Path): Path to the directory containing the package spec file.
+
+    Returns:
+        None
+    """
+    specfile: Optional[Path] = None
+    release_line = "Release:    0"
+
+    for file in package_dir.iterdir():
+        if not file.is_file():
+            continue
+
+        if file.name.endswith(".spec"):
+            specfile = file
+
+        if file.name.endswith(".changes"):
+            logger.info(".changes file already exists in package")
+            return
+
+    if not specfile:
+        raise ValueError("Cannot find spec file in package")
+
+    split_content = re.split(r"%changelog", specfile.read_text(), flags=re.IGNORECASE)
+    if len(split_content) < 2:
+        logger.info("Project has no changelog")
+        return
+
+    specfile_content, changes_file_content = split_content[0], "".join(
+        split_content[1:],
+    )
+
+    with open(package_dir / specfile, "w") as s_file:
+        specfile_content = "\n".join(
+            [
+                release_line if line.lower().startswith("release:") else line
+                for line in specfile_content.splitlines()
+            ],
+        )
+        s_file.write(specfile_content)
+
+    changes_filename = package_dir / f"{specfile.name[:-5]}.changes"
+
+    changes_filename.write_text(format_changelog(changes_file_content))
+
+
+def create_package(project_name: str, package_name: str) -> None:
+    """Creates the package with the name ``package_name`` in the project
+    ``project_name`` on OBS. No sources are uploaded in the process.
+
+    """
+    (root := ET.Element("package")).attrib["name"] = package_name
+    root.attrib["project"] = project_name
+
+    (title := ET.Element("title")).text = f"The {package_name} package"
+    descr = ET.Element("description")
+
+    root.append(title)
+    root.append(descr)
+
+    package_url = core.makeurl(
+        _API_URL,
+        ["source", project_name, package_name, "_meta"],
+    )
+    metafile = core.metafile(package_url, ET.tostring(root))
+    metafile.sync()
+
+
+def create_obs_project(
+    project: str,
+    targets: str,
+    owner: Optional[str],
+    package_config: PackageConfig,
+    description: Optional[str],
+):
+    """
+    Creates a new OBS project and its associated package, ensuring only a single
+    package is included per call.
+
+    Args:
+        project (str, optional): The desired name for the OBS project. Defaults to None.
+        targets (str): Comma-separated list of build targets for the project. Defaults to "".
+        owner (Optional[str], optional): The owner of the project. Defaults to None.
+        package_config (PackageConfig): The config for the package to be included in the project.
+        description (Optional[str], optional): A description for the project. Defaults to None.
+
+    Returns:
+        Tuple[str, str]: A tuple containing the created project name and associated package name.
+
+    Raises:
+        ValueError: If the provided package_config contains multiple packages.
+    """
+    conf.get_config()
+    owner = owner or conf.config["api_host_options"][_API_URL]["user"]
+    project_name = project or f"home:{owner}:packit"
+
+    targets_list = targets.split(",")
+    for target in targets_list:
+        if target in DEPRECATED_TARGET_MAP:
+            logger.warning(
+                f"Target '{target}' is deprecated. "
+                f"Please use '{DEPRECATED_TARGET_MAP[target]}' instead.",
+            )
+
+    project_metadata = targets_to_project_meta(
+        targets=targets_list,
+        owner=owner,
+        project_name=project_name,
+        description=description,
+    )
+
+    logger.info(f"Using OBS project name = {project_name}")
+
+    project_url = core.makeurl(
+        _API_URL,
+        ["source", project_name, "_meta"],
+    )
+    metafile = core.metafile(project_url, ET.tostring(project_metadata))
+    metafile.sync()
+
+    package_names = list(package_config.packages.keys())
+
+    if len(package_names) != 1:
+        raise ValueError("Cannot handle multiple packages in package_config")
+
+    create_package(project_name, (package_name := package_names[0]))
+
+    return project_name, package_name
+
+
+def init_obs_project(
+    build_dir: str,
+    package_name: str,
+    project_name: str,
+) -> Path:
+    """
+    Initializes an Open Build Service (OBS) project.
+
+    Args:
+        build_dir (str): Base directory for the project (local path).
+        package_name (str): Name of the package to be built.
+        project_name (str): Name of the OBS project to create.
+
+    Returns:
+        Path: Path to the empty package directory within the OBS project.
+    """
+    core.Project.init_project(
+        _API_URL,
+        (prj_dir := Path(build_dir)),
+        project_name,
+    )
+
+    (pkg_dir := (prj_dir / package_name)).mkdir()
+    core.checkout_package(
+        _API_URL,
+        project_name,
+        package_name,
+        prj_dir=prj_dir,
+        pathname=pkg_dir,
+    )
+
+    pkg = core.Package(pkg_dir)
+
+    for fname in os.listdir(pkg_dir):
+        pkg.delete_file(fname)
+
+    return pkg_dir
+
+
+def commit_srpm_and_get_build_results(
+    srpm: Path,
+    project_name: str,
+    package_name: str,
+    package_dir: Path,
+    upstream_ref: Optional[str],
+    wait: bool,
+):
+    """
+    Commits an SRPM and retrieves build results.
+
+    This function unpacks the provided SRPM, and commits all files in the package_dir to OBS,
+    and optionally waits for and retrieves the build results.
+
+    Args:
+        srpm (Path): Path to the SRPM file.
+        project_name (str): Name of the OBS project the package belongs to.
+        package_name (str): Name of the package.
+        package_dir (Path): Path to the directory where the SRPM is unpacked.
+        upstream_ref (Optional[str]): Git ref of the last upstream commit in the current branch
+        from which packit should generate patches. Defaults to None.
+        wait (bool, optional): Whether to wait for and retrieve build results. Defaults to True.
+
+    Returns:
+        None
+    """
+    # don't use the files argument of unpack_srcrpm, it allows for shell
+    # injection unless sanitized carefully
+    core.unpack_srcrpm(str(srpm), package_dir)
+
+    create_changes_file(package_dir=package_dir)
+
+    core.addFiles(
+        [str(file_path) for file_path in package_dir.iterdir() if file_path.is_file()],
+    )
+    pkg = core.Package(package_dir)
+    msg = "Created by packit"
+    if upstream_ref:
+        msg += f" from upstream revision {upstream_ref}"
+    pkg.commit(msg=msg)
+
+    # wait for the build result
+    if wait:
+        core.get_results(
+            _API_URL,
+            project_name,
+            package_name,
+            printJoin="",
+            wait=True,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "cachetools",
     "python-bugzilla",
     "backoff",
+    "opensuse-distro-aliases",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,8 @@ dependencies = [
     "cachetools",
     "python-bugzilla",
     "backoff",
+    # osc 1.8.2 introduced a regression that was fixed via https://github.com/openSUSE/osc/pull/1595 in 1.8.3
+    "osc >= 1.6.2, != 1.8.2",
     "opensuse-distro-aliases",
 ]
 

--- a/tests/unit/config/test_config_aliases.py
+++ b/tests/unit/config/test_config_aliases.py
@@ -96,6 +96,25 @@ class TestGetBuildTargets:
                     "fedora-rawhide-x86_64",
                 },
             ),
+            (
+                "opensuse-leap-all",
+                {
+                    "opensuse-leap-15.5-x86_64",
+                    "opensuse-leap-15.4-x86_64",
+                    "opensuse-leap-15.3-x86_64",
+                },
+            ),
+            (
+                "opensuse-all",
+                {
+                    "opensuse-tumbleweed-x86_64",
+                    "opensuse-leap-15.5-x86_64",
+                    "opensuse-leap-15.4-x86_64",
+                    "opensuse-leap-15.3-x86_64",
+                },
+            ),
+            ("opensuse-leap-15.5-aarch64", {"opensuse-leap-15.5-aarch64"}),
+            ("opensuse-tumbleweed-ppc64le", {"opensuse-tumbleweed-ppc64le"}),
         ],
     )
     def test_get_build_targets(self, name, targets, mock_get_aliases):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from flexmock import flexmock
 
 import packit
+import packit.config.aliases
 from packit.config import Config
 from packit.distgit import DistGit
 from packit.local_project import LocalProjectBuilder
@@ -25,6 +26,17 @@ def mock_get_aliases():
             "fedora-stable": ["fedora-31", "fedora-32"],
             "fedora-development": ["fedora-33", "fedora-rawhide"],
             "epel-all": ["epel-6", "epel-7", "epel-8"],
+            "opensuse-leap-all": [
+                "opensuse-leap-15.5",
+                "opensuse-leap-15.4",
+                "opensuse-leap-15.3",
+            ],
+            "opensuse-all": [
+                "opensuse-tumbleweed",
+                "opensuse-leap-15.5",
+                "opensuse-leap-15.4",
+                "opensuse-leap-15.3",
+            ],
         },
     )
 

--- a/tests/unit/test_obs_build.py
+++ b/tests/unit/test_obs_build.py
@@ -1,0 +1,134 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from packit.utils import obs_helper
+
+_NAME = "home:me:packit"
+_TITLE = "Packit project"
+_PERSON = "me"
+
+head = f"""<project name="{_NAME}">
+  <title>{_TITLE}</title>
+  <description/>
+  <person userid="{_PERSON}" role="maintainer"/>
+"""
+tail = """</repository>
+</project>
+"""
+
+
+@pytest.mark.usefixtures("mock_get_aliases")
+class TestTargetsToProject:
+    @pytest.mark.parametrize(
+        "targets,project_meta",
+        [
+            (
+                ["fedora-rawhide-x86_64"],
+                head
+                + """
+<repository name="fedora-rawhide-x86_64">
+  <path project="Fedora:Rawhide" repository="standard"/>
+  <arch>x86_64</arch>
+"""
+                + tail,
+            ),
+            (
+                ["fedora-rawhide-x86_64", "fedora-rawhide-aarch64"],
+                head
+                + """
+<repository name="fedora-rawhide-x86_64-aarch64">
+  <path project="Fedora:Rawhide" repository="standard"/>
+  <arch>x86_64</arch>
+  <arch>aarch64</arch>
+"""
+                + tail,
+            ),
+            (
+                [
+                    "fedora-rawhide-x86_64",
+                    "opensuse-leap-15.5-x86_64",
+                    "fedora-rawhide-aarch64",
+                    "opensuse-leap-15.5-ppc64le",
+                    "opensuse-tumbleweed-x86_64",
+                ],
+                head
+                + """
+<repository name="fedora-rawhide-x86_64-aarch64">
+  <path project="Fedora:Rawhide" repository="standard"/>
+  <arch>x86_64</arch>
+  <arch>aarch64</arch>
+</repository>
+<repository name="opensuse-leap-15.5-x86_64-ppc64le">
+  <path project="openSUSE:Leap:15.5" repository="standard"/>
+  <arch>x86_64</arch>
+  <arch>ppc64le</arch>
+</repository>
+<repository name="opensuse-tumbleweed-x86_64">
+  <path project="openSUSE:Factory" repository="snapshot"/>
+  <arch>x86_64</arch>
+"""
+                + tail,
+            ),
+        ],
+    )
+    def test_targets_to_project(
+        self,
+        targets: list[str],
+        project_meta: str,
+        mock_get_aliases,
+    ) -> None:
+        assert ET.canonicalize(project_meta, strip_text=True) == ET.canonicalize(
+            ET.tostring(
+                obs_helper.targets_to_project_meta(
+                    targets,
+                    owner=_PERSON,
+                    project_name=f"home:{_PERSON}:packit",
+                ),
+            ),
+            strip_text=True,
+        )
+
+
+changelog = (
+    "* Thu Aug 01 2024 Packit Team <hello@packit.dev> - 0.100.1-1\n"
+    + "- New upstream release 0.100.1\n"
+    + "* Mon Jul 29 2024 Packit Team <hello@packit.dev> - 0.100.0-1\n"
+    + "- New upstream release 0.100.0\n"
+    + "* Fri May  2 2003 Elliot Lee <sopwith@redhat.com>\n"
+    + "- Add emacs-21.3-ppc64.patch\n"
+    + "* Fri Jun 23 2006 Jesse Keating <jkeating@redhat.com> 0.6-4\n"
+    + "- And fix the link syntax.\n"
+    + "* Fri Jun 23 2006 Jesse Keating <jkeating@redhat.com>\n"
+    + "- 0.6-4\n"
+    + "- And fix the link syntax."
+)
+
+obs_changelog = (
+    "--------------------------------------------------------------------\n"
+    + "Thu Aug 01 12:00:00 UTC 2024 - Packit Team <hello@packit.dev>\n\n"
+    + "- 0.100.1-1\n"
+    + "  - New upstream release 0.100.1\n\n"
+    + "--------------------------------------------------------------------\n"
+    + "Mon Jul 29 12:00:00 UTC 2024 - Packit Team <hello@packit.dev>\n\n"
+    + "- 0.100.0-1\n"
+    + "  - New upstream release 0.100.0\n\n"
+    + "--------------------------------------------------------------------\n"
+    + "Fri May 2 12:00:00 UTC 2003 - Elliot Lee <sopwith@redhat.com>\n\n"
+    + "  - Add emacs-21.3-ppc64.patch\n\n"
+    + "--------------------------------------------------------------------\n"
+    + "Fri Jun 23 12:00:00 UTC 2006 - Jesse Keating <jkeating@redhat.com>\n\n"
+    + "- 0.6-4\n"
+    + "  - And fix the link syntax.\n\n"
+    + "--------------------------------------------------------------------\n"
+    + "Fri Jun 23 12:00:00 UTC 2006 - Jesse Keating <jkeating@redhat.com>\n\n"
+    + "- 0.6-4\n"
+    + "  - And fix the link syntax."
+)
+
+
+def test_format_changelog_to_obs_format():
+    assert obs_changelog == obs_helper.format_changelog(changelog)

--- a/tests_recording/test_data/test_api/ProposeUpdate.test_changelog_sync.yaml
+++ b/tests_recording/test_data/test_api/ProposeUpdate.test_changelog_sync.yaml
@@ -906,6 +906,123 @@ requests.sessions:
             raw: !!binary ""
             reason: OK
             status_code: 200
+      https://api.opensuse.org/public/source/openSUSE?view=productlist&expand=1&format=xml:
+        all:
+          metadata:
+            latency: 2.0559027194976807
+            module_call_list:
+            - unittest.case
+            - requre.record_and_replace
+            - tests_recording.test_api
+            - packit.api
+            - packit.config.aliases
+            - cachetools
+            - packit.config.aliases
+            - opensuse_distro_aliases
+            - requests.api
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 1
+            _content: "<productlist count=\"30\">\n  <product name=\"openSUSE-Addon-NonOss\"\
+              \ cpe=\"cpe:/o:opensuse:opensuse-addon-nonoss:20250123\" originproject=\"\
+              openSUSE:Factory\" originpackage=\"000product\" mtime=\"1737670982\"\
+              />\n  <product name=\"openSUSE\" cpe=\"cpe:/o:opensuse:opensuse:20250123\"\
+              \ originproject=\"openSUSE:Factory\" originpackage=\"000product\" mtime=\"\
+              1737670982\"/>\n  <product name=\"MicroOS\" cpe=\"cpe:/o:opensuse:microos:20250123\"\
+              \ originproject=\"openSUSE:Factory\" originpackage=\"000product\" mtime=\"\
+              1737670982\"/>\n  <product name=\"Aeon\" cpe=\"cpe:/o:opensuse:aeon:20250123\"\
+              \ originproject=\"openSUSE:Factory\" originpackage=\"000product\" mtime=\"\
+              1737670982\"/>\n  <product name=\"Kalpa\" cpe=\"cpe:/o:opensuse:kalpa:20250123\"\
+              \ originproject=\"openSUSE:Factory\" originpackage=\"000product\" mtime=\"\
+              1737670982\"/>\n  <product name=\"Leap-Micro\" cpe=\"cpe:/o:opensuse:leap-micro:6.1\"\
+              \ originproject=\"openSUSE:Leap:Micro:6.1\" originpackage=\"000product\"\
+              \ mtime=\"1733347355\"/>\n  <product name=\"Leap-Micro\" cpe=\"cpe:/o:opensuse:leap-micro:6.0\"\
+              \ originproject=\"openSUSE:Leap:Micro:6.0\" originpackage=\"000product\"\
+              \ mtime=\"1717159269\"/>\n  <product name=\"Leap-Micro\" cpe=\"cpe:/o:opensuse:leap-micro:5.5\"\
+              \ originproject=\"openSUSE:Leap:Micro:5.5\" originpackage=\"000product\"\
+              \ mtime=\"1696948985\"/>\n  <product name=\"Leap-Micro\" cpe=\"cpe:/o:opensuse:leap-micro:5.4\"\
+              \ originproject=\"openSUSE:Leap:Micro:5.4\" originpackage=\"000product\"\
+              \ mtime=\"1682595799\"/>\n  <product name=\"Leap-Micro\" cpe=\"cpe:/o:opensuse:leap-micro:5.3\"\
+              \ originproject=\"openSUSE:Leap:Micro:5.3\" originpackage=\"000product\"\
+              \ mtime=\"1668462197\"/>\n  <product name=\"Leap-Micro\" cpe=\"cpe:/o:opensuse:leap-micro:5.2\"\
+              \ originproject=\"openSUSE:Leap:Micro:5.2\" originpackage=\"000product\"\
+              \ mtime=\"1655743352\"/>\n  <product name=\"Leap-Addon-NonOss\" cpe=\"\
+              cpe:/o:opensuse:leap-addon-nonoss:15.6\" originproject=\"openSUSE:Leap:15.6\"\
+              \ originpackage=\"000product\" mtime=\"1718882265\"/>\n  <product name=\"\
+              Leap\" cpe=\"cpe:/o:opensuse:leap:15.6\" originproject=\"openSUSE:Leap:15.6\"\
+              \ originpackage=\"000product\" mtime=\"1718882265\"/>\n  <product name=\"\
+              Leap-Addon-NonOss\" cpe=\"cpe:/o:opensuse:leap-addon-nonoss:15.5\" originproject=\"\
+              openSUSE:Leap:15.5\" originpackage=\"000product\" mtime=\"1684852341\"\
+              />\n  <product name=\"Leap\" cpe=\"cpe:/o:opensuse:leap:15.5\" originproject=\"\
+              openSUSE:Leap:15.5\" originpackage=\"000product\" mtime=\"1684852341\"\
+              />\n  <product name=\"Leap-Addon-NonOss\" cpe=\"cpe:/o:opensuse:leap-addon-nonoss:15.4\"\
+              \ originproject=\"openSUSE:Leap:15.4\" originpackage=\"000product\"\
+              \ mtime=\"1653589470\"/>\n  <product name=\"Leap\" cpe=\"cpe:/o:opensuse:leap:15.4\"\
+              \ originproject=\"openSUSE:Leap:15.4\" originpackage=\"000product\"\
+              \ mtime=\"1653589470\"/>\n  <product name=\"Leap-Addon-NonOss\" cpe=\"\
+              cpe:/o:opensuse:leap-addon-nonoss:15.3\" originproject=\"openSUSE:Leap:15.3:Update:Respin\"\
+              \ originpackage=\"000product\" mtime=\"1646420134\"/>\n  <product name=\"\
+              Leap\" cpe=\"cpe:/o:opensuse:leap:15.3\" originproject=\"openSUSE:Leap:15.3:Update:Respin\"\
+              \ originpackage=\"000product\" mtime=\"1646420134\"/>\n  <product name=\"\
+              openSUSE-Addon-NonOss\" cpe=\"cpe:/o:opensuse:opensuse-addon-nonoss:15.2\"\
+              \ originproject=\"openSUSE:Leap:15.2\" originpackage=\"000product\"\
+              \ mtime=\"1593153191\"/>\n  <product name=\"openSUSE\" cpe=\"cpe:/o:opensuse:opensuse:15.2\"\
+              \ originproject=\"openSUSE:Leap:15.2\" originpackage=\"000product\"\
+              \ mtime=\"1593153191\"/>\n  <product name=\"openSUSE-Addon-NonOss\"\
+              \ cpe=\"cpe:/o:opensuse:opensuse-addon-nonoss:15.1\" originproject=\"\
+              openSUSE:Leap:15.1\" originpackage=\"000product\" mtime=\"1557886751\"\
+              />\n  <product name=\"openSUSE\" cpe=\"cpe:/o:opensuse:opensuse:15.1\"\
+              \ originproject=\"openSUSE:Leap:15.1\" originpackage=\"000product\"\
+              \ mtime=\"1557886751\"/>\n  <product name=\"openSUSE\" cpe=\"cpe:/o:opensuse:opensuse:15.0\"\
+              \ originproject=\"openSUSE:Leap:15.0\" originpackage=\"000product\"\
+              \ mtime=\"1526463153\"/>\n  <product name=\"openSUSE-Addon-NonOss\"\
+              \ cpe=\"cpe:/o:opensuse:opensuse-addon-nonoss:15.0\" originproject=\"\
+              openSUSE:Leap:15.0\" originpackage=\"000product\" mtime=\"1526463153\"\
+              />\n  <product name=\"openSUSE-Addon-NonOss\" cpe=\"cpe:/o:opensuse:opensuse-addon-nonoss:42.2\"\
+              \ originproject=\"openSUSE:Leap:42.2\" originpackage=\"_product\" mtime=\"\
+              1478347756\"/>\n  <product name=\"openSUSE\" cpe=\"cpe:/o:opensuse:opensuse:42.2\"\
+              \ originproject=\"openSUSE:Leap:42.2\" originpackage=\"_product\" mtime=\"\
+              1478347756\"/>\n  <product name=\"openSUSE-Addon-NonOss\" cpe=\"cpe:/o:opensuse:opensuse-addon-nonoss:42.3\"\
+              \ originproject=\"openSUSE:Leap:42.3\" originpackage=\"_product\" mtime=\"\
+              1500481143\"/>\n  <product name=\"openSUSE\" cpe=\"cpe:/o:opensuse:opensuse:42.3\"\
+              \ originproject=\"openSUSE:Leap:42.3\" originpackage=\"_product\" mtime=\"\
+              1500481143\"/>\n  <product name=\"openSUSE-Kubic\" cpe=\"cpe:/o:opensuse:opensuse-kubic:20170719\"\
+              \ originproject=\"openSUSE:Leap:42.3\" originpackage=\"_product\" mtime=\"\
+              1500481143\"/>\n</productlist>\n"
+            _next: null
+            elapsed: 2.055589
+            encoding: utf-8
+            headers:
+              Connection: Keep-Alive
+              Date: Fri, 24 Jan 2025 12:41:19 GMT
+              Keep-Alive: timeout=15, max=100
+              Server: Apache/2.4.58 (Linux/SUSE)
+              Strict-Transport-Security: max-age=31536000
+              Transfer-Encoding: chunked
+              cache-control: max-age=0, private, must-revalidate
+              content-encoding: gzip
+              content-type: application/xml; charset=utf-8
+              etag: W/"37547da7f066cf0682ab8f716902e32e"
+              referrer-policy: strict-origin-when-cross-origin
+              status: 200 OK
+              vary: Accept-Encoding
+              x-content-type-options: nosniff
+              x-download-options: noopen
+              x-frame-options: SAMEORIGIN
+              x-opensuse-apiversion: 2.11~alpha.20250122T141423.1d2ed363b
+              x-opensuse-runtimes: '{"view":58.58029992773663,"db":248.15871001780033,"backend":0}'
+              x-permitted-cross-domain-policies: none
+              x-powered-by: Phusion Passenger(R)
+              x-request-id: 14a8f0b5-ed3b-4f7e-bc0b-7eee687fc41c
+              x-runtime: '0.717574'
+              x-xss-protection: 1; mode=block
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
       https://bodhi.fedoraproject.org/releases/?state=current&state=pending&state=frozen&page=1:
         all:
           metadata:
@@ -1585,6 +1702,179 @@ requests.sessions:
               set-cookie: disgit_pagure=eyJfcGVybWFuZW50Ijp0cnVlLCJjc3JmX3Rva2VuIjoiYTYxOTQ3YWUyOTFjZjY0NjM5MThlNWM0NzAyOTYyZjZjOTJlYmZlOSJ9.GiEg-A.CnsKni8mqavkpTeLaARLdUg3pFA;
                 Expires=Sun, 22-Dec-2024 19:52:24 GMT; Secure; HttpOnly; Path=/
               x-fedora-appserver: pkgs01.iad2.fedoraproject.org
+            raw: !!binary ""
+            reason: OK
+            status_code: 200
+      https://get.opensuse.org/api/v0/distributions.json:
+        all:
+          metadata:
+            latency: 0.13317346572875977
+            module_call_list:
+            - unittest.case
+            - requre.record_and_replace
+            - tests_recording.test_api
+            - packit.api
+            - packit.config.aliases
+            - cachetools
+            - packit.config.aliases
+            - opensuse_distro_aliases
+            - requests.api
+            - requests.sessions
+            - requre.objects
+            - requre.cassette
+            - requests.sessions
+            - send
+          output:
+            __store_indicator: 2
+            _content:
+              Leap:
+              - name: openSUSE Leap
+                state: Alpha
+                upgrade-weight: 10
+                version: '16.0'
+              - name: openSUSE Leap
+                state: Stable
+                upgrade-weight: 9
+                version: '15.6'
+              - name: openSUSE Leap
+                state: EOL
+                upgrade-weight: 8
+                version: '15.5'
+              - name: openSUSE Leap
+                state: EOL
+                upgrade-weight: 7
+                version: '15.4'
+              - name: openSUSE Leap
+                state: EOL
+                upgrade-weight: 6
+                version: '15.3'
+              - name: openSUSE Leap
+                state: EOL
+                upgrade-weight: 5
+                version: '15.2'
+              - name: openSUSE Leap
+                state: EOL
+                upgrade-weight: 4
+                version: '15.1'
+              - name: openSUSE Leap
+                state: EOL
+                upgrade-weight: 3
+                version: '15.0'
+              - name: openSUSE Leap
+                state: EOL
+                upgrade-weight: 2
+                version: '42.3'
+              - name: openSUSE Leap
+                state: EOL
+                upgrade-weight: 1
+                version: '42.2'
+              - name: openSUSE Leap
+                state: EOL
+                upgrade-weight: 0
+                version: '42.1'
+              LeapMicro:
+              - name: openSUSE Leap Micro
+                state: Stable
+                upgrade-weight: 6
+                version: '6.1'
+              - name: openSUSE Leap Micro
+                state: Stable
+                upgrade-weight: 5
+                version: '6.0'
+              - name: openSUSE Leap Micro
+                state: Stable
+                upgrade-weight: 4
+                version: '5.5'
+              - name: openSUSE Leap Micro
+                state: EOL
+                upgrade-weight: 3
+                version: '5.4'
+              - name: openSUSE Leap Micro
+                state: EOL
+                upgrade-weight: 2
+                version: '5.3'
+              - name: openSUSE Leap Micro
+                state: EOL
+                upgrade-weight: 1
+                version: '5.2'
+              Tumbleweed:
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250122
+                version: '20250122'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250121
+                version: '20250121'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250120
+                version: '20250120'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250119
+                version: '20250119'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250118
+                version: '20250118'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250117
+                version: '20250117'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250116
+                version: '20250116'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250115
+                version: '20250115'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250114
+                version: '20250114'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250113
+                version: '20250113'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250112
+                version: '20250112'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250109
+                version: '20250109'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250108
+                version: '20250108'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250106
+                version: '20250106'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250105
+                version: '20250105'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250103
+                version: '20250103'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250102
+                version: '20250102'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20250101
+                version: '20250101'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20241226
+                version: '20241226'
+              - name: openSUSE Tumbleweed
+                upgrade-weight: 20241224
+                version: '20241224'
+            _next: null
+            elapsed: 0.133022
+            encoding: utf-8
+            headers:
+              cache-control: max-age=2419200
+              content-encoding: gzip
+              content-type: application/json
+              date: Fri, 24 Jan 2025 12:41:18 GMT
+              etag: W/"67938221-10f0"
+              expires: Fri, 21 Feb 2025 12:41:18 GMT
+              last-modified: Fri, 24 Jan 2025 12:05:53 GMT
+              referrer-policy: no-referrer-when-downgrade
+              strict-transport-security: max-age=15768000
+              transfer-encoding: chunked
+              vary: Accept-Encoding
+              x-content-type-options: nosniff
+              x-xss-protection: 1; mode=block
             raw: !!binary ""
             reason: OK
             status_code: 200


### PR DESCRIPTION
This is a very much WIP support for building rpms in the open build service. I have so far tested it only on packit via `packit build in-obs --targets fedora-rawhide-x86_64,fedora-rawhide-aarch64,opensuse-tumbleweed-x86_64,opensuse-tumbleweed-aarch64` which created this package: https://build.opensuse.org/package/show/home:dancermak:packit/packit ~~(it is unresolvable because my obs wrapper is not packaged)~~.

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [x] Implement waiting for package builds
- [x] Find the right obs abstraction library (currently it's using my wrapper [py-obs](https://github.com/dcermak/py-obs) but that one is not packaged anywhere, however osc is rather inconvenient to use as a lib). cc @dmach
- [ ] probably much more

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

RELEASE NOTES BEGIN

Packit now supports building packages in the open build service

RELEASE NOTES END
