### PR TITLE
Change the default changelog entry for release sync

### DIFF
--- a/packit/utils/changelog_helper.py
+++ b/packit/utils/changelog_helper.py
@@ -58,6 +58,7 @@ class ChangelogHelper:
         version: Optional[str] = None,
         resolved_bugs: Optional[list[str]] = None,
         upstream_tag: Optional[str] = None,
+        previous_version: Optional[str] = None,
     ) -> Optional[str]:
         """
         Runs changelog-entry action if present and returns string that can be
@@ -75,6 +76,7 @@ class ChangelogHelper:
             "PACKIT_PROJECT_VERSION": version,
             "PACKIT_RESOLVED_BUGS": resolved_bugs_str,
             "PACKIT_PROJECT_UPSTREAM_TAG": upstream_tag or "",
+            "PACKIT_PROJECT_PREVIOUS_VERSION": previous_version or "",
         }
         messages = self.up.get_output_from_action(ActionName.changelog_entry, env=env)
         if not messages:
@@ -108,11 +110,19 @@ class ChangelogHelper:
             resolved_bugs: list of bugs that should be referenced
         """
 
+        previous_specfile_version = None
+        try:
+            previous_specfile_version = self.dg.specfile.version
+        except Exception:
+            logger.debug(
+                "We were not able to get the previous version from specfile in dist-git",
+            )
 
         action_output = self.get_entry_from_action(
             version=full_version,
             resolved_bugs=resolved_bugs,
             upstream_tag=upstream_tag,
+            previous_version=previous_specfile_version,
         )
 
         comment = action_output or default_changelog_entry

--- a/tests/integration/test_changelog_helper.py
+++ b/tests/integration/test_changelog_helper.py
@@ -177,7 +177,7 @@ def test_update_distgit_when_copy_upstream_release_description_none(
     )
 
     with downstream._specfile.sections() as sections:
-        assert "- Update to upstream release 0.1.0" in sections.changelog
+        assert "- Update to version 0.1.0" in sections.changelog
 
 
 def test_update_distgit_changelog_entry_action_pass_env_vars(
@@ -200,6 +200,7 @@ def test_update_distgit_changelog_entry_action_pass_env_vars(
         "PACKIT_DOWNSTREAM_PACKAGE_NAME": "beer",
         "PACKIT_PROJECT_VERSION": "0.1.0",
         "PACKIT_RESOLVED_BUGS": "rhbz#123 rhbz#124",
+        "PACKIT_PROJECT_UPSTREAM_TAG": "0.1.0",
     }
     flexmock(upstream).should_receive("get_output_from_action").with_args(
         ActionName.changelog_entry,

--- a/tests/integration/test_changelog_helper.py
+++ b/tests/integration/test_changelog_helper.py
@@ -201,6 +201,7 @@ def test_update_distgit_changelog_entry_action_pass_env_vars(
         "PACKIT_PROJECT_VERSION": "0.1.0",
         "PACKIT_RESOLVED_BUGS": "rhbz#123 rhbz#124",
         "PACKIT_PROJECT_UPSTREAM_TAG": "0.1.0",
+        "PACKIT_PROJECT_PREVIOUS_VERSION": "0.0.0",
     }
     flexmock(upstream).should_receive("get_output_from_action").with_args(
         ActionName.changelog_entry,

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -145,7 +145,7 @@ def test_basic_local_update_use_downstream_specfile(
     assert "0.0.0" in changelog
     assert "0.1.0" in changelog
 
-    assert changelog.count("0.1.0") == 1
+    assert changelog.count("0.1.0-1") == 1
 
 
 def test_basic_local_update_with_multiple_sources(


### PR DESCRIPTION

TODO:

- [x] Update the docs
- [x] Inform via comments in packit-service

RELEASE NOTES BEGIN

As discussed and agreed on in https://pagure.io/packaging-committee/issue/1339,
we changed the default behaviour for changelog entry generation to comply with the packaging guidelines. The default changelog entry will be `- Update to version <version>`.
Users can still configure the behaviour using custom commands in
`changelog-entry` action or using `copy_upstream_release_description` config option.

RELEASE NOTES END
