### PR TITLE
Save original package config dict after setting defaults

### DIFF
--- a/tests/unit/config/test_package_config.py
+++ b/tests/unit/config/test_package_config.py
@@ -1833,6 +1833,22 @@ def test_test_command_identifiers():
     assert pc.test_command.default_identifier == identifier
 
 
+def test_get_raw_dict_with_defaults():
+    pc = PackageConfig.get_from_dict(
+        {
+            "specfile_path": "package.spec",
+        },
+        repo_name="package",
+        config_file_path="path",
+    )
+    assert pc.get_raw_dict_with_defaults() == {
+        "specfile_path": "package.spec",
+        "config_file_path": "path",
+        "upstream_package_name": "package",
+        "downstream_package_name": "package",
+    }
+
+
 def test_get_local_specfile_path():
     assert str(get_local_specfile_path(UP_OSBUILD)) == "osbuild.spec"
     assert not get_local_specfile_path(SYNC_FILES)


### PR DESCRIPTION
Once the package config is loaded via PackageConfigSchema().load(dict), all the default values in all job configs are set. This is therefore needed so that in packit service we are able to store the package config in DB with reasonable size.

Needed for packit/packit-service#1940
