### PR TITLE
Add a `scan-in-osh` subcommand

### DIFF
--- a/packit.spec
+++ b/packit.spec
@@ -36,6 +36,8 @@ Requires:       rpmdevtools
 # Copying files between repositories
 Requires:       rsync
 
+Recommends:       osh-cli
+
 %description -n python3-packit
 Python library for Packit,
 check out packit package for the executable.

--- a/packit/api.py
+++ b/packit/api.py
@@ -2053,6 +2053,51 @@ The first dist-git commit to be synced is '{short_hash}'.
             report_func=report_func,
         )
 
+    def run_osh_build(
+        self,
+        chroot: Optional[str] = "fedora-rawhide-x86_64",
+        srpm_path: Optional[Path] = None,
+        upstream_ref: Optional[str] = None,
+        release_suffix: Optional[str] = None,
+        base_srpm: Optional[Path] = None,
+        comment: Optional[str] = "Submitted through Packit.",
+    ) -> str:
+        """
+        Perform a build through OpenScanHub.
+        """
+        # `osh-cli` requires a kerberos ticket.
+        self.init_kerberos_ticket()
+
+        if not srpm_path:
+            srpm_path = self.create_srpm(
+                upstream_ref=upstream_ref,
+                srpm_dir=self.up.local_project.working_dir,
+                release_suffix=release_suffix,
+            )
+
+        if base_srpm:
+            cmd = [
+                "osh-cli",
+                "version-diff-build",
+                "--srpm=" + str(srpm_path),
+                "--base-srpm=" + str(base_srpm),
+            ]
+        else:
+            cmd = ["osh-cli", "mock-build", str(srpm_path)]
+
+        cmd.append("--config=" + str(chroot))
+        cmd.append("--nowait")
+        cmd.append("--json")
+        cmd.append("--comment=" + comment)
+
+        try:
+            cmd_result = commands.run_command(cmd, output=True)
+        except PackitCommandFailedError as ex:
+            logger.error(ex.stderr_output)
+            return None
+
+        return cmd_result.stdout
+
     def push_bodhi_update(self, update_alias: str):
         """Push selected bodhi update from testing to stable."""
         from bodhi.client.bindings import UpdateNotFound

--- a/packit/cli/packit_base.py
+++ b/packit/cli/packit_base.py
@@ -13,6 +13,7 @@ from packit.cli.init import init
 from packit.cli.prepare_sources import prepare_sources
 from packit.cli.propose_downstream import propose_downstream, pull_from_upstream
 from packit.cli.push_updates import push_updates
+from packit.cli.scan_in_osh import scan_in_osh
 from packit.cli.source_git import source_git
 from packit.cli.srpm import srpm
 from packit.cli.status import status
@@ -93,5 +94,7 @@ packit_base.add_command(validate_config)
 packit_base.add_command(source_git)
 packit_base.add_command(prepare_sources)
 packit_base.add_command(dist_git)
+packit_base.add_command(scan_in_osh)
+
 if __name__ == "__main__":
     packit_base()

--- a/packit/cli/scan_in_osh.py
+++ b/packit/cli/scan_in_osh.py
@@ -1,0 +1,86 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import json
+import logging
+import os
+import sys
+
+import click
+
+from packit.cli.types import LocalProjectParameter
+from packit.cli.utils import cover_packit_exception, get_packit_api, iterate_packages
+from packit.config import (
+    get_context_settings,
+    pass_config,
+)
+from packit.constants import (
+    PACKAGE_LONG_OPTION,
+    PACKAGE_OPTION_HELP,
+    PACKAGE_SHORT_OPTION,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@click.command("scan-in-osh", context_settings=get_context_settings())
+@pass_config
+@cover_packit_exception
+@iterate_packages
+@click.option(
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_LONG_OPTION,
+    multiple=True,
+    help=PACKAGE_OPTION_HELP.format(action="build"),
+)
+@click.option(
+    "--target",
+    help="Chroot to build in. (defaults to 'fedora-rawhide-x86_64')",
+    default="fedora-rawhide-x86_64",
+)
+@click.option(
+    "--base-srpm",
+    help="Base SRPM to perform a differential build",
+    default=None,
+)
+@click.option(
+    "--comment",
+    help="Comment for the build",
+    default="Submitted through Packit.",
+)
+@click.argument("path_or_url", type=LocalProjectParameter(), default=os.path.curdir)
+def scan_in_osh(
+    config,
+    path_or_url,
+    package_config,
+    target,
+    base_srpm,
+    comment,
+):
+    """
+    Perform a scan through OpenScanHub.
+    You need a valid kerberos ticket and set `dns_canonicalize_hostname=false`
+    in Kerberos configurations.
+    Documentation can be found at https://fedoraproject.org/wiki/OpenScanHub.
+    """
+    api = get_packit_api(
+        config=config,
+        package_config=package_config,
+        local_project=path_or_url,
+    )
+
+    if base_srpm:
+        logger.debug(f"Base SRPM: {base_srpm}")
+
+    cmd_result_stdout = api.run_osh_build(
+        chroot=target,
+        base_srpm=base_srpm,
+        comment=comment,
+    )
+
+    if cmd_result_stdout:
+        build_url = json.loads(cmd_result_stdout)["url"]
+        logger.info(f"Scan URL: {build_url}")
+        sys.exit(0)
+
+    sys.exit(1)


### PR DESCRIPTION
... to perform a scan through OpenScanHub.

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.

<!-- notes for reviewers -->

Kerberos login would require `dns_canonicalize_hostname = false` in `/etc/krb5.conf`. Related link: https://fedoraproject.org/wiki/Infrastructure/Kerberos#Extra_info_for_Infrastructure_people

Instructions to install `osh-cli` are given in https://fedoraproject.org/wiki/OpenScanHub. 

Command to perform a full build: `packit scan-in-osh`

Command to perform a differential build: `packit scan-in-osh --base-srpm=<path_to_old_srpm`


<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

openscanhub/fedora-infra#54

There is a [review request](https://bugzilla.redhat.com/show_bug.cgi?id=2275304) to add `osh-cli` to the official Fedora repositories.

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

Add a `scan-in-osh` subcommand in the CLI to perform a scan through OpenScanHub. By default, it performs a full scan of the packages and a differential scan can be performed through `--base-srpm` option.

RELEASE NOTES END


EDIT: Add a reference to change in `/etc/krb5.conf`.