### PR TITLE
remove [packit] prefix from pull-from-upstream dist-git commits

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1096,7 +1096,7 @@ The first dist-git commit to be synced is '{short_hash}'.
 
             commit_title, commit_description = get_commit_message_from_action(
                 output=commit_msg_action_output,
-                default_title=title or f"[packit] {version} upstream release",
+                default_title=title or f"Update to {version} upstream release",
                 default_description=description
                 or self.get_default_commit_description(upstream_tag, resolved_bugs),
             )

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -196,6 +196,8 @@ PACKAGE_OPTION_HELP = (
 SYNC_RELEASE_DEFAULT_COMMIT_DESCRIPTION = (
     "{resolved_bugs}Upstream tag: {upstream_tag}\n"
     "Upstream commit: {upstream_commit}\n"
+    "\n"
+    "Commit authored by Packit automation (https://packit.dev/)\n"
 )
 
 SYNC_RELEASE_PR_DESCRIPTION = (

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -361,16 +361,22 @@ def test_sync_release_downgrade(api_mock):
     [
         pytest.param(
             ["rhbz#123"],
-            "- Resolves: rhbz#123\n\nUpstream tag: 1.0.0\nUpstream commit: _\n",
+            "- Resolves: rhbz#123\n\nUpstream tag: 1.0.0\nUpstream commit: _\n"
+            "\nCommit authored by Packit automation (https://packit.dev/)\n",
         ),
         pytest.param(
             ["rhbz#123", "rhbz#222"],
             (
                 "- Resolves: rhbz#123\n- Resolves: rhbz#222\n\n"
                 "Upstream tag: 1.0.0\nUpstream commit: _\n"
+                "\nCommit authored by Packit automation (https://packit.dev/)\n"
             ),
         ),
-        pytest.param(None, "Upstream tag: 1.0.0\nUpstream commit: _\n"),
+        pytest.param(
+            None,
+            "Upstream tag: 1.0.0\nUpstream commit: _\n"
+            "\nCommit authored by Packit automation (https://packit.dev/)\n",
+        ),
     ],
 )
 def test_get_default_commit_description(api_mock, resolved_bugs, result):


### PR DESCRIPTION
Fixes: #2262

<!-- TODO list -->



<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->


<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit previously put the "[packit]" string as a prefix in the subject of pull-from-upstream commits. Now the prefix is no longer there - this is made unnecessary noise in autochangelog. This affects the default. Custom action can still override this behavior.

RELEASE NOTES END
