### PR TITLE
Introduce test command config options

### DIFF
--- a/packit/config/commands.py
+++ b/packit/config/commands.py
@@ -1,0 +1,15 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+from typing import Optional
+
+
+class TestCommandConfig:
+    """Configuration of test command."""
+
+    def __init__(
+        self,
+        default_labels: Optional[list[str]] = None,
+        default_identifier: Optional[str] = None,
+    ):
+        self.default_labels = default_labels
+        self.default_identifier = default_identifier

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -13,6 +13,7 @@ from re import split
 from typing import Any, Optional, Union
 
 from packit.actions import ActionName
+from packit.config.commands import TestCommandConfig
 from packit.config.notifications import (
     NotificationsConfig,
 )
@@ -226,6 +227,7 @@ class CommonPackageConfig:
         upload_sources: bool = True,
         pkg_tool: Optional[str] = None,
         version_update_mask: Optional[str] = None,
+        test_command: Optional[TestCommandConfig] = None,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -286,6 +288,7 @@ class CommonPackageConfig:
         self.version_update_mask = version_update_mask
         self.prerelease_suffix_pattern = prerelease_suffix_pattern
         self.prerelease_suffix_macro = prerelease_suffix_macro
+        self.test_command = test_command or TestCommandConfig()
 
         # from deprecated JobMetadataConfig
         self._targets: dict[str, dict[str, Any]]

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -26,6 +26,7 @@ from packit.config import (
     PackageConfig,
 )
 from packit.config.aliases import DEPRECATED_TARGET_MAP
+from packit.config.commands import TestCommandConfig
 from packit.config.job_config import (
     JobConfig,
     JobConfigTriggerType,
@@ -193,6 +194,17 @@ class NotificationsSchema(Schema):
     @post_load
     def make_instance(self, data, **kwargs):
         return NotificationsConfig(**data)
+
+
+class TestCommandSchema(Schema):
+    """Configuration of test command."""
+
+    default_labels = fields.List(fields.String, missing=None)
+    default_identifier = fields.String(missing=None)
+
+    @post_load
+    def make_instance(self, data, **kwargs):
+        return TestCommandConfig(**data)
 
 
 class TargetsListOrDict(fields.Field):
@@ -363,6 +375,7 @@ class CommonConfigSchema(Schema):
     prerelease_suffix_pattern = fields.String()
     prerelease_suffix_macro = fields.String(missing=None)
     upload_sources = fields.Bool(default=True)
+    test_command = fields.Nested(TestCommandSchema)
 
     # Former 'metadata' keys
     _targets = TargetsListOrDict(missing=None, data_key="targets")

--- a/tests/unit/config/test_package_config.py
+++ b/tests/unit/config/test_package_config.py
@@ -1728,6 +1728,32 @@ def test_notifications_section_failure_comment_message():
     assert pc.notifications.failure_comment.message == message
 
 
+def test_test_command_labels():
+    labels = ["label1", "label2"]
+    pc = PackageConfig.get_from_dict(
+        {
+            "specfile_path": "package.spec",
+            "test_command": {"default_labels": labels},
+        },
+        repo_name="package",
+    )
+    assert pc.test_command.default_labels == labels
+    assert not pc.test_command.default_identifier
+
+
+def test_test_command_identifiers():
+    identifier = "id1"
+    pc = PackageConfig.get_from_dict(
+        {
+            "specfile_path": "package.spec",
+            "test_command": {"default_identifier": identifier},
+        },
+        repo_name="package",
+    )
+    assert not pc.test_command.default_labels
+    assert pc.test_command.default_identifier == identifier
+
+
 def test_get_local_specfile_path():
     assert str(get_local_specfile_path(UP_OSBUILD)) == "osbuild.spec"
     assert not get_local_specfile_path(SYNC_FILES)


### PR DESCRIPTION
Introduce the default_labels and default_identifier nested config options in test_command, that will be used if /packit test service comment command is called without any arguments.

Needed for #2056

TODO:
- [x] followup service PR
- [ ] docs

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
