### PR TITLE
Do not download sources excluded using spec file conditions

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -600,6 +600,7 @@ class PackitRepositoryBase:
                 )
                 for spec_source in sources + patches
                 if spec_source.remote
+                and spec_source.valid  # skip invalid (excluded using conditions) sources
             )
         logger.debug(f"List of sources to download (url, path, optional): {sourcelist}")
         # Download all sources


### PR DESCRIPTION
Fixes https://github.com/packit/packit/issues/2129.

Merge after https://github.com/packit/specfile/pull/295.

RELEASE NOTES BEGIN

Packit no longer downloads sources excluded using spec file conditions.

RELEASE NOTES END
