### PR TITLE
Make sure release has a disttag

### DIFF
--- a/packit/utils/changelog_helper.py
+++ b/packit/utils/changelog_helper.py
@@ -222,6 +222,14 @@ class ChangelogHelper:
         # instead of changing version, we change Release field
         # upstream projects should take care of versions
         if update_release:
+            # Make sure the new release has a dist tag if it is not already included explicitly
+            # (in release) or implicitly (in up.specfile.raw_release)
+            if (
+                release
+                and not release.endswith("%{?dist}")
+                and not self.up.specfile.raw_release.endswith("%{?dist}")
+            ):
+                release = f"{release}%{{?dist}}"
             logger.debug(f"Setting Release in spec to {release!r}.")
             self.up.specfile.release = release
         if msg is not None:


### PR DESCRIPTION
Not sure if this is the most optimal place to put it

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #1978 

RELEASE NOTES BEGIN

Enforce dist tag `%{?dist}` when updating release

RELEASE NOTES END
