### PR TITLE
Implement linking of info in sync release PRs

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -43,6 +43,7 @@ from packit.constants import (
     DISTRO_DIR,
     FROM_DIST_GIT_TOKEN,
     FROM_SOURCE_GIT_TOKEN,
+    RELEASE_MONITORING_PROJECT_URL,
     REPO_NOT_PRISTINE_HINT,
     SYNC_RELEASE_DEFAULT_COMMIT_DESCRIPTION,
     SYNC_RELEASE_PR_DESCRIPTION,
@@ -797,6 +798,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         use_downstream_specfile: bool = False,
         add_pr_instructions: bool = False,
         resolved_bugs: Optional[list[str]] = None,
+        release_monitoring_project_id: Optional[int] = None,
     ) -> PullRequest:
         """Overload for type-checking; return PullRequest if create_pr=True."""
 
@@ -821,6 +823,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         use_downstream_specfile: bool = False,
         add_pr_instructions: bool = False,
         resolved_bugs: Optional[list[str]] = None,
+        release_monitoring_project_id: Optional[int] = None,
     ) -> None:
         """Overload for type-checking; return None if create_pr=False."""
 
@@ -844,6 +847,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         use_downstream_specfile: bool = False,
         add_pr_instructions: bool = False,
         resolved_bugs: Optional[list[str]] = None,
+        release_monitoring_project_id: Optional[int] = None,
     ) -> Optional[PullRequest]:
         """
         Update given package in dist-git
@@ -1041,6 +1045,7 @@ The first dist-git commit to be synced is '{short_hash}'.
                 pr_description = self.get_pr_description(
                     upstream_tag=upstream_tag,
                     version=version,
+                    release_monitoring_project_id=release_monitoring_project_id,
                 )
                 pr = self.push_and_create_pr(
                     pr_title=pr_title,
@@ -1099,7 +1104,12 @@ The first dist-git commit to be synced is '{short_hash}'.
         )
         return release.url if release else ""
 
-    def get_pr_description(self, upstream_tag: str, version: str) -> str:
+    def get_pr_description(
+        self,
+        upstream_tag: str,
+        version: str,
+        release_monitoring_project_id: Optional[int] = None,
+    ) -> str:
         """
         Get the description used in pull requests for syncing release.
         """
@@ -1116,11 +1126,21 @@ The first dist-git commit to be synced is '{short_hash}'.
         commit_info = f"[{commit}]({commit_link})" if commit_link else commit
         tag_info = f"[{upstream_tag}]({tag_link})" if tag_link else upstream_tag
         release_info = f" ([release details]({release_link}))" if release_link else ""
+        release_monitoring_info = (
+            (
+                f"Release monitoring project: "
+                f"[{release_monitoring_project_id}]"
+                f"({RELEASE_MONITORING_PROJECT_URL.format(project_id=release_monitoring_project_id)}"
+            )
+            if release_monitoring_project_id
+            else ""
+        )
 
         return SYNC_RELEASE_PR_DESCRIPTION.format(
             upstream_tag_info=tag_info,
             upstream_commit_info=commit_info,
-            release_info=release_info,
+            upstream_release_info=release_info,
+            release_monitoring_info=release_monitoring_info,
         )
 
     def get_pr_default_title_and_description(self):

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -197,6 +197,12 @@ SYNC_RELEASE_DEFAULT_COMMIT_DESCRIPTION = (
     "{resolved_bugs}Upstream tag: {upstream_tag}\n"
     "Upstream commit: {upstream_commit}\n"
 )
+
+SYNC_RELEASE_PR_DESCRIPTION = (
+    "Upstream tag: {upstream_tag_info}{release_info}\n"
+    "Upstream commit: {upstream_commit_info}\n"
+)
+
 SYNC_RELEASE_PR_INSTRUCTIONS = (
     "\n---\n\n"
     "If you need to do any change in this pull request, you can clone Packit's fork "

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -199,8 +199,9 @@ SYNC_RELEASE_DEFAULT_COMMIT_DESCRIPTION = (
 )
 
 SYNC_RELEASE_PR_DESCRIPTION = (
-    "Upstream tag: {upstream_tag_info}{release_info}\n"
+    "Upstream tag: {upstream_tag_info}{upstream_release_info}\n"
     "Upstream commit: {upstream_commit_info}\n"
+    "{release_monitoring_info}"
 )
 
 SYNC_RELEASE_PR_INSTRUCTIONS = (
@@ -240,3 +241,4 @@ SYNC_RELEASE_PR_INSTRUCTIONS = (
 )
 
 COMMIT_ACTION_DIVIDER = "---%<--- snip ---%<--- here ---%<---\n"
+RELEASE_MONITORING_PROJECT_URL = "https://release-monitoring.org/project/{project_id}"

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -202,6 +202,7 @@ SYNC_RELEASE_PR_DESCRIPTION = (
     "Upstream tag: {upstream_tag_info}{upstream_release_info}\n"
     "Upstream commit: {upstream_commit_info}\n"
     "{release_monitoring_info}"
+    "{resolved_bugzillas_info}"
 )
 
 SYNC_RELEASE_PR_INSTRUCTIONS = (
@@ -242,3 +243,4 @@ SYNC_RELEASE_PR_INSTRUCTIONS = (
 
 COMMIT_ACTION_DIVIDER = "---%<--- snip ---%<--- here ---%<---\n"
 RELEASE_MONITORING_PROJECT_URL = "https://release-monitoring.org/project/{project_id}"
+BUGZILLA_URL = "https://bugzilla.redhat.com/show_bug.cgi?id={bug_id}"

--- a/packit/utils/repo.py
+++ b/packit/utils/repo.py
@@ -548,3 +548,49 @@ def get_commit_message_from_action(
     # it is later reconstructed in a generic way for both defaults and override,
     # so we don't care about the whitespace at the beginning and the end
     return title.strip(), description.strip()
+
+
+def get_tag_link(git_url: str, upstream_tag: str) -> str:
+    """
+    Get link to the tag of a Git repo.
+    """
+    link = ""
+    git_repo = parse_git_repo(git_url)
+    if not git_repo:
+        return ""
+
+    forge = git_repo.hostname
+    if not forge:
+        return ""
+
+    if forge == "github.com":
+        link = f"{git_url}/releases/tag/{upstream_tag}"
+    # GitLab or GitLab instances (e.g. gitlab.gnome.org)
+    elif "gitlab" in forge:
+        link = f"{git_url}/-/tags/{upstream_tag}"
+
+    return link
+
+
+def get_commit_link(git_url: str, upstream_commit: str) -> str:
+    """
+    Get link to the commit of a Git repo.
+    """
+    link = ""
+    git_repo = parse_git_repo(git_url)
+    if not git_repo:
+        return ""
+
+    forge = git_repo.hostname
+    if not forge:
+        return ""
+
+    if forge == "github.com":
+        link = f"{git_url}/commit/{upstream_commit}"
+    # GitLab or GitLab instances (e.g. gitlab.gnome.org)
+    elif "gitlab" in forge:
+        link = f"{git_url}/-/commit/{upstream_commit}"
+    elif forge == "pagure.io":
+        link = f"{git_url}/c/{upstream_commit}"
+
+    return link

--- a/packit/utils/repo.py
+++ b/packit/utils/repo.py
@@ -160,7 +160,10 @@ def get_default_branch(repository: git.Repo) -> str:
     return config.get_value("init", "defaultBranch", "master")
 
 
-def git_remote_url_to_https_url(inp: str) -> str:
+def git_remote_url_to_https_url(
+    inp: str,
+    with_dot_git_suffix: Optional[bool] = True,
+) -> str:
     """
     turn provided git remote URL to https URL:
     returns empty string if the input can't be processed
@@ -173,9 +176,12 @@ def git_remote_url_to_https_url(inp: str) -> str:
 
     if inp.startswith(("http", "https")):
         logger.debug(f"Provided input {inp!r} is an url.")
+        if inp.endswith(".git"):
+            return inp if with_dot_git_suffix else inp[:-4]
+
         return inp
 
-    optional_suffix = ".git" if inp.endswith(".git") else ""
+    optional_suffix = ".git" if inp.endswith(".git") and with_dot_git_suffix else ""
     url_str = "https://{}/{}/{}{}".format(
         parsed_repo.hostname,
         parsed_repo.namespace,

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -355,7 +355,7 @@ def test_basic_local_update_copy_upstream_release_description(
     u, d, api = api_instance
     mock_spec_download_remote_s(d)
     flexmock(api).should_receive("init_kerberos_ticket").at_least().once()
-    release = flexmock(body="Some description of the upstream release")
+    release = flexmock(body="Some description of the upstream release", url="some-url")
     api.up.local_project.git_project = flexmock(
         get_release=lambda name, tag_name: release,
     )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -88,7 +88,12 @@ def config_mock():
 
 @pytest.fixture
 def git_project_mock():
-    return flexmock(upstream_project_url="dummy_url")
+    return (
+        flexmock(upstream_project_url="dummy_url")
+        .should_receive("get_release")
+        .and_return(flexmock(url="url"))
+        .mock()
+    )
 
 
 @pytest.fixture
@@ -116,6 +121,7 @@ def local_project_mock(git_project_mock, git_repo_mock):
         checkout_release=lambda *_: None,
         commit_hexsha="_",
         repo_name="package",
+        git_url="some-url",
     )
 
 
@@ -124,7 +130,10 @@ def upstream_mock(local_project_mock, package_config_mock):
     upstream = Upstream(
         config=get_test_config(),
         package_config=package_config_mock,
-        local_project=LocalProjectBuilder().build(working_dir="test"),
+        local_project=LocalProjectBuilder().build(
+            working_dir="test",
+            git_url="my-git-url",
+        ),
     )
     flexmock(upstream)
     upstream.should_receive("local_project").and_return(local_project_mock)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -360,30 +360,34 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
 
 
 @pytest.mark.parametrize(
-    "tag_link, commit_link, release_link, result",
+    "tag_link, commit_link, release_link, project_id, result",
     [
         pytest.param(
             "",
             "",
             "",
+            None,
             "Upstream tag: 1.0.0\nUpstream commit: _\n",
         ),
         pytest.param(
             "tag-link",
             "",
             "",
+            None,
             "Upstream tag: [1.0.0](tag-link)\nUpstream commit: _\n",
         ),
         pytest.param(
             "tag-link",
             "commit-link",
             "",
+            None,
             "Upstream tag: [1.0.0](tag-link)\nUpstream commit: [_](commit-link)\n",
         ),
         pytest.param(
             "tag-link",
             "",
             "release-link",
+            None,
             "Upstream tag: [1.0.0](tag-link) ([release details](release-link))\n"
             "Upstream commit: _\n",
         ),
@@ -391,16 +395,40 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
             "tag-link",
             "commit-link",
             "release-link",
+            None,
             "Upstream tag: [1.0.0](tag-link) ([release details](release-link))\n"
             "Upstream commit: [_](commit-link)\n",
         ),
+        pytest.param(
+            "tag-link",
+            "commit-link",
+            "release-link",
+            12345,
+            "Upstream tag: [1.0.0](tag-link) ([release details](release-link))\n"
+            "Upstream commit: [_](commit-link)\n"
+            "Release monitoring project: [12345](https://release-monitoring.org/project/12345",
+        ),
     ],
 )
-def test_get_pr_description(api_mock, tag_link, commit_link, release_link, result):
+def test_get_pr_description(
+    api_mock,
+    tag_link,
+    commit_link,
+    release_link,
+    project_id,
+    result,
+):
     flexmock(api).should_receive("get_tag_link").and_return(tag_link)
     flexmock(api).should_receive("get_commit_link").and_return(commit_link)
     flexmock(api_mock).should_receive("get_release_link").and_return(release_link)
-    assert api_mock.get_pr_description("1.0.0", version="1.0.0") == result
+    assert (
+        api_mock.get_pr_description(
+            "1.0.0",
+            version="1.0.0",
+            release_monitoring_project_id=project_id,
+        )
+        == result
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -360,12 +360,13 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
 
 
 @pytest.mark.parametrize(
-    "tag_link, commit_link, release_link, project_id, result",
+    "tag_link, commit_link, release_link, project_id, resolved_bugs, result",
     [
         pytest.param(
             "",
             "",
             "",
+            None,
             None,
             "Upstream tag: 1.0.0\nUpstream commit: _\n",
         ),
@@ -374,6 +375,7 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
             "",
             "",
             None,
+            None,
             "Upstream tag: [1.0.0](tag-link)\nUpstream commit: _\n",
         ),
         pytest.param(
@@ -381,12 +383,14 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
             "commit-link",
             "",
             None,
+            None,
             "Upstream tag: [1.0.0](tag-link)\nUpstream commit: [_](commit-link)\n",
         ),
         pytest.param(
             "tag-link",
             "",
             "release-link",
+            None,
             None,
             "Upstream tag: [1.0.0](tag-link) ([release details](release-link))\n"
             "Upstream commit: _\n",
@@ -396,6 +400,7 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
             "commit-link",
             "release-link",
             None,
+            None,
             "Upstream tag: [1.0.0](tag-link) ([release details](release-link))\n"
             "Upstream commit: [_](commit-link)\n",
         ),
@@ -404,9 +409,32 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
             "commit-link",
             "release-link",
             12345,
+            None,
             "Upstream tag: [1.0.0](tag-link) ([release details](release-link))\n"
             "Upstream commit: [_](commit-link)\n"
-            "Release monitoring project: [12345](https://release-monitoring.org/project/12345",
+            "Release monitoring project: [12345](https://release-monitoring.org/project/12345)\n",
+        ),
+        pytest.param(
+            "tag-link",
+            "commit-link",
+            "release-link",
+            12345,
+            ["rhbz#1234"],
+            "Upstream tag: [1.0.0](tag-link) ([release details](release-link))\n"
+            "Upstream commit: [_](commit-link)\n"
+            "Release monitoring project: [12345](https://release-monitoring.org/project/12345)\n"
+            "Resolves [rhbz#1234](https://bugzilla.redhat.com/show_bug.cgi?id=1234)\n",
+        ),
+        pytest.param(
+            "tag-link",
+            "commit-link",
+            "release-link",
+            12345,
+            ["rhbz#not-a-number"],
+            "Upstream tag: [1.0.0](tag-link) ([release details](release-link))\n"
+            "Upstream commit: [_](commit-link)\n"
+            "Release monitoring project: [12345](https://release-monitoring.org/project/12345)\n"
+            "Resolves rhbz#not-a-number\n",
         ),
     ],
 )
@@ -416,6 +444,7 @@ def test_get_pr_description(
     commit_link,
     release_link,
     project_id,
+    resolved_bugs,
     result,
 ):
     flexmock(api).should_receive("get_tag_link").and_return(tag_link)
@@ -426,6 +455,7 @@ def test_get_pr_description(
             "1.0.0",
             version="1.0.0",
             release_monitoring_project_id=project_id,
+            resolved_bugs=resolved_bugs,
         )
         == result
     )

--- a/tests_recording/test_api.py
+++ b/tests_recording/test_api.py
@@ -3,6 +3,8 @@
 
 from subprocess import check_output
 
+from flexmock import flexmock
+from ogr.services.github.project import GithubProject
 from requre.cassette import DataTypes
 from requre.helpers.files import StoreFiles
 from requre.helpers.simple_object import Simple
@@ -121,6 +123,10 @@ class ProposeUpdate(PackitTest):
         )
         changed_upstream_spec_content = self.api.up.absolute_specfile_path.read_text()
         assert original_upstream_spec_content != changed_upstream_spec_content
+        # mock the release as there is no real release 0
+        flexmock(GithubProject).should_receive("get_release").and_return(
+            flexmock(url="url"),
+        )
         self.api.package_config.sync_changelog = True
         self.api.sync_release(version="0", use_local_content=True)
         new_downstream_spec_content = self.api.dg.absolute_specfile_path.read_text()


### PR DESCRIPTION
Link the upstream tag and commit (do
not use GitProject from ogr API here as in pull from upstream this might not be initialised).
If GitProject is initialised, also include link to the release.

Fixes #2152

The issue proposed linking the new version in Anitya backend (e.g. PyPI), but I was not able to find an easy way how to obtain this (it was not possible to get this e.g. using anityia API). But I am open to suggestions.


RELEASE NOTES BEGIN

Packit now links the information related to upstream in PRs opened when syncing a release.

RELEASE NOTES END
