### PR TITLE
Modify get_specfile_version to not use expanded_version

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 import git
+import rpm
 
 from packit.actions import ActionName
 from packit.base_git import PackitRepositoryBase
@@ -245,7 +246,10 @@ class Upstream(PackitRepositoryBase):
 
     def get_specfile_version(self) -> str:
         """provide version from specfile"""
-        version = self.specfile.expanded_version
+        # we need to get the version from rpm spec header
+        # (as the version tag might not be present directly in the specfile,
+        # but e.g. imported)
+        version = self.specfile.rpm_spec.sourceHeader[rpm.RPMTAG_VERSION]
         logger.info(f"Version in spec file is {version!r}.")
         return version
 

--- a/tests/data/no_version_tag_in_spec/.packit.yaml
+++ b/tests/data/no_version_tag_in_spec/.packit.yaml
@@ -1,0 +1,6 @@
+specfile_path: beer.spec
+synced_files:
+  - beer.spec
+upstream_package_name: beerware
+downstream_package_name: beer
+create_pr: false

--- a/tests/data/no_version_tag_in_spec/beer.spec
+++ b/tests/data/no_version_tag_in_spec/beer.spec
@@ -1,0 +1,2 @@
+%global import() %%include %%(test -e %%{S:%%1} && echo %%{S:%%1} || echo %%{_sourcedir}/%%1)
+%import source

--- a/tests/data/no_version_tag_in_spec/source
+++ b/tests/data/no_version_tag_in_spec/source
@@ -1,0 +1,14 @@
+Name:           beer
+Version:        2.1.1
+Release:        1%{?dist}
+Summary:        A tool to make you happy
+
+License:        Beerware
+Source0:        %{upstream_name}-%{version}.tar.gz
+BuildArch:      noarch
+
+%description
+...but not too happy.
+
+%prep
+%autosetup -n %{upstream_name}-%{version}

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -165,8 +165,7 @@ def test_basic_local_update_with_multiple_sources(
             ["git", "commit", "-m", "Added new source to specfile"],
             cwd=git_path,
         )
-    api.up.specfile.reload()
-    api.dg.specfile.reload()
+    subprocess.check_call(["git", "tag", "0.1.0", "-f"], cwd=u)
 
     dist_git_first_source = d / TARBALL_NAME
     dist_git_second_source = d / "the_source.tar.gz"
@@ -215,7 +214,7 @@ def test_basic_local_update_with_adding_second_source(
         ["git", "commit", "-m", "Added new source to specfile"],
         cwd=u,
     )
-    api.up.specfile.reload()
+    subprocess.check_call(["git", "tag", "0.1.0", "-f"], cwd=u)
 
     dist_git_first_source = d / TARBALL_NAME
     dist_git_second_source = d / "the_source.tar.gz"

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -26,6 +26,7 @@ from packit.utils.commands import cwd
 from packit.utils.repo import create_new_repo
 from tests.spellbook import (
     EMPTY_CHANGELOG,
+    NO_VERSION_TAG_IN_SPECFILE,
     UPSTREAM_MACRO_IN_SOURCE,
     build_srpm,
     get_test_config,
@@ -101,6 +102,28 @@ def test_get_version_macro(upstream_instance):
         f.write(data)
 
     assert ups.get_specfile_version() == "1"
+
+
+def test_get_version_no_version_tag(tmp_path):
+    u_remote_path = tmp_path / "upstream_remote"
+    u_remote_path.mkdir(parents=True, exist_ok=True)
+
+    create_new_repo(u_remote_path, ["--bare"])
+
+    u = tmp_path / "upstream_git"
+    shutil.copytree(NO_VERSION_TAG_IN_SPECFILE, u)
+    initiate_git_repo(u, tag="0.1.0")
+
+    with cwd(tmp_path):
+        c = get_test_config()
+
+        pc = get_local_package_config(str(u))
+        pc.upstream_project_url = str(u)
+        lp = LocalProjectBuilder().build(working_dir=u)
+
+        ups = Upstream(c, pc, lp)
+
+    assert ups.get_specfile_version() == "2.1.1"
 
 
 def test_set_spec_ver(upstream_instance):

--- a/tests/spellbook.py
+++ b/tests/spellbook.py
@@ -41,6 +41,7 @@ SPECFILE = DATA_DIR / "upstream_git/beer.spec"
 UPSTREAM_SPEC_NOT_IN_ROOT = DATA_DIR / "spec_not_in_root/upstream"
 SYNC_FILES = DATA_DIR / "sync_files"
 CRONIE = DATA_DIR / "cronie"
+NO_VERSION_TAG_IN_SPECFILE = DATA_DIR / "no_version_tag_in_spec"
 
 
 def git_set_user_email(directory):


### PR DESCRIPTION
This way, if the specfile doesn't contain the version tag directly (but e.g. uses imports), get_specfile_version returned None. Fixes #2137


RELEASE NOTES BEGIN

Packit is now able to get the version from specfile even if the `Version` tag is not present in the specfile directly, but e.g. imported from another file.

RELEASE NOTES END
