### PR TITLE
Don't sync the release for downgrades

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -11,6 +11,7 @@ from typing import Callable, Optional
 
 import git
 import requests
+import rpm
 from git import GitCommandError, PushInfo
 from ogr.abstract import AccessLevel, GitProject, PullRequest
 from specfile import Specfile
@@ -137,6 +138,15 @@ class PackitRepositoryBase:
         from spec files can be found
         """
         return self.absolute_specfile_dir
+
+    def get_specfile_version(self) -> str:
+        """provide version from specfile"""
+        # we need to get the version from rpm spec header
+        # (as the version tag might not be present directly in the specfile,
+        # but e.g. imported)
+        version = self.specfile.rpm_spec.sourceHeader[rpm.RPMTAG_VERSION]
+        logger.info(f"Version in spec file is {version!r}.")
+        return version
 
     def create_branch(
         self,

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Optional, Union
 
 import git
-import rpm
 
 from packit.actions import ActionName
 from packit.base_git import PackitRepositoryBase
@@ -254,15 +253,6 @@ class Upstream(PackitRepositoryBase):
 
         version = get_upstream_version(self.package_config.downstream_package_name)
         logger.info(f"Version in upstream registries is {version!r}.")
-        return version
-
-    def get_specfile_version(self) -> str:
-        """provide version from specfile"""
-        # we need to get the version from rpm spec header
-        # (as the version tag might not be present directly in the specfile,
-        # but e.g. imported)
-        version = self.specfile.rpm_spec.sourceHeader[rpm.RPMTAG_VERSION]
-        logger.info(f"Version in spec file is {version!r}.")
         return version
 
     def get_version_from_action(self) -> str:

--- a/tests_recording/test_api.py
+++ b/tests_recording/test_api.py
@@ -133,6 +133,6 @@ class ProposeUpdate(PackitTest):
         flexmock(Bugzilla).should_receive("query").and_return([])
 
         self.api.package_config.sync_changelog = True
-        self.api.sync_release(version="0", use_local_content=True)
+        self.api.sync_release(version="1.0.0", use_local_content=True)
         new_downstream_spec_content = self.api.dg.absolute_specfile_path.read_text()
         assert changed_upstream_spec_content == new_downstream_spec_content


### PR DESCRIPTION
Compare the version to propose with version in the specfile of the particular branch.
Fixes #2208

RELEASE NOTES BEGIN

Packit now checks the version to propose against the version in specfile and doesn't create downgrade PRs.

RELEASE NOTES END
