### PR TITLE
Add newline after referencing bugzilla in commit message in sync down…

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1023,6 +1023,8 @@ The first dist-git commit to be synced is '{short_hash}'.
         if resolved_bugs:
             for bug in resolved_bugs:
                 resolved_bugs_msg += f"- Resolves {bug}\n"
+            # add one more newline so that the text after is not included in autochangelog
+            resolved_bugs_msg += "\n"
 
         return SYNC_RELEASE_DEFAULT_COMMIT_DESCRIPTION.format(
             upstream_tag=upstream_tag,

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -339,11 +339,11 @@ def test_sync_release_check_pr_instructions(api_mock):
     [
         pytest.param(
             ["rhbz#123"],
-            "- Resolves rhbz#123\nUpstream tag: 1.0.0\nUpstream commit: _\n",
+            "- Resolves rhbz#123\n\nUpstream tag: 1.0.0\nUpstream commit: _\n",
         ),
         pytest.param(
             ["rhbz#123", "rhbz#222"],
-            "- Resolves rhbz#123\n- Resolves rhbz#222\nUpstream tag: 1.0.0\nUpstream commit: _\n",
+            "- Resolves rhbz#123\n- Resolves rhbz#222\n\nUpstream tag: 1.0.0\nUpstream commit: _\n",
         ),
         pytest.param(None, "Upstream tag: 1.0.0\nUpstream commit: _\n"),
     ],


### PR DESCRIPTION
…stream

Without the additional newline, the content after ("Upstream commit: ...") is included in the automatically generated changelog when using %autochangelog.

RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
