### PR TITLE
Fix allowlisting automation

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -237,7 +237,10 @@ class PackitAPI:
     @property
     def pkg_tool(self) -> str:
         """Returns the packaging tool. Prefers the package-level override."""
-        return self.package_config.pkg_tool or self.config.pkg_tool
+        if self.package_config and self.package_config.pkg_tool:
+            return self.package_config.pkg_tool
+
+        return self.config.pkg_tool
 
     @property
     def sync_release_env(self):

--- a/tests/full.fmf
+++ b/tests/full.fmf
@@ -1,3 +1,6 @@
+summary:
+  Full test suite of the Packit
+
 require:
   - python3-flexmock
   - python3-pytest
@@ -23,16 +26,21 @@ require:
   - git
   - make
   #- rpmautospec-rpm-macros
+
 adjust:
   - when: "distro == rhel-9 or distro == centos-9 or distro == centos-stream-9"
     because: "build and deepdiff are not in EPEL 9: https://bugzilla.redhat.com/show_bug.cgi?id=2120251"
     require-:
       - python3-build
       - python3-deepdiff
+
 component:
   - packit
 tier: 1
 tag:
   - basic
-test: pytest-3 -v .
+
+test: pytest-3 -v $TEST_TARGET
 duration: 30m
+environment:
+  TEST_TARGET: .

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -11,6 +11,7 @@ from munch import Munch
 from packit import api as packit_api
 from packit.api import PackitAPI
 from packit.config import CommonPackageConfig, PackageConfig, RunCommandType
+from packit.config.config import Config
 from packit.copr_helper import CoprHelper
 from packit.distgit import DistGit
 from packit.exceptions import PackitException
@@ -342,3 +343,26 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
         api_mock.get_default_commit_description("1.0.0", resolved_bugs=resolved_bugs)
         == result
     )
+
+
+@pytest.mark.parametrize(
+    "package_config, config, expected_pkg_tool",
+    (
+        pytest.param(
+            flexmock(pkg_tool=None),
+            Config(),
+            "fedpkg",
+            id="default from config",
+        ),
+        pytest.param(
+            flexmock(pkg_tool="rhpkg"),
+            Config(),
+            "rhpkg",
+            id="package-level override",
+        ),
+        # regression in automated allowlisting
+        pytest.param(None, Config(), "fedpkg", id="no package_config given"),
+    ),
+)
+def test_pkg_tool_property(package_config, config, expected_pkg_tool):
+    assert PackitAPI(config, package_config).pkg_tool == expected_pkg_tool


### PR DESCRIPTION
Fixes packit/packit-service#2213

RELEASE NOTES BEGIN

We have fixed an issue that prevented automated allowlisting in the Packit Service.

RELEASE NOTES END
