### PR TITLE
fix(dg): relax the requirements for existing PRs

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1175,9 +1175,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         except PackitException as exc:
             logger.error(f"Push to fork failed: {exc}")
             raise
-        pr = repo.existing_pr(
-            pr_title, pr_description.rstrip(), git_branch, repo.local_project.ref
-        )
+        pr = repo.existing_pr(pr_title, git_branch, repo.local_project.ref)
         if pr is None:
             pr = repo.create_pull(
                 pr_title,

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -616,18 +616,20 @@ class PackitRepositoryBase:
         return None
 
     def existing_pr(
-        self, title: str, description: str, target_branch: str, source_branch: str
+        self, title: str, target_branch: str, source_branch: str
     ) -> Optional[PullRequest]:
-        """Look for an already created PR with the same:
-        title, description and branch name
+        """
+        Look for an already created PR.
 
         Args:
-            title (str)
-            description (str)
-            branch (str)
+            title: Title of the pull request.
+            description: Description of the pull request.
+            target_branch: Branch to which the PR is being merged.
+            source_branch: Branch from which the changes are being pulled.
 
         Return:
-            PullRequest: if one is found otherwise None
+            The `PullRequest` object if some existing PR is found, `None`
+            otherwise.
         """
         pull_requests = self.local_project.git_project.get_pr_list()
         user = self.get_user()
@@ -635,7 +637,6 @@ class PackitRepositoryBase:
         for pr in pull_requests:
             if (
                 pr.title == title
-                and pr.description == description
                 and pr.target_branch == target_branch
                 and pr.source_branch == source_branch
                 and pr.author == user

--- a/tests/unit/test_dg.py
+++ b/tests/unit/test_dg.py
@@ -13,11 +13,10 @@ from packit.local_project import LocalProjectBuilder
 
 
 @pytest.mark.parametrize(
-    "title, description, branch, source_branch, prs, exists",
+    "title, target_branch, source_branch, prs, exists",
     [
         (
             "Update",
-            "Upstream tag: 0.4.0\nUpstream commit: 6957453b",
             "f31",
             "f31-update",
             [
@@ -33,23 +32,6 @@ from packit.local_project import LocalProjectBuilder
         ),
         (
             "Update",
-            "Upstream tag: 0.4.0\nUpstream commit: 6957453b",
-            "f31",
-            "f31-update",
-            [
-                flexmock(
-                    title="Update",
-                    target_branch="f31",
-                    source_branch="f31-update",
-                    description="Upstream tag: 0.4.0\nUpstream commit: 8957453b",
-                    author="packit",
-                )
-            ],
-            False,
-        ),
-        (
-            "Update",
-            "Upstream tag: 0.4.0\nUpstream commit: 6957453b",
             "f32",
             "f31-update",
             [
@@ -65,7 +47,6 @@ from packit.local_project import LocalProjectBuilder
         ),
         (
             "Update",
-            "Upstream tag: 0.4.0\nUpstream commit: 6957453b",
             "f31",
             "f31-update",
             [
@@ -81,7 +62,6 @@ from packit.local_project import LocalProjectBuilder
         ),
         (
             "Update",
-            "Upstream tag: 0.4.0\nUpstream commit: 6957453b",
             "f31",
             "f32-update",
             [
@@ -97,7 +77,7 @@ from packit.local_project import LocalProjectBuilder
         ),
     ],
 )
-def test_existing_pr(title, description, branch, source_branch, prs, exists):
+def test_existing_pr(title, target_branch, source_branch, prs, exists):
     user_mock = flexmock().should_receive("get_username").and_return("packit").mock()
     local_project = LocalProjectBuilder().build(
         git_project=flexmock(service="something", get_pr_list=lambda: prs),
@@ -110,7 +90,7 @@ def test_existing_pr(title, description, branch, source_branch, prs, exists):
         ),
         local_project=local_project,
     )
-    pr = distgit.existing_pr(title, description, branch, source_branch)
+    pr = distgit.existing_pr(title, target_branch, source_branch)
     if exists:
         assert pr is not None
     else:


### PR DESCRIPTION
After introducing the commit action, we allow customizing of the beginning of the PR description (which includes the commit description). This conflicts with the pre-existing check for existing (pun not intended) PRs on dist-git.

Relaxing this condition to match the title, source & target branch with the user should be enough to not duplicate PRs.

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

RELEASE NOTES BEGIN

Packit now supports automatic ordering of ☕ after all checks pass.

RELEASE NOTES END
