### PR TITLE
Fix log message when downstream specfile version is higher

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1015,7 +1015,7 @@ The first dist-git commit to be synced is '{short_hash}'.
                 downstream_spec_ver = self.dg.get_specfile_version()
                 if compare_versions(version, downstream_spec_ver) < 0:
                     msg = (
-                        f"Downstream specfile version {downstream_spec_ver} is lower "
+                        f"Downstream specfile version {downstream_spec_ver} is higher "
                         f"than the version to propose ({version}). Skipping the update."
                     )
                     logger.debug(msg)


### PR DESCRIPTION
Then the version that is being proposed during syncing the release.

This log message is shown in the dashboard (see e.g. https://dashboard.packit.dev/results/propose-downstream/7733)

RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
