### PR TITLE
Add support for CBS Koji

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -100,13 +100,13 @@ jobs:
     list_on_homepage: True
     preserve_project: True
 
+  # downstream automation:
   - job: pull_from_upstream
     trigger: release
     dist_git_branches:
       - fedora-all
       - epel-9
 
-  # downstream automation:
   - job: koji_build
     trigger: commit
     packit_instances: ["stg"]

--- a/files/local-tests-requirements.yaml
+++ b/files/local-tests-requirements.yaml
@@ -8,6 +8,7 @@
     - ansible.builtin.include_tasks: tasks/specfile.yaml
     - ansible.builtin.include_tasks: tasks/sandcastle.yaml
     - ansible.builtin.include_tasks: tasks/centpkg.yaml
+    - ansible.builtin.include_tasks: tasks/centos-packager.yaml
     # To (re-)generate tests_recording/test_data/
     - ansible.builtin.include_tasks: tasks/requre.yaml
     - name: Install pre-commit

--- a/files/tasks/centos-packager.yaml
+++ b/files/tasks/centos-packager.yaml
@@ -1,0 +1,6 @@
+---
+- name: Install centos-packager
+  ansible.builtin.dnf:
+    name:
+      - centos-packager
+  become: true

--- a/packit/api.py
+++ b/packit/api.py
@@ -349,7 +349,7 @@ class PackitAPI:
             commit_msg: Use this commit message in dist-git.
             sync_default_files: Whether to sync the default files, that is: packit.yaml and
                 the spec-file.
-            pkg_tool: What tool (fedpkg/centpkg) to use upload to lookaside cache.
+            pkg_tool: What tool (fedpkg/centpkg/cbs) to use upload to lookaside cache.
             mark_commit_origin: Whether to include a Git-trailer in the dist-git
                 commit message to mark the hash of the upstream (source-git) commit.
             check_sync_status: Check the synchronization status of the source-git
@@ -1545,7 +1545,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         Args:
             force_new_sources: Download/upload the archive even if it's
                 name is already in the cache or in sources file.
-                Actually, fedpkg/centpkg won't upload it if archive with the same
+                Actually, fedpkg/centpkg/cbs won't upload it if archive with the same
                 name & hash is already there, so this might be useful only if
                 you want to upload archive with the same name but different hash.
             pkg_tool: Tool to upload sources.
@@ -2215,7 +2215,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         if self._kerberos_initialized:
             return
 
-        if not self.pkg_tool.startswith("fedpkg"):
+        if self.pkg_tool.startswith("centpkg"):
             # centpkg doesn't use kerberos
             return
 

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -159,6 +159,7 @@ class CommonPackageConfig:
             Keys are macro names and values are macro values. A value of None will undefine
             the corresponding macro.
         status_name_template: Template for configurable names for status checks.
+        sig: Special interest group (SIG) that maintains the “downstream” package.
     """
 
     def __init__(
@@ -239,6 +240,7 @@ class CommonPackageConfig:
         parse_time_macros: Optional[dict[str, str]] = None,
         require: Optional[RequirementsConfig] = None,
         status_name_template: Optional[str] = None,
+        sig: Optional[str] = None,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -349,6 +351,7 @@ class CommonPackageConfig:
         self.upload_sources = upload_sources
 
         self.pkg_tool = pkg_tool
+        self.sig = sig
 
         self.parse_time_macros = parse_time_macros or {}
 

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -35,6 +35,7 @@ def _construct_dist_git_instance(
     base_url: Optional[str],
     namespace: Optional[str],
     pkg_tool: Optional[str],
+    sig: Optional[str] = None,
 ) -> DistGitInstance:
     """Construct a dist-git instance information from provided configuration.
 
@@ -42,6 +43,10 @@ def _construct_dist_git_instance(
         base_url: Base URL of the dist-git provided from the config.
         namespace: Namespace in the dist-git provided from the config.
         pkg_tool: Packaging tool to be used provided from the config.
+        sig: SIG that maintains the “downstream” package. Used for adjusting the
+            namespace.
+
+            Defaults to `None`.
 
     Returns:
         Dist-git instance information that is used in config.
@@ -53,7 +58,7 @@ def _construct_dist_git_instance(
 
     # explicitly specified packaging tool overrides too
     if pkg_tool:
-        return DISTGIT_INSTANCES[pkg_tool]
+        return DISTGIT_INSTANCES[pkg_tool].for_sig(sig=sig)
 
     # we try the environment variables
     base_url, namespace = getenv("DISTGIT_URL"), getenv("DISTGIT_NAMESPACE")
@@ -267,7 +272,10 @@ class CommonPackageConfig:
             base_url=dist_git_base_url,
             namespace=dist_git_namespace,
             pkg_tool=pkg_tool,
+            sig=sig,
         )
+        self.pkg_tool = pkg_tool
+        self.sig = sig
 
         self.actions = actions or {}
         self.upstream_ref: Optional[str] = upstream_ref
@@ -349,9 +357,6 @@ class CommonPackageConfig:
 
         self.follow_fedora_branching = follow_fedora_branching
         self.upload_sources = upload_sources
-
-        self.pkg_tool = pkg_tool
-        self.sig = sig
 
         self.parse_time_macros = parse_time_macros or {}
 

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -47,6 +47,31 @@ DISTGIT_INSTANCES = {
         alternative_hostname=None,
         namespace="redhat/centos-stream/rpms",
     ),
+    "cbs-automotive-sig": DistGitInstance(
+        hostname="gitlab.com",
+        alternative_hostname=None,
+        namespace="CentOS/automotive/rpms",
+    ),
+    "cbs-cloud-sig": DistGitInstance(
+        hostname="gitlab.com",
+        alternative_hostname=None,
+        namespace="CentOS/cloud/rpms",
+    ),
+    "cbs-storage-sig": DistGitInstance(
+        hostname="gitlab.com",
+        alternative_hostname=None,
+        namespace="CentOS/storage/rpms",
+    ),
+    "cbs-isa-sig": DistGitInstance(
+        hostname="gitlab.com",
+        alternative_hostname=None,
+        namespace="CentOS/isa/rpms",
+    ),
+    "cbs-kmods-sig": DistGitInstance(
+        hostname="gitlab.com",
+        alternative_hostname=None,
+        namespace="CentOS/kmods/rpms",
+    ),
 }
 
 DISTGIT_HOSTNAME_CANDIDATES = set(

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -47,30 +47,10 @@ DISTGIT_INSTANCES = {
         alternative_hostname=None,
         namespace="redhat/centos-stream/rpms",
     ),
-    "centpkg-sig/automotive": DistGitInstance(
+    "centpkg-sig": DistGitInstance(
         hostname="gitlab.com",
         alternative_hostname=None,
-        namespace="CentOS/automotive/rpms",
-    ),
-    "centpkg-sig/cloud": DistGitInstance(
-        hostname="gitlab.com",
-        alternative_hostname=None,
-        namespace="CentOS/cloud/rpms",
-    ),
-    "centpkg-sig/storage": DistGitInstance(
-        hostname="gitlab.com",
-        alternative_hostname=None,
-        namespace="CentOS/storage/rpms",
-    ),
-    "centpkg-sig/isa": DistGitInstance(
-        hostname="gitlab.com",
-        alternative_hostname=None,
-        namespace="CentOS/isa/rpms",
-    ),
-    "centpkg-sig/kmods": DistGitInstance(
-        hostname="gitlab.com",
-        alternative_hostname=None,
-        namespace="CentOS/kmods/rpms",
+        namespace="CentOS/{sig}/rpms",
     ),
 }
 

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -47,27 +47,27 @@ DISTGIT_INSTANCES = {
         alternative_hostname=None,
         namespace="redhat/centos-stream/rpms",
     ),
-    "cbs-automotive-sig": DistGitInstance(
+    "centpkg-sig/automotive": DistGitInstance(
         hostname="gitlab.com",
         alternative_hostname=None,
         namespace="CentOS/automotive/rpms",
     ),
-    "cbs-cloud-sig": DistGitInstance(
+    "centpkg-sig/cloud": DistGitInstance(
         hostname="gitlab.com",
         alternative_hostname=None,
         namespace="CentOS/cloud/rpms",
     ),
-    "cbs-storage-sig": DistGitInstance(
+    "centpkg-sig/storage": DistGitInstance(
         hostname="gitlab.com",
         alternative_hostname=None,
         namespace="CentOS/storage/rpms",
     ),
-    "cbs-isa-sig": DistGitInstance(
+    "centpkg-sig/isa": DistGitInstance(
         hostname="gitlab.com",
         alternative_hostname=None,
         namespace="CentOS/isa/rpms",
     ),
-    "cbs-kmods-sig": DistGitInstance(
+    "centpkg-sig/kmods": DistGitInstance(
         hostname="gitlab.com",
         alternative_hostname=None,
         namespace="CentOS/kmods/rpms",

--- a/packit/dist_git_instance.py
+++ b/packit/dist_git_instance.py
@@ -7,7 +7,7 @@ from typing import Optional
 from ogr.parsing import RepoUrl, parse_git_repo
 
 
-@dataclass
+@dataclass(frozen=True)
 class DistGitInstance:
     hostname: str
     alternative_hostname: Optional[str]

--- a/packit/dist_git_instance.py
+++ b/packit/dist_git_instance.py
@@ -1,6 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+import dataclasses
 from dataclasses import dataclass
 from typing import Optional
 
@@ -12,6 +13,12 @@ class DistGitInstance:
     hostname: str
     alternative_hostname: Optional[str]
     namespace: str
+
+    def for_sig(self, sig: Optional[str]) -> "DistGitInstance":
+        if sig is None:
+            return self
+
+        return dataclasses.replace(self, namespace=self.namespace.format(sig=sig))
 
     @property
     def url(self) -> str:

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -200,7 +200,8 @@ class DistGit(PackitRepositoryBase):
         Clone package from dist-git, i.e. from:
         - Fedora's src.[stg.]fedoraproject.org
         - CentOS Stream's gitlab.com/redhat/centos-stream/rpms/
-        depending on configured pkg_tool: {fedpkg(default),fedpkg-stage,centpkg}
+        - CentOS CBS's gitlab.com/CentOS/<SIG>/rpms/
+        depending on configured pkg_tool: {fedpkg(default),fedpkg-stage,centpkg,cbs}
 
         Args:
             target_path: the name of a new directory to clone into
@@ -449,7 +450,7 @@ class DistGit(PackitRepositoryBase):
 
         Args:
             archive: Path to archive to upload to lookaside cache.
-            pkg_tool: Optional, rpkg tool (fedpkg/centpkg) to use to upload.
+            pkg_tool: Optional, rpkg tool (fedpkg/centpkg/cbs) to use to upload.
             offline: Whether to use offline mode of the tool
                      (no actual upload, just local file updates).
 

--- a/packit/pkgtool.py
+++ b/packit/pkgtool.py
@@ -25,7 +25,7 @@ class PkgTool:
         Args:
             fas_username: FAS username (used for cloning)
             directory: operate in this dist-git repository
-            tool: pkgtool to use (fedpkg, centpkg, cbs)
+            tool: pkgtool to use (fedpkg, centpkg, centpkg-sig)
         """
         self.fas_username = fas_username
         self.directory = Path(directory) if directory else None
@@ -61,15 +61,14 @@ class PkgTool:
             fail=fail,
         ).success
 
-    def sources(self, fail: bool = True) -> str:
+    def sources(self, fail: bool = True) -> bool:
         """Run the 'sources' command
 
         Args:
             fail: Raise an exception if the command fails
 
         Returns:
-            XXX vvv I wonder how is this possible without `output=True` vvv XXX
-            The 'stdout' of the sources command that is executed.
+            True, if the command finished successfully, False otherwise.
         """
         return commands.run_command_remote(
             cmd=[self.tool, "sources"],

--- a/packit/pkgtool.py
+++ b/packit/pkgtool.py
@@ -12,7 +12,7 @@ from packit.utils.logging import logger
 
 class PkgTool:
     """
-    Wrapper around fedpkg/centpkg.
+    Wrapper around fedpkg/centpkg/cbs.
     """
 
     def __init__(
@@ -25,7 +25,7 @@ class PkgTool:
         Args:
             fas_username: FAS username (used for cloning)
             directory: operate in this dist-git repository
-            tool: pkgtool to use (fedpkg, centpkg)
+            tool: pkgtool to use (fedpkg, centpkg, cbs)
         """
         self.fas_username = fas_username
         self.directory = Path(directory) if directory else None

--- a/packit/pkgtool.py
+++ b/packit/pkgtool.py
@@ -20,22 +20,26 @@ class PkgTool:
         fas_username: Optional[str] = None,
         directory: Union[Path, str, None] = None,
         tool: str = "fedpkg",
+        sig: Optional[str] = None,
     ):
         """
         Args:
             fas_username: FAS username (used for cloning)
             directory: operate in this dist-git repository
             tool: pkgtool to use (fedpkg, centpkg, centpkg-sig)
+            sig: name of the SIG; used for adjusting the path during cloning
         """
         self.fas_username = fas_username
         self.directory = Path(directory) if directory else None
         self.tool = tool
+        self.sig = sig
 
     def __repr__(self):
         return (
             "PkgTool("
             f"fas_username='{self.fas_username}', "
             f"directory='{self.directory}', "
+            f"sig='{self.sig}', "
             f"tool='{self.tool}')"
         )
 
@@ -151,7 +155,11 @@ class PkgTool:
             cmd += ["--branch", branch]
         if anonymous:
             cmd += ["--anonymous"]
-        cmd += [package_name, str(target_path)]
+
+        cmd += [
+            f"{self.sig}/rpms/{package_name}" if self.sig else package_name,
+            str(target_path),
+        ]
 
         error_msg = (
             f"{self.tool} failed to clone repository {package_name}; "

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -446,6 +446,7 @@ class CommonConfigSchema(Schema):
 
     # Packaging tool used for interaction with lookaside cache
     pkg_tool = fields.String(missing=None)
+    sig = fields.String(missing=None)
     version_update_mask = fields.String(missing=None)
 
     parse_time_macros = fields.Dict(missing=None)

--- a/tests/unit/config/test_common_package.py
+++ b/tests/unit/config/test_common_package.py
@@ -1,0 +1,46 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+from typing import Optional
+
+import pytest
+
+from packit.config.common_package_config import _construct_dist_git_instance
+from packit.constants import DISTGIT_INSTANCES
+from packit.dist_git_instance import DistGitInstance
+
+
+@pytest.mark.parametrize(
+    "base_url, namespace, pkg_tool, sig, expected_dg_instance",
+    (
+        (None, None, "fedpkg", None, DISTGIT_INSTANCES["fedpkg"]),
+        (None, None, "centpkg", None, DISTGIT_INSTANCES["centpkg"]),
+        (
+            None,
+            None,
+            "centpkg-sig",
+            "cloud",
+            DistGitInstance(
+                hostname="gitlab.com",
+                alternative_hostname=None,
+                namespace="CentOS/cloud/rpms",
+            ),
+        ),
+    ),
+)
+def test_construct_dg_instance(
+    base_url: str,
+    namespace: str,
+    pkg_tool: str,
+    sig: Optional[str],
+    expected_dg_instance: DistGitInstance,
+):
+    assert (
+        _construct_dist_git_instance(
+            base_url=base_url,
+            namespace=namespace,
+            pkg_tool=pkg_tool,
+            sig=sig,
+        )
+        == expected_dg_instance
+    )

--- a/tests/unit/utils/test_dist_git_instance.py
+++ b/tests/unit/utils/test_dist_git_instance.py
@@ -91,17 +91,29 @@ def test_from_url_and_namespace(url: str, namespace: str, expected: DistGitInsta
 
 
 @pytest.mark.parametrize(
-    "pkg_tool, package, expected_url",
+    "dg_instance, package, expected_url",
     (
-        ("fedpkg", "packit", "https://src.fedoraproject.org/rpms/packit"),
-        ("centpkg", "nispor", "https://gitlab.com/redhat/centos-stream/rpms/nispor"),
-        ("fedpkg-stage", "packit", "https://src.stg.fedoraproject.org/rpms/packit"),
         (
-            "centpkg-sig/cloud",
+            DISTGIT_INSTANCES["fedpkg"],
+            "packit",
+            "https://src.fedoraproject.org/rpms/packit",
+        ),
+        (
+            DISTGIT_INSTANCES["centpkg"],
+            "nispor",
+            "https://gitlab.com/redhat/centos-stream/rpms/nispor",
+        ),
+        (
+            DISTGIT_INSTANCES["fedpkg-stage"],
+            "packit",
+            "https://src.stg.fedoraproject.org/rpms/packit",
+        ),
+        (
+            DISTGIT_INSTANCES["centpkg-sig"].for_sig("cloud"),
             "hello-world",
             "https://gitlab.com/CentOS/cloud/rpms/hello-world",
         ),
     ),
 )
-def test_distgit_project_url_from_dg_constant(pkg_tool, package, expected_url):
-    assert DISTGIT_INSTANCES[pkg_tool].distgit_project_url(package) == expected_url
+def test_project_url_from_dg_instance(dg_instance, package, expected_url):
+    assert dg_instance.distgit_project_url(package=package) == expected_url

--- a/tests/unit/utils/test_dist_git_instance.py
+++ b/tests/unit/utils/test_dist_git_instance.py
@@ -97,7 +97,7 @@ def test_from_url_and_namespace(url: str, namespace: str, expected: DistGitInsta
         ("centpkg", "nispor", "https://gitlab.com/redhat/centos-stream/rpms/nispor"),
         ("fedpkg-stage", "packit", "https://src.stg.fedoraproject.org/rpms/packit"),
         (
-            "cbs-cloud-sig",
+            "centpkg-sig/cloud",
             "hello-world",
             "https://gitlab.com/CentOS/cloud/rpms/hello-world",
         ),

--- a/tests/unit/utils/test_dist_git_instance.py
+++ b/tests/unit/utils/test_dist_git_instance.py
@@ -16,6 +16,11 @@ CENTOS_DG = DistGitInstance(
     alternative_hostname=None,
     namespace="redhat/centos-stream/rpms",
 )
+CBS_CLOUD_DG = DistGitInstance(
+    hostname="gitlab.com",
+    alternative_hostname=None,
+    namespace="CentOS/cloud/rpms",
+)
 
 
 @pytest.mark.parametrize(
@@ -41,6 +46,11 @@ CENTOS_DG = DistGitInstance(
             "gitlab.com/redhat/centos-stream/rpms/hello-world.git",
             True,
         ),
+        pytest.param(
+            CBS_CLOUD_DG,
+            "gitlab.com/CentOS/cloud/rpms/hello-world.git",
+            True,
+        ),
     ),
 )
 def test_has_repository(dg: DistGitInstance, url: str, expected: bool):
@@ -62,6 +72,12 @@ def test_has_repository(dg: DistGitInstance, url: str, expected: bool):
             CENTOS_DG,
             id="stream-prod",
         ),
+        pytest.param(
+            "https://gitlab.com/",
+            "CentOS/cloud/rpms",
+            CBS_CLOUD_DG,
+            id="cbs-cloud-sig",
+        ),
     ),
 )
 def test_from_url_and_namespace(url: str, namespace: str, expected: DistGitInstance):
@@ -80,6 +96,11 @@ def test_from_url_and_namespace(url: str, namespace: str, expected: DistGitInsta
         ("fedpkg", "packit", "https://src.fedoraproject.org/rpms/packit"),
         ("centpkg", "nispor", "https://gitlab.com/redhat/centos-stream/rpms/nispor"),
         ("fedpkg-stage", "packit", "https://src.stg.fedoraproject.org/rpms/packit"),
+        (
+            "cbs-cloud-sig",
+            "hello-world",
+            "https://gitlab.com/CentOS/cloud/rpms/hello-world",
+        ),
     ),
 )
 def test_distgit_project_url_from_dg_constant(pkg_tool, package, expected_url):


### PR DESCRIPTION
tl;dr WIP support for CBS. What we really need there is `pull_from_upstream` though. 

### TODO list

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.
  - [x] new ‹sig› config option
- [ ] Rebuild ‹centpkg-sig› with the config that points to the GitLab

### Notes for reviewers

- I've managed to successfully run `packit build in-koji` from cloned dist-git SIG repo, Koji builds from CLI seem to be functional
- I've added new config option `sig`, it is being injected into the packaging tool and dist-git instance, it is not very ideal design and also it may hit its limits, though it is not very easy to work around as the packaging tool is being passed around just as a string (SIG ⇒ additional parameter)

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Related to #2305 

Merge with packit/packit.dev#906

<!-- release notes footer -->

RELEASE NOTES BEGIN

We have implemented a CLI support for Koji builds against CBS Koji instance.

RELEASE NOTES END
