### PR TITLE
Dist-git init improvements

### DIFF
--- a/packit/cli/dist_git_init.py
+++ b/packit/cli/dist_git_init.py
@@ -58,6 +58,10 @@ For more details, see https://packit.dev/docs/configuration/ or contact
     help="Python regex used for filtering upstream tags to exclude. ",
 )
 @click.option(
+    "--version-update-mask",
+    help="Python regex used for comparison of the old and the new version. ",
+)
+@click.option(
     "--issue-repository",
     help="URL of a git repository that can be used for reporting errors in form of issues. ",
 )
@@ -142,6 +146,7 @@ def init(
     upstream_tag_template,
     upstream_tag_include,
     upstream_tag_exclude,
+    version_update_mask,
     issue_repository,
     no_pull,
     no_koji_build,
@@ -204,6 +209,7 @@ def init(
         upstream_tag_template=upstream_tag_template,
         upstream_tag_include=upstream_tag_include,
         upstream_tag_exclude=upstream_tag_exclude,
+        version_update_mask=version_update_mask,
         issue_repository=issue_repository,
         no_pull=no_pull,
         no_koji_build=no_koji_build,
@@ -242,6 +248,7 @@ class DistGitInitializer:
         upstream_tag_template: Optional[str] = None,
         upstream_tag_include: Optional[str] = None,
         upstream_tag_exclude: Optional[str] = None,
+        version_update_mask: Optional[str] = None,
         issue_repository: Optional[str] = None,
         no_pull: bool = False,
         no_koji_build: bool = False,
@@ -260,6 +267,7 @@ class DistGitInitializer:
         self.upstream_tag_template = upstream_tag_template
         self.upstream_tag_include = upstream_tag_include
         self.upstream_tag_exclude = upstream_tag_exclude
+        self.version_update_mask = version_update_mask
         self.issue_repository = issue_repository
         self.no_pull = no_pull
         self.no_koji_build = no_koji_build
@@ -355,6 +363,7 @@ class DistGitInitializer:
             "upstream_tag_template",
             "upstream_tag_include",
             "upstream_tag_exclude",
+            "version_update_mask",
             "issue_repository",
             "allowed_committers",
             "allowed_pr_authors",


### PR DESCRIPTION
Fixes #2285

RELEASE NOTES BEGIN
 
`packit dist-git init` now allows specifying `--version-update-mask` option and also any arbitrary top-level configuration options.

RELEASE NOTES END
