### PR TITLE
Add failure_comment_message to notifications config

### DIFF
--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -4,10 +4,9 @@
 """
 Common package config attributes so they can be imported both in PackageConfig and JobConfig
 """
-import warnings
 import logging
+import warnings
 from enum import Enum
-
 from os import getenv
 from os.path import basename
 from re import split
@@ -16,7 +15,6 @@ from typing import Dict, List, Optional, Union, Any, Set
 from packit.actions import ActionName
 from packit.config.notifications import (
     NotificationsConfig,
-    PullRequestNotificationsConfig,
 )
 from packit.config.sources import SourcesItem
 from packit.constants import PROD_DISTGIT_URL, DISTGIT_NAMESPACE
@@ -218,9 +216,7 @@ class CommonPackageConfig:
         self.sync_changelog: bool = sync_changelog
         self.create_sync_note: bool = create_sync_note
         self.spec_source_id: str = spec_source_id
-        self.notifications = notifications or NotificationsConfig(
-            pull_request=PullRequestNotificationsConfig()
-        )
+        self.notifications = notifications or NotificationsConfig()
         self.identifier = identifier
 
         # The default is set also on schema level,

--- a/packit/config/notifications.py
+++ b/packit/config/notifications.py
@@ -1,5 +1,6 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
+from typing import Optional
 
 
 class PullRequestNotificationsConfig:
@@ -12,5 +13,10 @@ class PullRequestNotificationsConfig:
 class NotificationsConfig:
     """Configuration of notifications."""
 
-    def __init__(self, pull_request: PullRequestNotificationsConfig):
-        self.pull_request = pull_request
+    def __init__(
+        self,
+        pull_request: Optional[PullRequestNotificationsConfig] = None,
+        failure_comment_message: Optional[str] = None,
+    ):
+        self.pull_request = pull_request or PullRequestNotificationsConfig()
+        self.failure_comment_message = failure_comment_message

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -178,6 +178,7 @@ class NotificationsSchema(Schema):
     """Configuration of notifications."""
 
     pull_request = fields.Nested(PullRequestNotificationsSchema)
+    failure_comment_message = fields.String(missing=None)
 
     @post_load
     def make_instance(self, data, **kwargs):

--- a/tests/unit/config/test_package_config.py
+++ b/tests/unit/config/test_package_config.py
@@ -491,6 +491,25 @@ def test_package_config_not_equal(not_equal_package_config):
             {
                 "downstream_package_name": "package",
                 "specfile_path": "fedora/package.spec",
+                "notifications": {
+                    "pull_request": {"successful_build": False},
+                    "failure_comment_message": "my comment",
+                },
+            },
+            True,
+        ),
+        (
+            {
+                "downstream_package_name": "package",
+                "specfile_path": "fedora/package.spec",
+                "notifications": {"failure_comment_message": "my comment"},
+            },
+            True,
+        ),
+        (
+            {
+                "downstream_package_name": "package",
+                "specfile_path": "fedora/package.spec",
                 "notifications": {"pull_request": {"successful_build": "nie"}},
             },
             False,
@@ -1676,6 +1695,20 @@ def test_notifications_section():
         {"specfile_path": "package.spec"}, repo_name="package"
     )
     assert not pc.notifications.pull_request.successful_build
+    assert pc.notifications.failure_comment_message is None
+
+
+def test_notifications_section_failure_comment_message():
+    message = "my message"
+    pc = PackageConfig.get_from_dict(
+        {
+            "specfile_path": "package.spec",
+            "notifications": {"failure_comment_message": message},
+        },
+        repo_name="package",
+    )
+    assert not pc.notifications.pull_request.successful_build
+    assert pc.notifications.failure_comment_message == message
 
 
 def test_get_local_specfile_path():


### PR DESCRIPTION
Related to packit/packit-service#1911

TODO:
- [ ] Update or write new documentation in `packit/packit.dev`.

I was also thinking about naming it only `failure_comment`, let me know WDYT.

RELEASE NOTES BEGIN
N/A

RELEASE NOTES END
