### PR TITLE
Consider all tags when looking for the previous release

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -365,7 +365,7 @@ class Upstream(PackitRepositoryBase):
             f"the upstream repository {self.local_project.working_dir}.",
         )
 
-        tags = self.list_tags(before if before is not None else self._merged_ref)
+        tags = self.list_tags(self._merged_ref)
 
         if not tags:
             logger.info("No tags found in the repository.")


### PR DESCRIPTION
Using the current release tag as a reference when listing available tags ensures that if a project uses release branches, only the correct tags will be listed. However, there are projects where release tags are standalone, not connected to any existing branch, and using a reference in such case leads to incorrect results at best. I think that avoiding using a reference is a better alternative, because projects with release branches can still use tag filtering to make things work correctly.

Fixes https://github.com/packit/packit/issues/2207.