### PR TITLE
pull-from-upstream with no upstream

### DIFF
--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -17,7 +17,7 @@ from packit.api import PackitAPI
 from packit.config import Config, JobType, get_local_package_config
 from packit.config.common_package_config import MultiplePackages
 from packit.config.package_config import PackageConfig
-from packit.constants import DISTRO_DIR, SRC_GIT_CONFIG
+from packit.constants import DISTGIT_HOSTNAME_CANDIDATES, DISTRO_DIR, SRC_GIT_CONFIG
 from packit.exceptions import PackitException, PackitNotAGitRepoException
 from packit.local_project import LocalProject
 
@@ -312,29 +312,26 @@ def get_packit_api(
     lp_downstream = None
 
     for url in remote_urls:
-        parsed_url = parse_git_repo(url)
-        if not parsed_url.hostname:
+        remote_hostname = get_hostname_or_none(url=url)
+        if not remote_hostname:
             continue
 
-        if package_config.dist_git_instance.has_repository(url):
-            lp_downstream = local_project
-            logger.debug(
-                "Input directory is a downstream repository. Deduced from package config.",
-            )
+        if upstream_hostname and remote_hostname == upstream_hostname:
+            lp_upstream = local_project
+            logger.debug("Input directory is an upstream repository.")
             break
 
-        if upstream_hostname and parsed_url.hostname == upstream_hostname:
-            lp_upstream = local_project
-            logger.debug(
-                "Input directory is an upstream repository. Upstream hostname matches.",
-            )
+        if package_config.dist_git_base_url and (
+            remote_hostname in package_config.dist_git_base_url
+            or remote_hostname in DISTGIT_HOSTNAME_CANDIDATES
+        ):
+            lp_downstream = local_project
+            logger.debug("Input directory is a downstream repository.")
             break
     else:
         lp_upstream = local_project
         # fallback, this is the past behavior
-        logger.debug(
-            "Input directory is an upstream repository. No suitable remote found.",
-        )
+        logger.debug("Input directory is an upstream repository.")
 
     return PackitAPI(
         config=config,

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -77,6 +77,7 @@ class Upstream(PackitRepositoryBase):
                 repo_name=self.package_config.upstream_package_name,
                 cache=self.repository_cache,
                 merge_pr=self.package_config.merge_pr_in_ci,
+                specfile=self.specfile,
             )
             # TODO: Turn this on once p-s mocks are updated
             # builder = LocalProjectBuilder(cache=self.repository_cache)

--- a/packit/utils/lookaside.py
+++ b/packit/utils/lookaside.py
@@ -93,10 +93,8 @@ class LookasideCache:
         archive_name = os.path.basename(archive_path)
         archive_hash = self.cache.hash_file(archive_path)
 
-        return self.cache.remote_file_exists_head(
+        return self.cache.remote_file_exists(
             name=self._get_package(package),
             filename=archive_name,
             hash=archive_hash,
-            # `hashtype` is a required argument, yet it doesn't have a default…
-            hashtype=None,
         )


### PR DESCRIPTION
A **dirty** draft for **pull-from-upstream with no upstream**. Many topics to discuss around this.

This code worked from the command line; in `.packit.yaml` there should be no `upstream_project_url` key then sources are taken from the specfile, exploded in `api.up.local_project.working_dir`. Every repository operation is avoided using a *flag* that tell us the upstream is not a repo and *defaults* for the commit message and the changelog.

---

# Topics to discuss

Why not use the `sources` key in config?
The `sources` dictionary is meant for overriding the SourceX entries in the Specfile. I think we need something different here, we want to use the SourcesX and not change them.
If the `upstream_project_url` key is not set then I think it comes "natural" to look after the sources in the urls specified in the Specfile.

But the first **question is**: when we collect the project's sources, should we loop over all the sources and patches referenced in the Specfile (which are remote and not local in dist-git)? And should we explode all the tarballs we found? I fear this could not work, probably not all referenced tarballs need to be exploded. Then probably it is better having something more explicit in our config, a new dictionary key with the SourceX and PatchY url entries which Packit should download plus the information if Packit should explode them or not.


The code inside this PR is dirty but somehow it is working. 
It is creating a `working_dir` inside the `Upstream` `LocalProject` using the `Specfile` entries (and for this reason the Specfile is given to the `LocalProject`) and it is using a flag (`up_is_git_repo`) to avoid all the git repo related operations (since we don't have a git repo in the `working_dir`).

**Solution 1.  cleaning this PR** (removing duplicate code, fixing tests ecc.) and merging it like it is now more or less.
PRO: quick solution
CONS: dirty, the flag in the `sync_release` method is making code less readable and having a `Specfile` into the `LocalProject` is increasing complexity in code. 

Other solutions:

Why not create another `sync_release` method just for the cases where we don't have an upstream? Because most of the calls in the `sync_release` method are calls to the `api.dg` object; probably we will have a lot of code duplication creating a new method.
And yet, we need different `api.up` calls, all those running an `action`. Even though we don't really have an upstream we need it (an `Upstream` object with a `woking_dir`) to be able to run the `actions`.

**Solution 2. create a `FakeUpstream`+`ActionManager` object and refactoring `PackitRepositoryBase`**
PRO: Better code than solution 1.
CONS: A slightly big refactoring.

For me the question is: how do we want to run actions in a *fake* `Upstream` object? 
Now the `PackitRepositoryBase` is managing actions but I would say that we don't really need a repository for managing actions. We could have a new `class ActionManager` with the code taken from the `PackitRepositoryBase` but the new code should not depend on a *git repo*. Both the old `Upstream` and the new `FakeUpstream` should have an `ActionManager` and the difference between an `Upstream` object and a `FakeUpstream` object should be that all the git related operations in the `FakeUpstream` should do nothing. 
With a `FakeUpstream` and a new `ActionManager` we could probably get rid of the `up_is_git_repo` flag in the `sync_release` method and also make the `FakeUpstream`+`ActionManager` work on something different than the `LocalProject` in this way we could also get rid of the `Specfile` in the `LocalProject` code. 

**Solution 3. Create a `NonRepo` object to be used inside `LocalProject` and using LocalProjectBuilder**

We could also hide the *non git nature* of the new `Upstream` `LocalProject` inside `LocalProject` itself without touching the `class Upstream` code.
The `LocalProject.git_repo` is a `git.Repo` object. We could probably build a `LocalProject` with a new `NonRepo` object which has the same API than the `git.Repo` (from the point of view of Packit) but with no implementations for all the methods (we can print just warnings). Probably in this way we can get rid of the `up_is_git_repo` in the `sync_release` method in most of the cases.
We need to build a `LocalProject` with the sources in the `working_dir` and for not having the Specfile in the `LocalProject` object itself we should probably start using the `LocalProjectBuilder`.

PRO: A solution in the middle of 1&2. Smaller refactoring than 2 and better code than 1.
CONS: Bigger refactoring than solution 1 and worse code than solution 2.


Other **question**:
How do we resolve: commit message and changelog without a repository to query?
In solution 1. we depend on the `action` implemented by the users and on some static defaults.
Do we have other ways?

---

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

RELEASE NOTES BEGIN

Packit now supports automatic ordering of ☕ after all checks pass.

RELEASE NOTES END
