### PR TITLE
Add package names to changelog_entry action

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -517,7 +517,10 @@ class Upstream(PackitRepositoryBase):
         self._fix_spec_source(archive)
         self._fix_spec_prep(archive)
 
-        ChangelogHelper(self).prepare_upstream_locally(
+        ChangelogHelper(
+            self,
+            package_config=self.package_config,
+        ).prepare_upstream_locally(
             version,
             commit,
             update_release,
@@ -1073,7 +1076,10 @@ class SRPMBuilder:
         self.upstream.fetch_upstream_archive()
         self.upstream.create_patches_and_update_specfile(self.upstream_ref)
 
-        ChangelogHelper(self.upstream).prepare_upstream_using_source_git(
+        ChangelogHelper(
+            self.upstream,
+            package_config=self.upstream.package_config,
+        ).prepare_upstream_using_source_git(
             update_release,
             release_suffix,
         )

--- a/packit/utils/changelog_helper.py
+++ b/packit/utils/changelog_helper.py
@@ -70,7 +70,7 @@ class ChangelogHelper:
             Changelog entry or `None` if action is not present.
         """
         resolved_bugs_str = " ".join(resolved_bugs) if resolved_bugs else ""
-        env = {
+        env = self.package_config.get_package_names_as_env() | {
             "PACKIT_PROJECT_VERSION": version,
             "PACKIT_RESOLVED_BUGS": resolved_bugs_str,
         }

--- a/tests/integration/test_changelog_helper.py
+++ b/tests/integration/test_changelog_helper.py
@@ -171,6 +171,9 @@ def test_update_distgit_changelog_entry_action_pass_env_vars(
         .mock()
     )
     expected_env = {
+        "PACKIT_CONFIG_PACKAGE_NAME": "beer",
+        "PACKIT_UPSTREAM_PACKAGE_NAME": "beerware",
+        "PACKIT_DOWNSTREAM_PACKAGE_NAME": "beer",
         "PACKIT_PROJECT_VERSION": "0.1.0",
         "PACKIT_RESOLVED_BUGS": "rhbz#123 rhbz#124",
     }


### PR DESCRIPTION
Fixes packit#2076

RELEASE NOTES BEGIN
Packit now exports `PACKIT_UPSTREAM_PACKAGE_NAME`, `PACKIT_DOWNSTREAM_PACKAGE_NAME` and `PACKIT_CONFIG_PACKAGE_NAME` also in the `changelog_entry` action.
RELEASE NOTES END
