### PR TITLE
fix(dg): fix the hostname candidates to be a set

### DIFF
--- a/packit/constants.py
+++ b/packit/constants.py
@@ -64,9 +64,12 @@ DISTGIT_INSTANCES = {
 }
 
 DISTGIT_HOSTNAME_CANDIDATES = set(
-    itertools.chain(
-        (distgit.hostname, distgit.alternative_hostname)
-        for distgit in DISTGIT_INSTANCES.values()
+    filter(
+        lambda hostname: hostname is not None,
+        itertools.chain.from_iterable(
+            (distgit.hostname, distgit.alternative_hostname)
+            for distgit in DISTGIT_INSTANCES.values()
+        ),
     ),
 )
 

--- a/tests/unit/test_dg.py
+++ b/tests/unit/test_dg.py
@@ -7,7 +7,7 @@ import pytest
 from flexmock import flexmock
 
 from packit.config import CommonPackageConfig, Config, PackageConfig
-from packit.constants import EXISTING_BODHI_UPDATE_REGEX
+from packit.constants import DISTGIT_HOSTNAME_CANDIDATES, EXISTING_BODHI_UPDATE_REGEX
 from packit.distgit import DistGit
 from packit.local_project import LocalProjectBuilder
 
@@ -173,3 +173,14 @@ def test_bodhi_regex(exception_message, matches):
 )
 def test_get_bugzilla_ids_from_changelog(changelog, bugs):
     assert DistGit.get_bugzilla_ids_from_changelog(changelog) == bugs
+
+
+# Regression test for constructing the hostname candidates from the possible dist-git instances
+def test_hostname_candidates():
+    assert {
+        "src.stg.fedoraproject.org",
+        "gitlab.com",
+        "src.fedoraproject.org",
+        "pkgs.fedoraproject.org",
+        "pkgs.stg.fedoraproject.org",
+    } == DISTGIT_HOSTNAME_CANDIDATES


### PR DESCRIPTION
When introducing the dataclass for distgit instances, I've switched to constructing the hostname candidates from the said instances of dataclass instead of a fixed set of URLs.

This change introduces 2 problems though:
1. ‹itertools.chain› constructed a pair of hostnames ‹(hostname, alternative hostname)›
2. Even after switching to ‹itertools.chain.from_iterable› we need to filter out the ‹None› values, since ‹gitlab.com› doesn't have any alternative hostname

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.
- [ ] Handle the case when hostname can host both upstream and downstream repositories (like gitlab.com).

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #2116

RELEASE NOTES BEGIN

We have fixed an issue that you could encounter when running the Packit from the CLI that caused misinterpretation of the repository to be an upstream repo instead of a downstream.

RELEASE NOTES END
