### PR TITLE
Set specfile content when there is no dist-git specfile

### DIFF
--- a/packit/utils/changelog_helper.py
+++ b/packit/utils/changelog_helper.py
@@ -150,6 +150,12 @@ class ChangelogHelper:
                 self.up.absolute_specfile_path,
                 self.dg.get_absolute_specfile_path(),
             )
+            # set the specfile content now that the downstream spec file is present
+            self.dg.set_specfile_content(
+                self.up.specfile,
+                full_version,
+                comment=None if self.dg.specfile.has_autochangelog else comment,
+            )
 
     def _get_release_for_source_git(
         self,


### PR DESCRIPTION
When there is no specfile in dist-git during release syncing (e.g. first release), Packit copies the upstream one. This commit also additionally sets its content (version, changelog entry) after the upstream specfile is copied.

RELEASE NOTES BEGIN

Packit now correctly sets the specfile content (e.g. changelog entry) even if it syncs the specfile from upstream the first time.

RELEASE NOTES END
