### PR TITLE
Don't sync ACLs by default during release syncing

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -801,6 +801,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         resolved_bugs: Optional[list[str]] = None,
         release_monitoring_project_id: Optional[int] = None,
         pr_description_footer: Optional[str] = None,
+        sync_acls: Optional[bool] = False,
     ) -> PullRequest:
         """Overload for type-checking; return PullRequest if create_pr=True."""
 
@@ -827,6 +828,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         resolved_bugs: Optional[list[str]] = None,
         release_monitoring_project_id: Optional[int] = None,
         pr_description_footer: Optional[str] = None,
+        sync_acls: Optional[bool] = False,
     ) -> None:
         """Overload for type-checking; return None if create_pr=False."""
 
@@ -852,6 +854,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         resolved_bugs: Optional[list[str]] = None,
         release_monitoring_project_id: Optional[int] = None,
         pr_description_footer: Optional[str] = None,
+        sync_acls: Optional[bool] = False,
     ) -> Optional[PullRequest]:
         """
         Update given package in dist-git
@@ -886,6 +889,8 @@ The first dist-git commit to be synced is '{short_hash}'.
             release_monitoring_project_id: ID of the project in release monitoring if the syncing
                 happens as reaction to that.
             pr_description_footer: Footer for the PR description (used by packit-service)
+            sync_acls: Whether to sync the ACLs of original repo and
+                fork when creating a PR from fork.
 
         Returns:
             The created (or existing if one already exists) PullRequest if
@@ -1062,6 +1067,7 @@ The first dist-git commit to be synced is '{short_hash}'.
                     pr_description=f"{pr_description}{pr_instructions}{footer}",
                     git_branch=dist_git_branch,
                     repo=self.dg,
+                    sync_acls=sync_acls,
                 )
             else:
                 self.dg.push(refspec=f"HEAD:{dist_git_branch}")
@@ -1381,10 +1387,11 @@ The first dist-git commit to be synced is '{short_hash}'.
         pr_description: str,
         git_branch: str,
         repo: Union[Upstream, DistGit],
+        sync_acls: bool = False,
     ) -> PullRequest:
         # the branch may already be up, let's push forcefully
         try:
-            repo.push_to_fork(repo.local_project.ref, force=True)
+            repo.push_to_fork(repo.local_project.ref, force=True, sync_acls=sync_acls)
         except PackitException as exc:
             logger.error(f"Push to fork failed: {exc}")
             raise

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -55,6 +55,7 @@ def sync_release(
     use_downstream_specfile,
     package_config,
     resolved_bugs,
+    sync_acls,
 ):
     api = get_packit_api(
         config=config,
@@ -82,6 +83,7 @@ def sync_release(
             force=force,
             use_downstream_specfile=use_downstream_specfile,
             resolved_bugs=resolved_bugs,
+            sync_acls=sync_acls,
         )
 
 
@@ -124,6 +126,12 @@ def sync_release_common_options(func):
         required=False,
         default=None,
         multiple=True,
+    )
+    @click.option(
+        "--sync-acls",
+        default=False,
+        is_flag=True,
+        help="Sync ACLs between dist-git repo and the fork, is considered only with --pr option.",
     )
     @click.option(
         PACKAGE_SHORT_OPTION,
@@ -174,6 +182,7 @@ def propose_downstream(
     local_content,
     upstream_ref,
     force,
+    sync_acls,
     resolve_bug,
     package_config,
 ):
@@ -200,6 +209,7 @@ def propose_downstream(
         use_downstream_specfile=False,
         package_config=package_config,
         resolved_bugs=resolve_bug,
+        sync_acls=sync_acls,
     )
 
 
@@ -217,6 +227,7 @@ def pull_from_upstream(
     path_or_url,
     version,
     force,
+    sync_acls,
     resolve_bug,
     package_config,
 ):
@@ -243,4 +254,5 @@ def pull_from_upstream(
         use_downstream_specfile=True,
         package_config=package_config,
         resolved_bugs=resolve_bug,
+        sync_acls=sync_acls,
     )

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -113,16 +113,22 @@ class Upstream(PackitRepositoryBase):
         force: bool = False,
         fork: bool = True,
         remote_name: Optional[str] = None,
+        sync_acls: Optional[bool] = False,
     ) -> tuple[str, Optional[str]]:
         """
         push current branch to fork if fork=True, else to origin
 
-        :param branch_name: the branch where we push
-        :param force: push forcefully?
-        :param fork: push to fork?
-        :param remote_name: name of remote where we should push
+        Args:
+            branch_name: the branch where we push
+            force: push forcefully?
+            fork: push to fork?
+            remote_name: name of remote where we should push
                if None, try to find a ssh_url
-        :return: name of the branch where we pushed
+            sync_acls: whether to sync the ACLs of the original repo and the fork
+
+        Returns:
+            name of the branch where we pushed
+
         """
         logger.debug(
             f"About to {'force ' if force else ''}push changes to branch {branch_name!r}.",
@@ -136,6 +142,11 @@ class Upstream(PackitRepositoryBase):
                 else:
                     # ogr is awesome! if you want to fork your own repo, you'll get it!
                     project = self.local_project.git_project.get_fork(create=True)
+
+                if sync_acls:
+                    # synchronize ACLs between original repo and fork
+                    self.sync_acls(self.local_project.git_project, project)
+
                 fork_username = project.namespace
                 fork_urls = project.get_git_urls()
 

--- a/tests/integration/test_using_cockpit.py
+++ b/tests/integration/test_using_cockpit.py
@@ -59,7 +59,7 @@ def test_update_on_cockpit_ostree(cockpit_ostree):
     flexmock(DistGit).should_receive("existing_pr").and_return(None)
     flexmock(
         PackitAPI,
-        push_and_create_pr=lambda pr_title, pr_description, git_branch, repo: None,
+        push_and_create_pr=lambda pr_title, pr_description, git_branch, repo, sync_acls: None,
     )
 
     pc = get_local_package_config(str(upstream_path))

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -334,6 +334,7 @@ def test_sync_release_check_pr_instructions(api_mock):
         ),
         git_branch=str,
         repo=DistGit,
+        sync_acls=False,
     ).and_return(flexmock())
     api_mock.sync_release(version="1.1", dist_git_branch="_", add_pr_instructions=True)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -61,6 +61,7 @@ def test_propose_downstream_command():
         use_downstream_specfile=False,
         package_config=PackageConfig,
         resolved_bugs=None,
+        sync_acls=False,
     ).and_return()
     result = call_packit(packit_base, parameters=["propose-downstream", "."])
     assert result.exit_code == 0
@@ -84,6 +85,7 @@ def test_pull_from_upstream_command():
         use_downstream_specfile=True,
         package_config=PackageConfig,
         resolved_bugs=None,
+        sync_acls=False,
     ).and_return()
     result = call_packit(packit_base, parameters=["pull-from-upstream", "."])
     assert result.exit_code == 0


### PR DESCRIPTION
This was mainly added for the service, so we will pass this argument from there and in CLI, by default not sync the ACLS. Fixes #2206
TODO: 
- [ ] packit-service PR to pass the `sync_acls=True`

RELEASE NOTES BEGIN

`pull-from-upstream` and `propose-downstream` commands now have the `--sync-acls` option that enables syncing the ACLs between dits-git repo and fork. The default behaviour was, however, changed to not sync the ACLs.

RELEASE NOTES END
