### PR TITLE
Stop supporting [.]packit.json for the configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: prettier
         exclude: tests_recording/test_data/
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-added-large-files
         exclude: tests_recording/test_data/test_api/
@@ -38,7 +38,7 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.6.0
     hooks:
       - id: mypy
         args: [--no-strict-optional, --ignore-missing-imports]
@@ -53,7 +53,7 @@ repos:
             types-cachetools,
           ]
   - repo: https://github.com/teemtee/tmt.git
-    rev: 1.27.0
+    rev: 1.28.2
     hooks:
       - id: tmt-lint
   - repo: https://github.com/packit/pre-commit-hooks

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -14,10 +14,8 @@ SRC_GIT_CONFIG = "source-git.yaml"
 CONFIG_FILE_NAMES = {
     ".packit.yaml",
     ".packit.yml",
-    ".packit.json",
     "packit.yaml",
     "packit.yml",
-    "packit.json",
 }
 
 # local branch name when checking out a PR before we merge it with the target branch

--- a/tests/data/dist_git/.packit.json
+++ b/tests/data/dist_git/.packit.json
@@ -1,8 +1,0 @@
-{
-  "specfile_path": "beer.spec",
-  "synced_files": ["beer.spec"],
-  "upstream_package_name": "beerware",
-  "downstream_package_name": "beer",
-  "create_pr": false,
-  "upstream_project_url": "../upstream_remote-upstream_git"
-}

--- a/tests/data/dist_git/.packit.yaml
+++ b/tests/data/dist_git/.packit.yaml
@@ -1,0 +1,7 @@
+specfile_path: beer.spec
+synced_files:
+  - beer.spec
+upstream_package_name: beerware
+downstream_package_name: beer
+create_pr: false
+upstream_project_url: "../upstream_remote-upstream_git"

--- a/tests/data/dist_git_with_autochangelog/.packit.json
+++ b/tests/data/dist_git_with_autochangelog/.packit.json
@@ -1,8 +1,0 @@
-{
-  "specfile_path": "beer.spec",
-  "synced_files": ["beer.spec"],
-  "upstream_package_name": "beerware",
-  "downstream_package_name": "beer",
-  "create_pr": false,
-  "upstream_project_url": "../upstream_remote-upstream_git"
-}

--- a/tests/data/dist_git_with_autochangelog/.packit.yaml
+++ b/tests/data/dist_git_with_autochangelog/.packit.yaml
@@ -1,0 +1,7 @@
+specfile_path: beer.spec
+synced_files:
+  - beer.spec
+upstream_package_name: beerware
+downstream_package_name: beer
+create_pr: false
+upstream_project_url: "../upstream_remote-upstream_git"

--- a/tests/data/empty_changelog/.packit.json
+++ b/tests/data/empty_changelog/.packit.json
@@ -1,7 +1,0 @@
-{
-  "specfile_path": "beer.spec",
-  "synced_files": ["beer.spec"],
-  "upstream_package_name": "beerware",
-  "downstream_package_name": "beer",
-  "create_pr": false
-}

--- a/tests/data/empty_changelog/.packit.yaml
+++ b/tests/data/empty_changelog/.packit.yaml
@@ -1,0 +1,6 @@
+specfile_path: beer.spec
+synced_files:
+  - beer.spec
+upstream_package_name: beerware
+downstream_package_name: beer
+create_pr: false

--- a/tests/data/spec_not_in_root/upstream/.packit.json
+++ b/tests/data/spec_not_in_root/upstream/.packit.json
@@ -1,7 +1,0 @@
-{
-  "specfile_path": "dir_with_spec/beer.spec",
-  "synced_files": ["beer.spec"],
-  "upstream_package_name": "beerware",
-  "downstream_package_name": "beer",
-  "create_pr": false
-}

--- a/tests/data/spec_not_in_root/upstream/.packit.yaml
+++ b/tests/data/spec_not_in_root/upstream/.packit.yaml
@@ -1,0 +1,6 @@
+specfile_path: dir_with_spec/beer.spec
+synced_files:
+  - beer.spec
+upstream_package_name: beerware
+downstream_package_name: beer
+create_pr: false

--- a/tests/data/upstream_git/.packit.json
+++ b/tests/data/upstream_git/.packit.json
@@ -1,7 +1,0 @@
-{
-  "specfile_path": "beer.spec",
-  "synced_files": ["beer.spec"],
-  "upstream_package_name": "beerware",
-  "downstream_package_name": "beer",
-  "create_pr": false
-}

--- a/tests/data/upstream_git/.packit.yaml
+++ b/tests/data/upstream_git/.packit.yaml
@@ -1,0 +1,6 @@
+specfile_path: beer.spec
+synced_files:
+  - beer.spec
+upstream_package_name: beerware
+downstream_package_name: beer
+create_pr: false

--- a/tests/data/upstream_git_macro_in_source/.packit.json
+++ b/tests/data/upstream_git_macro_in_source/.packit.json
@@ -1,7 +1,0 @@
-{
-  "specfile_path": "beer.spec",
-  "synced_files": ["beer.spec"],
-  "upstream_package_name": "beerware",
-  "downstream_package_name": "beer",
-  "create_pr": false
-}

--- a/tests/data/upstream_git_macro_in_source/.packit.yaml
+++ b/tests/data/upstream_git_macro_in_source/.packit.yaml
@@ -1,0 +1,6 @@
+specfile_path: beer.spec
+synced_files:
+  - beer.spec
+upstream_package_name: beerware
+downstream_package_name: beer
+create_pr: false

--- a/tests/data/upstream_git_weird_sources/.packit.json
+++ b/tests/data/upstream_git_weird_sources/.packit.json
@@ -1,5 +1,0 @@
-{
-  "specfile_path": "beer.spec",
-  "upstream_package_name": "beerware",
-  "downstream_package_name": "beer"
-}

--- a/tests/data/upstream_git_weird_sources/.packit.yaml
+++ b/tests/data/upstream_git_weird_sources/.packit.yaml
@@ -1,0 +1,3 @@
+specfile_path: beer.spec
+upstream_package_name: beerware
+downstream_package_name: beer

--- a/tests/data/upstream_git_with_multiple_sources/.packit.json
+++ b/tests/data/upstream_git_with_multiple_sources/.packit.json
@@ -1,7 +1,0 @@
-{
-  "specfile_path": "beer.spec",
-  "synced_files": ["beer.spec"],
-  "upstream_package_name": "beerware",
-  "downstream_package_name": "beer",
-  "create_pr": false
-}

--- a/tests/data/upstream_git_with_multiple_sources/.packit.yaml
+++ b/tests/data/upstream_git_with_multiple_sources/.packit.yaml
@@ -1,0 +1,6 @@
+specfile_path: beer.spec
+synced_files:
+  - beer.spec
+upstream_package_name: beerware
+downstream_package_name: beer
+create_pr: false

--- a/tests/functional/test_srpm.py
+++ b/tests/functional/test_srpm.py
@@ -4,9 +4,10 @@
 """
 Functional tests for srpm command
 """
-import json
 import subprocess
 from pathlib import Path
+
+import yaml
 
 from packit.utils.commands import cwd
 from tests.functional.spellbook import call_real_packit
@@ -55,14 +56,14 @@ def test_srpm_command_no_tags(upstream_and_remote):
 
 def test_action_output(upstream_and_remote):
     upstream_repo_path = upstream_and_remote[0]
-    packit_yaml_path = upstream_repo_path / ".packit.json"
-    packit_yaml_dict = json.loads(packit_yaml_path.read_text())
+    packit_yaml_path = upstream_repo_path / ".packit.yaml"
+    packit_yaml_dict = yaml.safe_load(packit_yaml_path.read_text())
     # http://www.atlaspiv.cz/?page=detail&beer_id=4187
     the_line_we_want = "MadCat - Imperial Stout Rum Barrel Aged 20°"
     packit_yaml_dict["actions"] = {
         "post-upstream-clone": [f"bash -c 'echo {the_line_we_want}'"],
     }
-    packit_yaml_path.write_text(json.dumps(packit_yaml_dict))
+    packit_yaml_path.write_text(yaml.dump(packit_yaml_dict))
     out = call_real_packit(
         parameters=["srpm"],
         cwd=upstream_repo_path,
@@ -134,8 +135,8 @@ def test_srpm_twice(cwd_upstream_or_distgit):
 
 
 def _test_srpm_symlinking(upstream_repo_path, path_prefix):
-    packit_yaml_path = upstream_repo_path / ".packit.json"
-    packit_yaml_dict = json.loads(packit_yaml_path.read_text())
+    packit_yaml_path = upstream_repo_path / ".packit.yaml"
+    packit_yaml_dict = yaml.safe_load(packit_yaml_path.read_text())
 
     sources_tarball = "random_sources.tar.gz"
     desired_path = f"{path_prefix}/tmp/{sources_tarball}"
@@ -144,7 +145,7 @@ def _test_srpm_symlinking(upstream_repo_path, path_prefix):
             f"bash -c 'mkdir tmp; touch {desired_path}; echo {desired_path}'",
         ],
     }
-    packit_yaml_path.write_text(json.dumps(packit_yaml_dict))
+    packit_yaml_path.write_text(yaml.dump(packit_yaml_dict))
     out = call_real_packit(
         parameters=["srpm"],
         cwd=upstream_repo_path,


### PR DESCRIPTION
- [x] Write new tests or update the old ones to cover new functionality.
- [N/A] Update or write new documentation in `packit/packit.dev`. (The docs doesn't mention `[.]packit.json` anywhere)

Fixes #1573 

RELEASE NOTES BEGIN

Packit no longer accepts `packit.json` or `.packit.json` as a configuration file name.

RELEASE NOTES END
