### PR TITLE
Run git clean after syncing release in a branch

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1002,6 +1002,8 @@ The first dist-git commit to be synced is '{short_hash}'.
                 self.up.local_project.git_repo.git.checkout(current_up_branch, "-f")
             self.dg.refresh_specfile()
             self.dg.local_project.git_repo.git.reset("--hard", "HEAD")
+            self.dg.local_project.git_repo.git.clean("-xdf")
+
         return pr
 
     def get_default_commit_description(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -93,7 +93,11 @@ def git_project_mock():
 @pytest.fixture
 def git_repo_mock():
     return flexmock(
-        git=flexmock(checkout=lambda *_: None, reset=lambda *_: None),
+        git=flexmock(
+            checkout=lambda *_: None,
+            reset=lambda *_: None,
+            clean=lambda *_: None,
+        ),
         remote=lambda *_: flexmock(refs={"_": "_"}),
         branches=[],
         create_head=lambda *_, **__: None,


### PR DESCRIPTION
By this, we will make sure the untracked files (that were e.g. for one branch gitignored) will not be committed when syncing other branch (without having that file gitignored).

Fixes https://github.com/packit/packit-service/issues/2181

TODO:

- [x] Write new tests or update the old ones to cover new functionality.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

RELEASE NOTES BEGIN

Packit now properly cleans up the branch after syncing the release which should prevent unwanted files (e.g.tarballs) being committed in dist-git.
RELEASE NOTES END
