### PR TITLE
Introduce new job trigger: "ignore"

### DIFF
--- a/packit/config/job_config.py
+++ b/packit/config/job_config.py
@@ -48,6 +48,7 @@ class JobConfigTriggerType(Enum):
     release = "release"
     pull_request = "pull_request"
     commit = "commit"
+    ignore = "ignore"
 
 
 class JobConfig(MultiplePackages):

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -584,6 +584,33 @@ def test_serialize_and_deserialize_job_config(config):
             },
             False,
         ),
+        (
+            {
+                "job": "tests",
+                "trigger": "ignore",
+                "labels": ["regression", "long"],
+                "packages": {
+                    "package": {
+                        "specfile_path": "packages.spec",
+                        "enable_net": False,
+                        "branch": "main",
+                    },
+                },
+            },
+            {
+                "job": "tests",
+                "trigger": "ignore",
+                "labels": ["regression", "long"],
+                "packages": {
+                    "package": {
+                        "specfile_path": "packages.spec",
+                        "enable_net": False,
+                        "branch": "main",
+                    },
+                },
+            },
+            False,
+        ),
     ],
 )
 def test_deserialize_and_serialize_job_config(config_in, config_out, validation_error):


### PR DESCRIPTION
In some cases it could be valuable for users to create a job that is ignored by Packit (read: it's not executed). Typical use case is when users want to define a template job that could be used in real test jobs using the yaml format.
E.g.:
```
      jobs:
    - &my-abstract-job
      job: tests
      trigger: ignore
      ... other generic repeating values ...

    - my-real-job
      <<: *my-abstract-job
      trigger: pull_request
      ...test specific values...
```

This is especially useful for projects with many similar jobs defined in the .packit.yaml configuration file. Using templates users can make their .packit.yaml config file much shorter, which reduces also maintainance burden.

The original problem was, that each job requires a defined trigger, so it was not possible to create a template that is not executed at all. For this purposes, it's possible to specify "ignore" trigger, which will not be executed by packit.

This can be used also to disable some jobs temporarily, e.g. when they are wanted in future, however due to an issue/changes (e.g. environment change, infra) they will be failing for a period of time.

Issue: #2231

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
  - Opened PR: https://github.com/packit/packit.dev/pull/833

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

RELEASE NOTES BEGIN

Packit now supports automatic ordering of ☕ after all checks pass.

RELEASE NOTES END
