### PR TITLE
Be able to specify bugs resolved by an update

### DIFF
--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -54,6 +54,7 @@ def sync_release(
     force,
     use_downstream_specfile,
     package_config,
+    resolved_bugs,
 ):
     api = get_packit_api(
         config=config,
@@ -80,6 +81,7 @@ def sync_release(
             create_pr=pr,
             force=force,
             use_downstream_specfile=use_downstream_specfile,
+            resolved_bugs=resolved_bugs,
         )
 
 
@@ -114,6 +116,14 @@ def sync_release_common_options(func):
         default=False,
         is_flag=True,
         help="Don't discard changes in the git repo by default, unless this is set.",
+    )
+    @click.option(
+        "-b",
+        "--resolve-bug",
+        help="Bug(s) that are resolved with the update, e.g. rhbz#123 (multiple can be specified)",
+        required=False,
+        default=None,
+        multiple=True,
     )
     @click.option(
         PACKAGE_SHORT_OPTION,
@@ -164,6 +174,7 @@ def propose_downstream(
     local_content,
     upstream_ref,
     force,
+    resolve_bug,
     package_config,
 ):
     """
@@ -188,6 +199,7 @@ def propose_downstream(
         upstream_ref=upstream_ref,
         use_downstream_specfile=False,
         package_config=package_config,
+        resolved_bugs=resolve_bug,
     )
 
 
@@ -205,6 +217,7 @@ def pull_from_upstream(
     path_or_url,
     version,
     force,
+    resolve_bug,
     package_config,
 ):
     """
@@ -229,4 +242,5 @@ def pull_from_upstream(
         upstream_ref=None,
         use_downstream_specfile=True,
         package_config=package_config,
+        resolved_bugs=resolve_bug,
     )

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -205,7 +205,7 @@ PACKAGE_OPTION_HELP = (
 )
 
 SYNC_RELEASE_DEFAULT_COMMIT_DESCRIPTION = (
-    "Upstream tag: {upstream_tag}\nUpstream commit: {upstream_commit}\n"
+    "Upstream tag: {upstream_tag}\nUpstream commit: {upstream_commit}\n{resolved_bugs}"
 )
 SYNC_RELEASE_PR_INSTRUCTIONS = (
     "\n---\n\n"

--- a/tests/integration/test_changelog_helper.py
+++ b/tests/integration/test_changelog_helper.py
@@ -107,10 +107,12 @@ def test_update_distgit_when_copy_upstream_release_description(
     ChangelogHelper(upstream, downstream, package_config).update_dist_git(
         upstream_tag="0.1.0",
         full_version="0.1.0",
+        resolved_bugs=["rhbz#123"],
     )
 
     with downstream._specfile.sections() as sections:
         assert "Some release 0.1.0" in sections.changelog
+        assert "- Resolves rhbz#123" in sections.changelog
 
 
 @pytest.mark.skipif(
@@ -170,6 +172,7 @@ def test_update_distgit_changelog_entry_action_pass_env_vars(
     )
     expected_env = {
         "PACKIT_PROJECT_VERSION": "0.1.0",
+        "PACKIT_RESOLVED_BUGS": "rhbz#123 rhbz#124",
     }
     flexmock(upstream).should_receive("get_output_from_action").with_args(
         ActionName.changelog_entry,
@@ -179,4 +182,5 @@ def test_update_distgit_changelog_entry_action_pass_env_vars(
     ChangelogHelper(upstream, downstream, package_config).update_dist_git(
         upstream_tag="0.1.0",
         full_version="0.1.0",
+        resolved_bugs=["rhbz#123", "rhbz#124"],
     )

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -317,3 +317,30 @@ def test_sync_release_check_pr_instructions(api_mock):
         repo=DistGit,
     ).and_return(flexmock())
     api_mock.sync_release(version="1.1", dist_git_branch="_", add_pr_instructions=True)
+
+
+@pytest.mark.parametrize(
+    "resolved_bugs, result",
+    [
+        pytest.param(
+            ["rhbz#123"],
+            "Upstream tag: 1.0.0\nUpstream commit: _\nResolves rhbz#123\n",
+        ),
+        pytest.param(
+            ["rhbz#123", "rhbz#222"],
+            "Upstream tag: 1.0.0\nUpstream commit: _\nResolves rhbz#123\nResolves rhbz#222\n",
+        ),
+        pytest.param(None, "Upstream tag: 1.0.0\nUpstream commit: _\n"),
+    ],
+)
+def test_get_default_commit_description(api_mock, resolved_bugs, result):
+    class Specfile:
+        def __init__(self, has_autochangelog: bool):
+            self.has_autochangelog = has_autochangelog
+
+    spec = Specfile(has_autochangelog=True)
+    api_mock.dg.should_receive("specfile").and_return(spec)
+    assert (
+        api_mock.get_default_commit_description("1.0.0", resolved_bugs=resolved_bugs)
+        == result
+    )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -60,6 +60,7 @@ def test_propose_downstream_command():
         upstream_ref=None,
         use_downstream_specfile=False,
         package_config=PackageConfig,
+        resolved_bugs=None,
     ).and_return()
     result = call_packit(packit_base, parameters=["propose-downstream", "."])
     assert result.exit_code == 0
@@ -82,6 +83,7 @@ def test_pull_from_upstream_command():
         upstream_ref=None,
         use_downstream_specfile=True,
         package_config=PackageConfig,
+        resolved_bugs=None,
     ).and_return()
     result = call_packit(packit_base, parameters=["pull-from-upstream", "."])
     assert result.exit_code == 0


### PR DESCRIPTION
Add an argument to sync_release that takes list of bugs. These will be then added to the changelog in the end as "- Resolves {bug}". In case of using autochangelog, these bugs will be referenced in the end of the commit message. Besides these default behaviours, Packit will provide the PACKIT_RESOLVED_BUGS env variable to commit-message and changelog-entry actions.

Related to #1920

TODO:
- [x] More tests
- [ ] Update or write new documentation in `packit/packit.dev`.
- [x] Followup PR for passing Upstream Release Monitoring bug in packit-service


RELEASE NOTES BEGIN

You can now specify bugs resolved by an update by `-b` or `--resolve-bug` option for `propose-downstream` and `pull-from-upstream` commands. The values will be added by default to the changelog (or commit if autochangelog is used) and provided in `commit-message` and `changelog-entry` actions as `PACKIT_RESOLVED_BUGS` env variable.
RELEASE NOTES END
