### PR TITLE
Skip ACLs syncing for other forges than Pagure

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -15,6 +15,7 @@ from bodhi.client.bindings import BodhiClientException
 from fedora.client import AuthError
 from lazy_object_proxy import Proxy
 from ogr.abstract import PullRequest
+from ogr.services.pagure import PagureProject
 from specfile.utils import NEVR
 
 from packit.base_git import PackitRepositoryBase
@@ -297,8 +298,8 @@ class DistGit(PackitRepositoryBase):
                     "Unable to create a fork of repository "
                     f"{self.local_project.git_project.full_repo_name}",
                 )
-            if sync_acls:
-                # synchronize ACLs between original repo and fork
+            if sync_acls and isinstance(self.local_project.git_project, PagureProject):
+                # synchronize ACLs between original repo and fork for Pagure
                 self.sync_acls(self.local_project.git_project, fork)
             fork_urls = fork.get_git_urls()
             self.local_project.git_repo.create_remote(

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -14,6 +14,7 @@ from typing import Optional, Union
 
 import git
 from lazy_object_proxy import Proxy
+from ogr.services.pagure import PagureProject
 
 from packit.actions import ActionName
 from packit.base_git import PackitRepositoryBase
@@ -154,8 +155,11 @@ class Upstream(PackitRepositoryBase):
                     # ogr is awesome! if you want to fork your own repo, you'll get it!
                     project = self.local_project.git_project.get_fork(create=True)
 
-                if sync_acls:
-                    # synchronize ACLs between original repo and fork
+                if sync_acls and isinstance(
+                    self.local_project.git_project,
+                    PagureProject,
+                ):
+                    # synchronize ACLs between original repo and fork for Pagure
                     self.sync_acls(self.local_project.git_project, project)
 
                 fork_username = project.namespace


### PR DESCRIPTION
For GitLab, the maintainers should be able to push to the PR by default without the need to sync the ACLs.
Fixes packit/packit-service#2429


<!-- release notes footer -->

RELEASE NOTES BEGIN

We have fixed the syncing of ACLs for `propose-downtream` for CentOS Stream.

RELEASE NOTES END
