### PR TITLE
Change configuration schema for failure comment

### DIFF
--- a/packit/config/notifications.py
+++ b/packit/config/notifications.py
@@ -10,13 +10,20 @@ class PullRequestNotificationsConfig:
         self.successful_build = successful_build
 
 
+class FailureCommentNotificationsConfig:
+    """Configuration of the failure comment."""
+
+    def __init__(self, message: Optional[str] = None):
+        self.message = message
+
+
 class NotificationsConfig:
     """Configuration of notifications."""
 
     def __init__(
         self,
         pull_request: Optional[PullRequestNotificationsConfig] = None,
-        failure_comment_message: Optional[str] = None,
+        failure_comment: Optional[FailureCommentNotificationsConfig] = None,
     ):
         self.pull_request = pull_request or PullRequestNotificationsConfig()
-        self.failure_comment_message = failure_comment_message
+        self.failure_comment = failure_comment or FailureCommentNotificationsConfig()

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -31,7 +31,10 @@ from packit.config.job_config import (
     JobConfigTriggerType,
     get_default_jobs,
 )
-from packit.config.notifications import NotificationsConfig
+from packit.config.notifications import (
+    NotificationsConfig,
+    FailureCommentNotificationsConfig,
+)
 from packit.config.notifications import PullRequestNotificationsConfig
 from packit.config.sources import SourcesItem
 from packit.constants import CHROOT_SPECIFIC_COPR_CONFIGURATION
@@ -174,11 +177,21 @@ class PullRequestNotificationsSchema(Schema):
         return PullRequestNotificationsConfig(**data)
 
 
+class FailureCommentNotificationsSchema(Schema):
+    """Configuration of commenting on failures."""
+
+    message = fields.String(missing=None)
+
+    @post_load
+    def make_instance(self, data, **kwargs):
+        return FailureCommentNotificationsConfig(**data)
+
+
 class NotificationsSchema(Schema):
     """Configuration of notifications."""
 
     pull_request = fields.Nested(PullRequestNotificationsSchema)
-    failure_comment_message = fields.String(missing=None)
+    failure_comment = fields.Nested(FailureCommentNotificationsSchema)
 
     @post_load
     def make_instance(self, data, **kwargs):

--- a/tests/unit/config/test_package_config.py
+++ b/tests/unit/config/test_package_config.py
@@ -493,7 +493,7 @@ def test_package_config_not_equal(not_equal_package_config):
                 "specfile_path": "fedora/package.spec",
                 "notifications": {
                     "pull_request": {"successful_build": False},
-                    "failure_comment_message": "my comment",
+                    "failure_comment": {"message": "my comment"},
                 },
             },
             True,
@@ -502,7 +502,7 @@ def test_package_config_not_equal(not_equal_package_config):
             {
                 "downstream_package_name": "package",
                 "specfile_path": "fedora/package.spec",
-                "notifications": {"failure_comment_message": "my comment"},
+                "notifications": {"failure_comment": {"message": "my comment"}},
             },
             True,
         ),
@@ -1695,7 +1695,7 @@ def test_notifications_section():
         {"specfile_path": "package.spec"}, repo_name="package"
     )
     assert not pc.notifications.pull_request.successful_build
-    assert pc.notifications.failure_comment_message is None
+    assert pc.notifications.failure_comment.message is None
 
 
 def test_notifications_section_failure_comment_message():
@@ -1703,12 +1703,12 @@ def test_notifications_section_failure_comment_message():
     pc = PackageConfig.get_from_dict(
         {
             "specfile_path": "package.spec",
-            "notifications": {"failure_comment_message": message},
+            "notifications": {"failure_comment": {"message": message}},
         },
         repo_name="package",
     )
     assert not pc.notifications.pull_request.successful_build
-    assert pc.notifications.failure_comment_message == message
+    assert pc.notifications.failure_comment.message == message
 
 
 def test_get_local_specfile_path():


### PR DESCRIPTION
Instead of having one value failure_comment_message, create a nested one failure_comment.message so that failure_comment can be extended in the future if needed. Related to packit/packit-service#1911


RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
