### PR TITLE
Fix sanitize version method

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -30,7 +30,7 @@ from packit.exceptions import (
 from packit.local_project import LocalProject
 from packit.patches import PatchGenerator, PatchMetadata
 from packit.sync import iter_srcs
-from packit.utils import commands, sanitize_branch_name_for_rpm
+from packit.utils import commands, sanitize_version
 from packit.utils.changelog_helper import ChangelogHelper
 from packit.utils.commands import run_command
 from packit.utils.repo import get_current_version_command, git_remote_url_to_https_url
@@ -301,7 +301,7 @@ class Upstream(PackitRepositoryBase):
             version = self.specfile.expanded_version
 
         logger.debug(f"Version: {version}")
-        version = sanitize_branch_name_for_rpm(version)
+        version = sanitize_version(version)
         logger.debug(f"Sanitized version: {version}")
 
         return version
@@ -487,7 +487,7 @@ class Upstream(PackitRepositoryBase):
             # the leading dot is put here b/c git_desc_suffix can be empty
             # and we could have two subsequent dots - rpm errors out in such a case
         current_branch = self.local_project.ref
-        sanitized_current_branch = sanitize_branch_name_for_rpm(current_branch)
+        sanitized_current_branch = sanitize_version(current_branch)
         current_time = datetime.datetime.now().strftime(DATETIME_FORMAT)
         return (
             f"{original_release_number}.{current_time}."
@@ -1110,7 +1110,7 @@ class SRPMBuilder:
             "PACKIT_RPMSPEC_RELEASE": self.upstream.get_spec_release(release_suffix),
             "PACKIT_PROJECT_COMMIT": current_commit,
             "PACKIT_PROJECT_ARCHIVE": archive,
-            "PACKIT_PROJECT_BRANCH": sanitize_branch_name_for_rpm(
+            "PACKIT_PROJECT_BRANCH": sanitize_version(
                 self.upstream.local_project.ref,
             ),
         }

--- a/packit/utils/__init__.py
+++ b/packit/utils/__init__.py
@@ -39,6 +39,7 @@ __all__ = [
     set_logging.__name__,
     StreamLogger.__name__,
 ]
+OFFENDERS = "!@#$%&*()={[}]|\\'\":;<,>/?`"
 
 
 def sanitize_branch_name(branch_name: str) -> str:
@@ -49,18 +50,25 @@ def sanitize_branch_name(branch_name: str) -> str:
         Name must contain only letters, digits, underscores, dashes and dots.
     """
     # https://stackoverflow.com/questions/3411771/best-way-to-replace-multiple-characters-in-a-string
-    offenders = "!@#$%^&*()+={[}]|\\'\":;<,>/?~`"
+    offenders = OFFENDERS + "^~+"
     for o in offenders:
         branch_name = branch_name.replace(o, "-")
     return branch_name
 
 
-def sanitize_branch_name_for_rpm(branch_name: str) -> str:
-    """
+def sanitize_version(version: str) -> str:
+    """Sanitize given string to be usable as a version.
+
     rpm is picky about release: hates "/" - it's an error
     also prints a warning for "-"
+
+    Follows rules in
+    https://github.com/rpm-software-management/rpm/blob/master/docs/manual/spec.md#version
+
+    The version string consists of alphanumeric characters,
+    which can optionally be segmented with the separators
+    ., _ and +, plus ~ and ^
     """
-    offenders = "!@#$%^&*()={[}]|\\'\":;<,>/?~`"
-    for o in offenders:
-        branch_name = branch_name.replace(o, "")
-    return branch_name.replace("-", ".")
+    for o in OFFENDERS:
+        version = version.replace(o, "")
+    return version.replace("-", ".")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -9,7 +9,7 @@ import pytest
 from flexmock import flexmock
 
 from packit.api import get_packit_version
-from packit.utils import sanitize_branch_name, sanitize_branch_name_for_rpm
+from packit.utils import sanitize_branch_name, sanitize_version
 
 
 def test_get_packit_version_not_installed():
@@ -33,9 +33,17 @@ def test_relative_to(to, from_, exp):
 
 
 @pytest.mark.parametrize(
-    "inp,exp,exp_rpm",
-    (("pr/123", "pr-123", "pr123"), ("🌈🌈🌈", "🌈🌈🌈", "🌈🌈🌈"), ("@#$#$%", "------", "")),
+    "inp,exp,ver",
+    (
+        ("pr/123", "pr-123", "pr123"),
+        ("🌈🌈🌈", "🌈🌈🌈", "🌈🌈🌈"),
+        ("@#$#$%", "------", ""),
+        ("pr+1", "pr-1", "pr+1"),
+        ("pr^1", "pr-1", "pr^1"),
+        ("pr~1", "pr-1", "pr~1"),
+        ("pr-1", "pr-1", "pr.1"),
+    ),
 )
-def test_sanitize_branch(inp, exp, exp_rpm):
+def test_sanitize_branch(inp, exp, ver):
     assert sanitize_branch_name(inp) == exp
-    assert sanitize_branch_name_for_rpm(inp) == exp_rpm
+    assert sanitize_version(inp) == ver


### PR DESCRIPTION
Following documentation at
https://github.com/rpm-software-management/rpm/blob/master/docs/manual/spec.md#version

Fixes #2101

RELEASE NOTES BEGIN

Now Packit allows ~^+ (special characters) in a tag (used for building the version string). 

RELEASE NOTES END
