### PR TITLE
Support pre-release versions in sync_release

### DIFF
--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -221,6 +221,8 @@ class CommonPackageConfig:
         follow_fedora_branching: bool = False,
         upstream_tag_include: str = "",
         upstream_tag_exclude: str = "",
+        prerelease_suffix_pattern: str = r"([.\-_~^]?)(alpha|beta|rc|pre(view)?)([.\-_]?\d+)?",
+        prerelease_suffix_macro: Optional[str] = None,
         upload_sources: bool = True,
         pkg_tool: Optional[str] = None,
         version_update_mask: Optional[str] = None,
@@ -282,6 +284,8 @@ class CommonPackageConfig:
         self.upstream_tag_include = upstream_tag_include
         self.upstream_tag_exclude = upstream_tag_exclude
         self.version_update_mask = version_update_mask
+        self.prerelease_suffix_pattern = prerelease_suffix_pattern
+        self.prerelease_suffix_macro = prerelease_suffix_macro
 
         # from deprecated JobMetadataConfig
         self._targets: dict[str, dict[str, Any]]

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -360,6 +360,8 @@ class CommonConfigSchema(Schema):
     update_release = fields.Bool(default=True)
     upstream_tag_include = fields.String()
     upstream_tag_exclude = fields.String()
+    prerelease_suffix_pattern = fields.String()
+    prerelease_suffix_macro = fields.String(missing=None)
     upload_sources = fields.Bool(default=True)
 
     # Former 'metadata' keys


### PR DESCRIPTION
There are two ways how to support pre-releases in a spec file.

The simpler way relies on the `%version_no_tilde` macro from `rust-srpm-macros` (not present on EL < 9) that converts a pre-release version with `~` back to upstream version. An optional argument defines upstream delimiter that defaults to `-`.
Here is an example of a spec file using this macro:

```specfile
Version:        3.28.0~rc3

...

Source0:        https://example.com/files/v%{version_no_tilde}/%{name}-%{version_no_tilde}.tar.gz

...

%prep
%autosetup -p1 -n %{name}-%{version_no_tilde}
```

If upstream version doesn't have a delimiter, for example `3.28.0b5`, you can use `%{version_no_tilde %{quote:%nil}}`.

The second, more complex way requires you to define a macro, typically called `prerelease` or `prerel`, and package version (value of the `Version` tag) and upstream version are constructed depending on whether it is defined or commented out.
Here is an example of such a spec file:

```specfile
%global base_version 3.28.0
%global prerelease rc3

%global package_version %{base_version}%{?prerelease:~%{prerelease}}
%global upstream_version %{base_version}%{?prerelease:-%{prerelease}}

...

Version:        %{package_version}

...

Source0:        https://example.com/files/v%{upstream_version}/%{name}-%{upstream_version}.tar.gz

...

%prep
%autosetup -p1 -n %{name}-%{upstream_version}
```

And a little more complex example that achieves the same (but this time there is no delimiter in upstream version and tarball URL is slightly different):

```specfile
%global majorver 3
%global minorver 28
%global patchver 0
%global prerel rc3

%if 0%{?prerel:1}
%global package_version %{majorver}.%{minorver}.%{patchver}~%{prerel}
%global upstream_version %{majorver}.%{minorver}.%{patchver}%{prerel}
%else
%global package_version %{majorver}.%{minorver}.%{patchver}
%global upstream_version %{majorver}.%{minorver}.%{patchver}
%endif

...

Version:        %{package_version}

...

Source0:        https://example.com/files/v%{majorver}.%{minorver}/%{name}-%{upstream_version}.tar.gz

...

%prep
%autosetup -p1 -n %{name}-%{upstream_version}
```

Packit supports both ways. There is a new config option `prerelease_suffix_pattern` that defines a regex that is used to determine if a version is a pre-release or not. It defaults to `([.\-_~^]?)(alpha|beta|rc|pre(view)?)([.\-_]?\d+)?` and you can adjust it if your project uses a different versioning scheme or undefine it to opt-out from pre-release processing. The first capturing group of the regex should capture the delimiter (and can be empty if there is none).
If a pre-release is detected, the delimiter is replaced with `~`. You can also configure the `prerelease_suffix_macro` option to correspond to a pre-release macro in your spec file and this macro will be commented out or uncommented accordingly.

---

TODO:

- [ ] Make the above a documentation article
- [ ] Document the new config options

Merge after https://github.com/packit/specfile/pull/317.

Fixes https://github.com/packit/packit/issues/2013.

RELEASE NOTES BEGIN

Packit now supports pre-release version in `propose_downstream` and `pull_from_upstream`. A spec file update might be required, see the documentation for more details.

RELEASE NOTES END