### PR TITLE
Add parse_time_macros option

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -120,6 +120,12 @@ class PackitRepositoryBase:
             self._specfile = Specfile(
                 self.absolute_specfile_path,
                 sourcedir=self.absolute_source_dir,
+                macros=[
+                    # both keys (though unlikely) and values could have been interpreted
+                    # as numbers by the YAML parser, convert them (back) to strings
+                    (str(k), v if v is None else str(v))
+                    for k, v in self.package_config.parse_time_macros.items()
+                ],
                 autosave=True,
             )
         return self._specfile

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -152,6 +152,9 @@ class CommonPackageConfig:
         version_update_mask: String containing a reg exp. The old version contained in the
             specfile and the newly released version have both to match this reg exp
             otherwise Packit shall not sync the release downstream.
+        parse_time_macros: Dict with macros to (un)define before parsing specfile.
+            Keys are macro names and values are macro values. A value of None will undefine
+            the corresponding macro.
     """
 
     def __init__(
@@ -228,6 +231,7 @@ class CommonPackageConfig:
         pkg_tool: Optional[str] = None,
         version_update_mask: Optional[str] = None,
         test_command: Optional[TestCommandConfig] = None,
+        parse_time_macros: Optional[dict[str, str]] = None,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -333,6 +337,8 @@ class CommonPackageConfig:
         self.upload_sources = upload_sources
 
         self.pkg_tool = pkg_tool
+
+        self.parse_time_macros = parse_time_macros or {}
 
     @property
     def dist_git_base_url(self) -> str:

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -413,6 +413,8 @@ class CommonConfigSchema(Schema):
     pkg_tool = fields.String(missing=None)
     version_update_mask = fields.String(missing=None)
 
+    parse_time_macros = fields.Dict(missing=None)
+
     @staticmethod
     def spec_source_id_serialize(value: CommonPackageConfig):
         return value.spec_source_id

--- a/tests/unit/test_base_git.py
+++ b/tests/unit/test_base_git.py
@@ -479,6 +479,7 @@ def test_set_spec_content(tmp_path):
         package_config=flexmock(
             prerelease_suffix_macro=None,
             prerelease_suffix_pattern=None,
+            parse_time_macros={},
         ),
     )
     dist_git._specfile_path = distgit_spec_path
@@ -633,6 +634,7 @@ def test_set_spec_content_reset_release(
         package_config=flexmock(
             prerelease_suffix_macro=None,
             prerelease_suffix_pattern=None,
+            parse_time_macros={},
         ),
     )
     dist_git._specfile_path = distgit_spec_path
@@ -679,6 +681,7 @@ def test_set_spec_content_no_changelog(tmp_path, changelog_section):
         package_config=flexmock(
             prerelease_suffix_macro=None,
             prerelease_suffix_pattern=None,
+            parse_time_macros={},
         ),
     )
     dist_git._specfile_path = distgit_spec_path
@@ -780,6 +783,7 @@ def test_set_spec_content_version_macros(
         package_config=flexmock(
             prerelease_suffix_macro=None,
             prerelease_suffix_pattern=None,
+            parse_time_macros={},
         ),
     )
     dist_git._specfile_path = distgit_spec_path
@@ -1004,6 +1008,7 @@ def test_set_spec_content_prerelease(
         package_config=flexmock(
             prerelease_suffix_macro=prerelease_suffix_macro,
             prerelease_suffix_pattern=prerelease_suffix_pattern,
+            parse_time_macros={},
         ),
     )
     dist_git._specfile_path = distgit_spec_path


### PR DESCRIPTION
Fixes #2203.

RELEASE NOTES BEGIN

There is a new global configuration option `parse_time_macros` that allows to configure macros to be explicitly defined or undefined at spec file parse time.

RELEASE NOTES END
