### PR TITLE
Always add bugs to commit message when syncing release

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1011,7 +1011,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         In case the autochangelog is used, the bugs should be referenced in the commits.
         """
         resolved_bugs_msg = ""
-        if resolved_bugs and self.dg.specfile.has_autochangelog:
+        if resolved_bugs:
             for bug in resolved_bugs:
                 resolved_bugs_msg += f"Resolves {bug}\n"
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -334,12 +334,6 @@ def test_sync_release_check_pr_instructions(api_mock):
     ],
 )
 def test_get_default_commit_description(api_mock, resolved_bugs, result):
-    class Specfile:
-        def __init__(self, has_autochangelog: bool):
-            self.has_autochangelog = has_autochangelog
-
-    spec = Specfile(has_autochangelog=True)
-    api_mock.dg.should_receive("specfile").and_return(spec)
     assert (
         api_mock.get_default_commit_description("1.0.0", resolved_bugs=resolved_bugs)
         == result


### PR DESCRIPTION
Remove the condition of adding them only when %autochangelog is used, after discussion with @lachmanfrantisek we agreed this could be beneficial in general.



RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
