### PR TITLE
Flexmock is now in EPEL 9

### DIFF
--- a/files/tasks/packit-service-requirements.yaml
+++ b/files/tasks/packit-service-requirements.yaml
@@ -40,9 +40,3 @@
     src: "{{ reverse_dir}}/files/packit-service.yaml"
     dest: "{{ ansible_user_dir }}/.config/packit-service.yaml"
     state: link
-
-- name: Get up-to-date version of flexmock from PyPI
-  ansible.builtin.pip:
-    name: flexmock
-    state: latest
-  become: true

--- a/files/tasks/rpm-test-deps.yaml
+++ b/files/tasks/rpm-test-deps.yaml
@@ -6,6 +6,7 @@
       - python3-setuptools_scm
       - python3-distro
       - rpmautospec-rpm-macros
+      - python3-flexmock
     state: present
   become: true
 
@@ -14,20 +15,17 @@
     name:
       - python3-pytest-cov
       - python3-pytest-timeout
-      - python3-flexmock
       - python3-deepdiff
     state: present
   when: ansible_facts['distribution'] == 'Fedora'
   become: true
 
 # packages not in epel, install from PyPI
-# flexmock: https://bugzilla.redhat.com/show_bug.cgi?id=2120251
 - name: (EPEL) Install dependencies from PyPI
   ansible.builtin.pip:
     name:
       - pytest-cov
       - pytest-timeout
-      - flexmock
       - deepdiff
     state: latest
   when: ansible_facts['distribution'] != 'Fedora'

--- a/plans/full.fmf
+++ b/plans/full.fmf
@@ -10,9 +10,9 @@ prepare:
     script: dnf -y config-manager --save --setopt="*:packit:packit-dev.priority=5"
 adjust:
   - when: "distro == rhel-9 or distro == centos-9 or distro == centos-stream-9"
-    because: "flexmock and deepdiff are not in EPEL 9: https://bugzilla.redhat.com/show_bug.cgi?id=2120251"
+    because: "deepdiff is not in EPEL 9"
     prepare:
       - how: install
         package: python3-pip
       - how: shell
-        script: pip3 install flexmock deepdiff
+        script: pip3 install deepdiff

--- a/plans/session-recording.fmf
+++ b/plans/session-recording.fmf
@@ -7,10 +7,3 @@ adjust:
       - how: install
         name: Enable the Copr-repo for Requre
         copr: packit/packit-dev
-  - when: "distro == rhel-9 or distro == centos-9 or distro == centos-stream-9"
-    because: "flexmock is not in EPEL 9: https://bugzilla.redhat.com/show_bug.cgi?id=2120251"
-    prepare+:
-      - how: install
-        package: python3-pip
-      - how: shell
-        script: pip3 install flexmock

--- a/tests/full.fmf
+++ b/tests/full.fmf
@@ -20,9 +20,8 @@ require:
   #- rpmautospec-rpm-macros
 adjust:
   - when: "distro == rhel-9 or distro == centos-9 or distro == centos-stream-9"
-    because: "flexmock and deepdiff are not in EPEL 9: https://bugzilla.redhat.com/show_bug.cgi?id=2120251"
+    because: "deepdiff is not in EPEL 9: https://bugzilla.redhat.com/show_bug.cgi?id=2120251"
     require-:
-      - python3-flexmock
       - python3-deepdiff
 component:
   - packit

--- a/tests_recording/main.fmf
+++ b/tests_recording/main.fmf
@@ -6,11 +6,6 @@ require:
   - python3-packit
   - python3-specfile
   - python3-requests-kerberos
-adjust:
-  - when: "distro == rhel-9 or distro == centos-9 or distro == centos-stream-9"
-    because: "flexmock is not in EPEL 9: https://bugzilla.redhat.com/show_bug.cgi?id=2120251"
-    require-:
-      - python3-flexmock
 component:
   - packit
 tier: 2


### PR DESCRIPTION
[RHBZ#2120251](https://bugzilla.redhat.com/show_bug.cgi?id=2120251)

The reverse-dep tests probably need to merge packit/packit-service#2198 first.