### PR TITLE
Check proposed and current version before release

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -745,24 +745,25 @@ The first dist-git commit to be synced is '{short_hash}'.
         proposed: str, release we are preparing for package
         target_branch: str, Fedora branch where release the package
         """
-        masked_current = re.match(self.package_config.version_update_mask, current)
-        masked_proposed = re.match(
-            self.package_config.version_update_mask,
-            proposed,
-        )
-        if (
-            masked_current
-            and masked_proposed
-            and masked_current.group(0) != masked_proposed.group(0)
-        ):
-            raise ReleaseSkippedPackitException(
-                f"The upstream released version {current} does not match "
-                f"specfile version {proposed} at branch {target_branch} "
-                f"using the version_update_mask "
-                f'"{self.package_config.version_update_mask}".'
-                "\nYou can change the version_update_mask with an empty string "
-                "to skip this check.",
+        if self.package_config.version_update_mask is not None:
+            masked_current = re.match(self.package_config.version_update_mask, current)
+            masked_proposed = re.match(
+                self.package_config.version_update_mask,
+                proposed,
             )
+            if (
+                masked_current
+                and masked_proposed
+                and masked_current.group(0) != masked_proposed.group(0)
+            ):
+                raise ReleaseSkippedPackitException(
+                    f"The upstream released version {current} does not match "
+                    f"specfile version {proposed} at branch {target_branch} "
+                    f"using the version_update_mask "
+                    f'"{self.package_config.version_update_mask}".'
+                    "\nYou can change the version_update_mask with an empty string "
+                    "to skip this check.",
+                )
 
     @overload
     def sync_release(

--- a/packit/api.py
+++ b/packit/api.py
@@ -58,6 +58,7 @@ from packit.exceptions import (
     PackitRPMNotFoundException,
     PackitSRPMException,
     PackitSRPMNotFoundException,
+    ReleaseSkippedPackitException,
 )
 from packit.local_project import LocalProject
 from packit.patches import PatchGenerator
@@ -732,6 +733,37 @@ The first dist-git commit to be synced is '{short_hash}'.
 """
         return f"'{source_git}' is up to date with '{dist_git}'."
 
+    def check_version_distance(
+        self,
+        current,
+        proposed,
+        target_branch,
+    ) -> None:
+        """Check 'distance' between new and old release
+
+        current: str, already released version for package
+        proposed: str, release we are preparing for package
+        target_branch: str, Fedora branch where release the package
+        """
+        masked_current = re.match(self.package_config.version_update_mask, current)
+        masked_proposed = re.match(
+            self.package_config.version_update_mask,
+            proposed,
+        )
+        if (
+            masked_current
+            and masked_proposed
+            and masked_current.group(0) != masked_proposed.group(0)
+        ):
+            raise ReleaseSkippedPackitException(
+                f"The upstream released version {current} does not match "
+                f"specfile version {proposed} at branch {target_branch} "
+                f"using the version_update_mask "
+                f'"{self.package_config.version_update_mask}".'
+                "\nYou can change the version_update_mask with an empty string "
+                "to skip this check.",
+            )
+
     @overload
     def sync_release(
         self,
@@ -872,9 +904,6 @@ The first dist-git commit to be synced is '{short_hash}'.
             raise PackitException(
                 "The repository is dirty, will not discard the changes. Use --force to bypass.",
             )
-        # do not add anything between distgit clone and saving gpg keys!
-        self.up.allowed_gpg_keys = self.dg.get_allowed_gpg_keys_from_downstream_config()
-
         upstream_ref = self.up._expand_git_ref(
             upstream_ref or self.package_config.upstream_ref,
         )
@@ -890,37 +919,46 @@ The first dist-git commit to be synced is '{short_hash}'.
                 )
             elif not use_local_content:
                 self.up.local_project.checkout_release(upstream_tag)
-            self.up.run_action(
-                actions=ActionName.post_upstream_clone,
-                env=self.sync_release_env,
-            )
 
-            if not use_downstream_specfile:
-                spec_ver = self.up.get_specfile_version()
-                if compare_versions(version, spec_ver) > 0:
-                    logger.warning(f"Version {spec_ver!r} in spec file is outdated.")
-
-            self.dg.check_last_commit()
-
-            self.up.run_action(actions=ActionName.pre_sync, env=self.sync_release_env)
-            if not use_downstream_specfile:
-                self.up.specfile.reload()
             self.dg.create_branch(
                 dist_git_branch,
                 base=f"remotes/origin/{dist_git_branch}",
                 setup_tracking=True,
             )
-
             # fetch and reset --hard upstream/$branch?
             logger.info(f"Using {dist_git_branch!r} dist-git branch.")
             self.dg.update_branch(dist_git_branch)
             self.dg.switch_branch(dist_git_branch)
+
+            # do not add anything between distgit clone/checkout and saving gpg keys!
+            self.up.allowed_gpg_keys = (
+                self.dg.get_allowed_gpg_keys_from_downstream_config()
+            )
 
             if use_downstream_specfile:
                 logger.info(
                     "Using the downstream specfile instead of the upstream one.",
                 )
                 self.up.set_specfile(self.dg.specfile)
+
+            self.up.run_action(
+                actions=ActionName.post_upstream_clone,
+                env=self.sync_release_env,
+            )
+
+            # compare versions here because users can mangle with specfile in
+            # post_upstream_clone action
+            spec_ver = self.up.get_specfile_version()
+            if compare_versions(version, spec_ver) > 0:
+                logger.warning(f"Version {spec_ver!r} in spec file is outdated.")
+
+            self.check_version_distance(version, spec_ver, dist_git_branch)
+
+            self.dg.check_last_commit()
+
+            self.up.run_action(actions=ActionName.pre_sync, env=self.sync_release_env)
+            if not use_downstream_specfile:
+                self.up.specfile.reload()
 
             if create_pr:
                 local_pr_branch = (

--- a/packit/api.py
+++ b/packit/api.py
@@ -34,6 +34,7 @@ from tabulate import tabulate
 
 from packit.actions import ActionName
 from packit.config import Config, PackageConfig, RunCommandType
+from packit.config.aliases import get_branches
 from packit.config.common_package_config import MultiplePackages
 from packit.config.package_config import find_packit_yaml, load_packit_yaml
 from packit.config.package_config_validator import PackageConfigValidator
@@ -739,13 +740,19 @@ The first dist-git commit to be synced is '{short_hash}'.
         proposed,
         target_branch,
     ) -> None:
-        """Check 'distance' between new and old release
+        """Following this guidelines:
+        https://docs.fedoraproject.org/en-US/fesco/Updates_Policy/#philosophy
+        we want to avoid major updates of packages within a **stable** release.
 
         current: str, already released version for package
         proposed: str, release we are preparing for package
         target_branch: str, Fedora branch where release the package
         """
-        if self.package_config.version_update_mask is not None:
+        branches_to_check = get_branches("fedora-branched")
+        if (
+            self.package_config.version_update_mask
+            and target_branch in branches_to_check
+        ):
             masked_current = re.match(self.package_config.version_update_mask, current)
             masked_proposed = re.match(
                 self.package_config.version_update_mask,

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -223,7 +223,7 @@ class CommonPackageConfig:
         upstream_tag_exclude: str = "",
         upload_sources: bool = True,
         pkg_tool: Optional[str] = None,
-        version_update_mask: str = "",
+        version_update_mask: Optional[str] = None,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -148,6 +148,9 @@ class CommonPackageConfig:
         module_hotfixes: if set, copr will generate repo files with module_hotfixes=1
         upload_sources: If Packit should upload sources to lookaside cache. True by default.
         pkg_tool: Tool that is used for interaction with the lookaside cache.
+        version_update_mask: String containing a reg exp. The old version contained in the
+            specfile and the newly released version have both to match this reg exp
+            otherwise Packit shall not sync the release downstream.
     """
 
     def __init__(
@@ -220,6 +223,7 @@ class CommonPackageConfig:
         upstream_tag_exclude: str = "",
         upload_sources: bool = True,
         pkg_tool: Optional[str] = None,
+        version_update_mask: str = "",
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -277,6 +281,7 @@ class CommonPackageConfig:
         self.update_release = update_release
         self.upstream_tag_include = upstream_tag_include
         self.upstream_tag_exclude = upstream_tag_exclude
+        self.version_update_mask = version_update_mask
 
         # from deprecated JobMetadataConfig
         self._targets: dict[str, dict[str, Any]]

--- a/packit/exceptions.py
+++ b/packit/exceptions.py
@@ -119,3 +119,7 @@ class ImageBuilderError(PackitException):
 
     def __init__(self, errors):
         self.errors = errors
+
+
+class ReleaseSkippedPackitException(PackitException):
+    """The release of the new version has been skipped due to a failing check"""

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -396,6 +396,7 @@ class CommonConfigSchema(Schema):
 
     # Packaging tool used for interaction with lookaside cache
     pkg_tool = fields.String(missing=None)
+    version_update_mask = fields.String(missing="")
 
     @staticmethod
     def spec_source_id_serialize(value: CommonPackageConfig):

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -396,7 +396,7 @@ class CommonConfigSchema(Schema):
 
     # Packaging tool used for interaction with lookaside cache
     pkg_tool = fields.String(missing=None)
-    version_update_mask = fields.String(missing="")
+    version_update_mask = fields.String(missing=None)
 
     @staticmethod
     def spec_source_id_serialize(value: CommonPackageConfig):

--- a/tests/integration/test_using_cockpit.py
+++ b/tests/integration/test_using_cockpit.py
@@ -71,6 +71,7 @@ def test_update_on_cockpit_ostree(cockpit_ostree):
         working_dir=dist_git_path,
         git_repo=CALCULATE,
     )
+    flexmock(api.up, get_specfile_version=lambda: "178")
 
     with cwd(upstream_path):
         api.sync_release(
@@ -112,6 +113,7 @@ def test_update_on_cockpit_ostree_pr_exists(cockpit_ostree):
         working_dir=dist_git_path,
         git_repo=CALCULATE,
     )
+    flexmock(api.up, get_specfile_version=lambda: "178")
 
     with cwd(upstream_path):
         assert pr == api.sync_release(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -64,6 +64,7 @@ def package_config_mock():
         patch_generation_patch_id_digits=4,
         is_sub_package=False,
         pkg_tool=None,
+        version_update_mask="",
     )
     mock.should_receive("get_all_files_to_sync").and_return([])
     mock.should_receive("get_package_names_as_env").and_return({})

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -382,12 +382,13 @@ def test_pkg_tool_property(package_config, config, expected_pkg_tool):
 
 
 @pytest.mark.parametrize(
-    "current_version, proposed_version, target_branch, exp",
+    "current_version, proposed_version, target_branch, version_update_mask, exp",
     (
         pytest.param(
             "3.10.0",
             "4.0.0",
             "rawhide",
+            None,
             does_not_raise(),
             id="skip version distance check for rawhide",
         ),
@@ -395,6 +396,7 @@ def test_pkg_tool_property(package_config, config, expected_pkg_tool):
             "3.10.0",
             "4.0.0",
             "f38",
+            r"\d+\.\d+\.",
             pytest.raises(PackitException),
             id="proposed version far too distant for f38",
         ),
@@ -402,19 +404,24 @@ def test_pkg_tool_property(package_config, config, expected_pkg_tool):
             "3.10.0",
             "3.10.1",
             "f38",
+            r"\d+\.\d+\.",
             does_not_raise(),
             id="proposed version ok for f38",
         ),
     ),
 )
-def test_check_version_distance(current_version, proposed_version, target_branch, exp):
+def test_check_version_distance(
+    current_version,
+    proposed_version,
+    target_branch,
+    version_update_mask,
+    exp,
+):
     package_config = flexmock(
-        version_update_mask=r"\d+\.\d+\.",
+        version_update_mask=version_update_mask,
     )
     config = Config()
-    from packit import api
 
-    flexmock(api, get_branches=lambda _: ["f38"])
     with exp:
         PackitAPI(config, package_config).check_version_distance(
             current_version,


### PR DESCRIPTION
On stable branches we should avoid doing major updates releases.

Fixes #2130
Merge before packit/packit-service#2250

RELEASE NOTES BEGIN

Now Packit can check,  using the `update_version_mask`,  that  the proposed version release and the actual package release for the target dist-git branch are compatible.

RELEASE NOTES END
