### PR TITLE
Fallback to default changelog message if changelog is None

### DIFF
--- a/packit/utils/changelog_helper.py
+++ b/packit/utils/changelog_helper.py
@@ -115,18 +115,22 @@ class ChangelogHelper:
             version=full_version,
             resolved_bugs=resolved_bugs,
         )
-        comment = action_output or (
-            self.up.local_project.git_project.get_release(
-                tag_name=upstream_tag,
-                name=full_version,
-            ).body
-            if self.package_config.copy_upstream_release_description
-            # in pull_from_upstream workflow, upstream git_project can be None
-            and self.up.local_project.git_project
-            else self.up.get_commit_messages(
-                after=self.up.get_last_tag(before=upstream_tag),
-                before=upstream_tag,
+        comment = (
+            action_output
+            or (
+                self.up.local_project.git_project.get_release(
+                    tag_name=upstream_tag,
+                    name=full_version,
+                ).body
+                if self.package_config.copy_upstream_release_description
+                # in pull_from_upstream workflow, upstream git_project can be None
+                and self.up.local_project.git_project
+                else self.up.get_commit_messages(
+                    after=self.up.get_last_tag(before=upstream_tag),
+                    before=upstream_tag,
+                )
             )
+            or f"- Update to upstream release {full_version}"
         )
         if not action_output and resolved_bugs:
             comment += "\n"

--- a/tests/integration/test_changelog_helper.py
+++ b/tests/integration/test_changelog_helper.py
@@ -156,6 +156,30 @@ def test_update_distgit_unsafe_commit_messages(upstream, distgit_instance):
     assert len(downstream.specfile.rpm_spec.sourceHeader[rpm.RPMTAG_CHANGELOGTEXT]) == 2
 
 
+def test_update_distgit_when_copy_upstream_release_description_none(
+    upstream,
+    distgit_instance,
+):
+    _, downstream = distgit_instance
+    package_config = upstream.package_config
+    package_config.copy_upstream_release_description = True
+    upstream.local_project.git_project = (
+        flexmock()
+        .should_receive("get_release")
+        .with_args(tag_name="0.1.0", name="0.1.0")
+        .and_return(flexmock(body=None))
+        .mock()
+    )
+
+    ChangelogHelper(upstream, downstream, package_config).update_dist_git(
+        upstream_tag="0.1.0",
+        full_version="0.1.0",
+    )
+
+    with downstream._specfile.sections() as sections:
+        assert "- Update to upstream release 0.1.0" in sections.changelog
+
+
 def test_update_distgit_changelog_entry_action_pass_env_vars(
     upstream,
     distgit_instance,


### PR DESCRIPTION
In case the changelog is None, e.g. release has no description, fallback to the default message.

Fixes packit/packit-service#2281

RELEASE NOTES BEGIN

We have fixed a bug preventing the release from being synced downstream if the changelog to be set is empty.

RELEASE NOTES END
