### PR TITLE
validate-config: Check monitoring for pull-from-upstream

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -2065,7 +2065,7 @@ The first dist-git commit to be synced is '{short_hash}'.
             self.up.local_project.free_resources()
 
     @staticmethod
-    def validate_package_config(working_dir: Path) -> str:
+    def validate_package_config(working_dir: Path, offline: bool = False) -> str:
         """Validate package config.
 
         Args:
@@ -2083,7 +2083,7 @@ The first dist-git commit to be synced is '{short_hash}'.
             try_local_dir_last=True,
         )
         config_content = load_packit_yaml(config_path)
-        v = PackageConfigValidator(config_path, config_content, working_dir)
+        v = PackageConfigValidator(config_path, config_content, working_dir, offline)
         return v.validate()
 
     def init_source_git(

--- a/packit/cli/validate_config.py
+++ b/packit/cli/validate_config.py
@@ -21,17 +21,24 @@ logger = logging.getLogger(__name__)
 
 @click.command("validate-config", context_settings=get_context_settings())
 @click.argument("path_or_url", type=LocalProjectParameter(), default=os.path.curdir)
+@click.option(
+    "--offline",
+    default=False,
+    is_flag=True,
+    help="Do not make remote API calls requiring network access.",
+)
 @cover_packit_exception
-def validate_config(path_or_url: LocalProject):
+def validate_config(path_or_url: LocalProject, offline: bool):
     """
     Validate PackageConfig.
 
     \b
     - checks missing values
     - checks incorrect types
+    - checks whether monitoring is enabled if 'pull_from_upstream` is used
 
     PATH_OR_URL argument is a local path or a URL to a git repository with packit configuration file
     """
-    output = PackitAPI.validate_package_config(path_or_url.working_dir)
+    output = PackitAPI.validate_package_config(path_or_url.working_dir, offline)
     logger.info(output)
     # TODO: print more if config.debug

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -244,6 +244,10 @@ SYNC_RELEASE_PR_INSTRUCTIONS = (
 COMMIT_ACTION_DIVIDER = "---%<--- snip ---%<--- here ---%<---\n"
 RELEASE_MONITORING_PROJECT_URL = "https://release-monitoring.org/project/{project_id}"
 BUGZILLA_URL = "https://bugzilla.redhat.com/show_bug.cgi?id={bug_id}"
+ANITYA_MONITORING_CHECK_URL = (
+    "https://src.fedoraproject.org/_dg/anitya/rpms/{package_name}"
+)
+RELEASE_MONITORING_PACKAGE_CHECK_URL = "https://release-monitoring.org//api/v2/packages/?name={package_name}&distribution=Fedora"
 
 # connection timeout and read timeout in seconds
 # with connection timeout, the actual value will usually be a multiple of what is configured,


### PR DESCRIPTION
Add 2 checks regarding monitoring of the package by Upstream Release Monitoring if pull-from-upstream job is present in the config.

Fixes #2224



RELEASE NOTES BEGIN
`packit validate-config` now checks whether the Upstream Release Monitoring for the package is correctly configured if `pull_from_upstream` job is present in the configuration.

RELEASE NOTES END
