### PR TITLE
Add --merged-ref to prepare-sources

### DIFF
--- a/packit/cli/prepare_sources.py
+++ b/packit/cli/prepare_sources.py
@@ -44,6 +44,11 @@ def load_job_config(job_config):
     "(this option implies the repository is source-git).",
 )
 @click.option(
+    "--merged-ref",
+    default=None,
+    help="Git ref used to identify correct most recent tag.",
+)
+@click.option(
     "--update-release/--no-update-release",
     default=None,
     help=(
@@ -134,6 +139,7 @@ def prepare_sources(
     path_or_url,
     job_config_index,
     upstream_ref,
+    merged_ref,
     update_release,
     bump,
     release_suffix,
@@ -186,6 +192,7 @@ def prepare_sources(
 
     api.prepare_sources(
         upstream_ref=upstream_ref,
+        merged_ref=merged_ref,
         update_release=update_release,
         release_suffix=release_suffix,
         result_dir=result_dir,

--- a/packit/utils/source_script.py
+++ b/packit/utils/source_script.py
@@ -13,6 +13,7 @@ def create_source_script(
     update_release: bool = True,
     release_suffix: Optional[str] = None,
     package: Optional[str] = None,
+    merged_ref: Optional[str] = None,
 ):
     options = []
     if ref:
@@ -27,6 +28,8 @@ def create_source_script(
         options += ["--no-update-release"]
     if release_suffix:
         options += ["--release-suffix", f"'{release_suffix}'"]
+    if merged_ref:
+        options += ["--merged-ref", f"'{merged_ref}'"]
 
     # do not create symlinks in Copr environment
     options += ["--no-create-symlinks"]


### PR DESCRIPTION
Related to https://github.com/packit/packit/issues/2184.

Should I add the option also to other CLI commands, namely `srpm` and probably all subcommands of `build`?