### PR TITLE
Fix pypi_publish action

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -4,7 +4,6 @@
 name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
-  workflow_dispatch:
   release:
     types: [released]
 
@@ -16,8 +15,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-tags: true
       - uses: actions/setup-python@v4
 
       - name: Get history and tags for SCM versioning to work

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -20,6 +20,11 @@ jobs:
           fetch-tags: true
       - uses: actions/setup-python@v4
 
+      - name: Get history and tags for SCM versioning to work
+        run: |
+          git fetch --prune --unshallow
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+
       - name: Build a source tarball and a binary wheel
         # https://pypa-build.readthedocs.io
         run: |


### PR DESCRIPTION
With version [0.86.0](https://github.com/packit/packit/actions/runs/6901837024) the **pypi_bublish** action is failing.
The failing command is `python -m build` which is retrieving a *wrong version*.
If you clone the repo and you run `python -m build` you get the correct version. 
But if you run `python -m build` in this container, which is doing more or less what the github **checkout** action does, you get the wrong version.

```FROM ubuntu:latest

RUN apt-get update && apt-get install -y --no-install-recommends \
git \
python3 \
python3.10-venv \
python3-pip
RUN git config --global --add safe.directory /packit
RUN git config --global init.defaultBranch main
RUN git init /packit
WORKDIR /packit
RUN git remote add origin https://github.com/packit/packit
RUN git config --local gc.auto 0
RUN git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
RUN git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
#RUN git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
RUN git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin 44f90cd5f3fb6dae923679bd8d7ca202f57a4fad
RUN git checkout --progress --force 44f90cd5f3fb6dae923679bd8d7ca202f57a4fad
RUN git fetch --prune --unshallow
RUN git fetch --depth=1 origin +refs/tags/*:refs/tags/*
``` 

A [thread](https://github.com/pypa/setuptools_scm/issues/414) about the problem.
And thanks to @webknjaz [solution](https://github.com/ansible/pylibssh/blob/1e7b17f/.github/workflows/build-test-n-publish.yml#L146-L151) adding this two lines of code to the container makes **scm** work again.