### PR TITLE
Revert "Temporarily lock deepdiff version to fix CI failures"

### DIFF
--- a/files/tasks/rpm-test-deps.yaml
+++ b/files/tasks/rpm-test-deps.yaml
@@ -28,9 +28,7 @@
       - pytest-cov
       - pytest-timeout
       - flexmock
-      # the version lock can be removed once this is resolved:
-      # https://github.com/seperman/deepdiff/issues/416
-      - deepdiff==6.3.1
+      - deepdiff
     state: latest
   when: ansible_facts['distribution'] != 'Fedora'
   become: true

--- a/plans/full.fmf
+++ b/plans/full.fmf
@@ -15,6 +15,4 @@ adjust:
       - how: install
         package: python3-pip
       - how: shell
-        # the version lock on deepdiff can be removed once this is resolved:
-        # https://github.com/seperman/deepdiff/issues/416
-        script: pip3 install flexmock deepdiff==6.3.1
+        script: pip3 install flexmock deepdiff


### PR DESCRIPTION
This reverts commit d95db9fecdaf2c4b89b29cfc523b55b2be498042.

The deepdiff bug has been fixed: https://github.com/seperman/deepdiff/commit/410019e