### PR TITLE
Force switch the dist-git branch when syncing release

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -936,7 +936,7 @@ The first dist-git commit to be synced is '{short_hash}'.
             # fetch and reset --hard upstream/$branch?
             logger.info(f"Using {dist_git_branch!r} dist-git branch.")
             self.dg.update_branch(dist_git_branch)
-            self.dg.switch_branch(dist_git_branch)
+            self.dg.switch_branch(dist_git_branch, force=True)
 
             # do not add anything between distgit clone/checkout and saving gpg keys!
             self.up.allowed_gpg_keys = (

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -153,17 +153,26 @@ class PackitRepositoryBase:
             setup_tracking=setup_tracking,
         )
 
-    def switch_branch(self, branch: Optional[str] = None) -> None:
+    def switch_branch(
+        self,
+        branch: Optional[str] = None,
+        force: Optional[bool] = False,
+    ) -> None:
         """
         Switch to a specified branch.
 
         Args:
             branch: branch to switch to, defaults to repo's default branch
+            force: whether to use force switch
         """
         branch = branch or self.local_project.git_project.default_branch
-        logger.debug(f"Switching to branch {branch!r}")
+        logger.debug(f"Switching {'(force)' if force else ''} to branch {branch!r}")
+        switch_args = [branch]
+        if force:
+            switch_args.append("-f")
+
         try:
-            self.local_project.git_repo.git.switch(branch)
+            self.local_project.git_repo.git.switch(*switch_args)
         except GitCommandError as exc:
             raise PackitException(f"Failed to switch branch to {branch!r}") from exc
 


### PR DESCRIPTION
Previously we hit the issue of untracked files preventing switch to another branch. I was not able (yet) to find how/why are these files added, as we do git reset and clean always in the end of syncing. This should workaround the issue for now.

Fixes packit/packit-service#2234

RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
