### PR TITLE
Optional lookaside cache

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1251,7 +1251,11 @@ The first dist-git commit to be synced is '{short_hash}'.
         # we would lose the unchanged ones from sources file,
         # because upload_to_lookaside_cache maintains the sources file in addition
         # to uploading, and it replaces it entirely, losing the previous content
-        self.dg.upload_to_lookaside_cache(archives=archives, pkg_tool=pkg_tool)
+        self.dg.upload_to_lookaside_cache(
+            archives=archives,
+            pkg_tool=pkg_tool,
+            offline=not self.package_config.upload_sources,
+        )
 
     def build(
         self,

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -112,6 +112,7 @@ class CommonPackageConfig:
         tf_extra_params: Additional Testing Farm parameters to merge into the
             payload of TF requests.
         module_hotfixes: if set, copr will generate repo files with module_hotfixes=1
+        upload_sources: If Packit should upload sources to lookaside cache. True by default.
 
     """
 
@@ -183,6 +184,7 @@ class CommonPackageConfig:
         follow_fedora_branching: bool = False,
         upstream_tag_include: str = "",
         upstream_tag_exclude: str = "",
+        upload_sources: bool = True,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -281,6 +283,7 @@ class CommonPackageConfig:
         self.copr_chroot = copr_chroot
 
         self.follow_fedora_branching = follow_fedora_branching
+        self.upload_sources = upload_sources
 
     @property
     def targets_dict(self):

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -386,6 +386,7 @@ class DistGit(PackitRepositoryBase):
         self,
         archives: Iterable[Path],
         pkg_tool: str = "",
+        offline: bool = False,
     ) -> None:
         """Upload files (archives) to the lookaside cache.
 
@@ -394,6 +395,8 @@ class DistGit(PackitRepositoryBase):
         Args:
             archive: Path to archive to upload to lookaside cache.
             pkg_tool: Optional, rpkg tool (fedpkg/centpkg) to use to upload.
+            offline: Whether to use offline mode of the tool
+                     (no actual upload, just local file updates).
 
         Raises:
             PackitException, if the upload fails.
@@ -405,7 +408,10 @@ class DistGit(PackitRepositoryBase):
             tool=pkg_tool or self.config.pkg_tool,
         )
         try:
-            pkg_tool_.new_sources(sources=archives)
+            pkg_tool_.new_sources(
+                sources=archives,
+                offline=offline,
+            )
         except Exception as ex:
             logger.error(
                 f"'{pkg_tool_.tool} new-sources' failed for the following reason: {ex!r}",

--- a/packit/pkgtool.py
+++ b/packit/pkgtool.py
@@ -39,14 +39,22 @@ class PkgTool:
             f"tool='{self.tool}')"
         )
 
-    def new_sources(self, sources: Optional[Iterable[Path]] = None, fail: bool = True):
+    def new_sources(
+        self,
+        sources: Optional[Iterable[Path]] = None,
+        fail: bool = True,
+        offline: bool = False,
+    ):
         sources = sources or []
         if not self.directory.is_dir():
             raise Exception(f"Cannot access {self.tool} repository: {self.directory}")
 
+        cmd = [self.tool, "new-sources"]
+        if offline:
+            cmd.append("--offline")
         sources_ = [str(source) for source in sources] if sources else []
         return commands.run_command_remote(
-            cmd=[self.tool, "new-sources", *sources_],
+            cmd=cmd + sources_,
             cwd=self.directory,
             error_message="Adding new sources failed:",
             print_live=True,

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -360,6 +360,7 @@ class CommonConfigSchema(Schema):
     update_release = fields.Bool(default=True)
     upstream_tag_include = fields.String()
     upstream_tag_exclude = fields.String()
+    upload_sources = fields.Bool(default=True)
 
     # Former 'metadata' keys
     _targets = TargetsListOrDict(missing=None, data_key="targets")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -157,7 +157,7 @@ def mock_remote_functionality(distgit: Path, upstream: Path):
     )
     flexmock(DistGit).should_receive("existing_pr").and_return(None)
 
-    def mocked_new_sources(sources=None):
+    def mocked_new_sources(sources=None, offline=False):
         sources = sources or []
         if not all(Path(s).is_file() for s in sources):
             raise RuntimeError("archive does not exist")

--- a/tests/integration/test_using_cockpit.py
+++ b/tests/integration/test_using_cockpit.py
@@ -53,7 +53,7 @@ def test_update_on_cockpit_ostree(cockpit_ostree):
         DistGit,
         push_to_fork=lambda *args, **kwargs: None,
         is_archive_in_lookaside_cache=lambda archive_path: False,
-        upload_to_lookaside_cache=lambda archives, pkg_tool: None,
+        upload_to_lookaside_cache=lambda archives, pkg_tool, offline: None,
         download_upstream_archives=lambda: ["the-archive"],
     )
     flexmock(DistGit).should_receive("existing_pr").and_return(None)
@@ -97,7 +97,7 @@ def test_update_on_cockpit_ostree_pr_exists(cockpit_ostree):
         DistGit,
         push_to_fork=lambda *args, **kwargs: None,
         is_archive_in_lookaside_cache=lambda archive_path: False,
-        upload_to_lookaside_cache=lambda archives, pkg_tool: None,
+        upload_to_lookaside_cache=lambda archives, pkg_tool, offline: None,
         download_upstream_archives=lambda: ["the-archive"],
     )
     pr = flexmock(url="https://example.com/pull/1")


### PR DESCRIPTION
TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.  (packit/packit.dev#744)

Fixes #2082 

RELEASE NOTES BEGIN

If you have concerns about Packit uploading new archives to lookaside cache before creating a pull request, you can newly set `upload_sources` to False to disable this.

RELEASE NOTES END
