### PR TITLE
Make sure the latest builds of ogr and specfile are available for upstream test jobs

### DIFF
--- a/plans/full.fmf
+++ b/plans/full.fmf
@@ -1,17 +1,22 @@
 summary: Unit, integration & functional tests.
 discover+:
   filter: tier:1
-prepare:
-  # enable packit-dev Copr repo to get the latest builds of ogr and specfile
-  - how: install
-    copr: packit/packit-dev
-  # make sure the Copr repo has higher priority than TF Tag Repository
-  - how: shell
-    script: dnf -y config-manager --save --setopt="*:packit:packit-dev.priority=5"
 adjust:
+  - when: "initiator == packit"
+    because: "have the latest builds of ogr and specfile available for upstream test jobs"
+    prepare+:
+      # enable packit-dev Copr repo to get the latest builds of ogr and specfile
+      - how: install
+        copr: packit/packit-dev
+      # make sure the Copr repo has higher priority than TF Tag Repository
+      - how: shell
+        script: dnf -y config-manager --save --setopt="*:packit:packit-dev.priority=5"
+      # upgrade ogr and specfile in case they are already installed
+      - how: shell
+        script: dnf -y upgrade python3-ogr python3-specfile
   - when: "distro == rhel-9 or distro == centos-9 or distro == centos-stream-9"
     because: "build and deepdiff are not in EPEL 9"
-    prepare:
+    prepare+:
       - how: install
         package: python3-pip
       - how: shell

--- a/plans/session-recording.fmf
+++ b/plans/session-recording.fmf
@@ -2,8 +2,20 @@ summary: Session recording testcases
 discover+:
   filter: tier:2
 adjust:
+  - when: "initiator == packit"
+    because: "have the latest builds of ogr and specfile available for upstream test jobs"
+    prepare+:
+      # enable packit-dev Copr repo to get the latest builds of ogr and specfile
+      - how: install
+        copr: packit/packit-dev
+      # make sure the Copr repo has higher priority than TF Tag Repository
+      - how: shell
+        script: dnf -y config-manager --save --setopt="*:packit:packit-dev.priority=5"
+      # upgrade ogr and specfile in case they are already installed
+      - how: shell
+        script: dnf -y upgrade python3-ogr python3-specfile
   - when: "distro <= rhel-9 or distro <= centos-9 or distro == centos-stream-8 or distro == centos-stream-9"
-    prepare:
+    prepare+:
       - how: install
         name: Enable the Copr-repo for Requre
         copr: packit/packit-dev


### PR DESCRIPTION
But not when run on a dist-git PR, in that case we want to test with stable versions.