### PR TITLE
Detect bugs in changelog when submitting Bodhi update

### DIFF
--- a/tests/unit/test_dg.py
+++ b/tests/unit/test_dg.py
@@ -148,3 +148,28 @@ def test_monorepo_regression():
 )
 def test_bodhi_regex(exception_message, matches):
     assert bool(re.match(EXISTING_BODHI_UPDATE_REGEX, exception_message)) == matches
+
+
+@pytest.mark.parametrize(
+    "changelog, bugs",
+    [
+        (
+            "* Fri Sep 29 2023 Packit <hello@packit.dev> - 0.82.0-1"
+            "- Resolves rhbz#2240355",
+            ["2240355"],
+        ),
+        (
+            "* Fri Sep 29 2023 Packit <hello@packit.dev> - 0.82.0-1"
+            "- Resolves rhbz#2240355"
+            "- Resolves rhbz#2340355",
+            ["2240355", "2340355"],
+        ),
+        (
+            "* Fri Sep 29 2023 Packit <hello@packit.dev> - 0.82.0-1"
+            "- Update without associated bugs",
+            [],
+        ),
+    ],
+)
+def test_get_bugzilla_ids_from_changelog(changelog, bugs):
+    assert DistGit.get_bugzilla_ids_from_changelog(changelog) == bugs


### PR DESCRIPTION
Use the same regex as Bodhi does for the automatic updates.

Related to #1920


RELEASE NOTES BEGIN
Packit now also detects resolved bugs in the default update notes (created from changelog diff) and assigns these when submitting the Bodhi updates.

RELEASE NOTES END
