### PR TITLE
Add log suggestions to use upstream_tag_template in sync_release

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1135,6 +1135,11 @@ The first dist-git commit to be synced is '{short_hash}'.
             else:
                 self.dg.push(refspec=f"HEAD:{dist_git_branch}")
         finally:
+            # version should hold the plain version string
+            if version.startswith("v"):
+                logger.warning(
+                    "Please, check whether the `upstream_tag_template` needs to be configured.",
+                )
             if not use_local_content and not upstream_ref:
                 logger.info(f"Checking out the original branch {current_up_branch}.")
                 self.up.local_project.git_repo.git.checkout(current_up_branch, "-f")

--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -555,7 +555,10 @@ class LocalProject:
         try:
             self.git_repo.git.checkout(tag)
         except Exception as ex:
-            raise PackitException("Cannot checkout release tag.") from ex
+            raise PackitException(
+                "Cannot checkout release tag. Please, check whether the "
+                "'upstream_tag_template' needs to be configured.",
+            ) from ex
 
     def fetch(self, remote: str, refspec: Optional[str] = None, force: bool = False):
         """


### PR DESCRIPTION
Related to #2235

Merge before/after

RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
