### PR TITLE
fix(action): pass promised variables to ‹post-upstream-clone›

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -252,9 +252,9 @@ class PackitAPI:
 
         return self.config.pkg_tool
 
-    def common_action_env(self, version: Optional[str] = None) -> dict[str, str]:
+    def common_env(self, version: Optional[str] = None) -> dict[str, str]:
         """
-        Constructs an environment with vairables that are shared across multiple
+        Constructs an environment with variables that are shared across multiple
         different actions.
 
         Exposed environment variables:
@@ -397,7 +397,7 @@ class PackitAPI:
 
         if self.up.actions_handler.with_action(
             action=ActionName.prepare_files,
-            env=self.common_action_env(version=version),
+            env=self.common_env(version=version),
         ):
             synced_files = self._prepare_files_to_sync(
                 synced_files=synced_files,
@@ -408,7 +408,7 @@ class PackitAPI:
         sync_files(synced_files)
         if upstream_ref and self.up.actions_handler.with_action(
             action=ActionName.create_patches,
-            env=self.common_action_env(version=version),
+            env=self.common_env(version=version),
         ):
             patches = self.up.create_patches(
                 upstream=upstream_ref,
@@ -1082,7 +1082,7 @@ The first dist-git commit to be synced is '{short_hash}'.
 
             self.up.actions_handler.run_action(
                 actions=ActionName.post_upstream_clone,
-                env=self.common_action_env(version=version),
+                env=self.common_env(version=version),
             )
 
             # compare versions here because users can mangle with specfile in
@@ -1105,7 +1105,7 @@ The first dist-git commit to be synced is '{short_hash}'.
 
             self.up.actions_handler.run_action(
                 actions=ActionName.pre_sync,
-                env=self.common_action_env(version=version),
+                env=self.common_env(version=version),
             )
             if not use_downstream_specfile:
                 self.up.specfile.reload()
@@ -1149,7 +1149,7 @@ The first dist-git commit to be synced is '{short_hash}'.
                     if resolved_bugs
                     else "",
                 }
-                | self.common_action_env(version),
+                | self.common_env(version),
             )
 
             commit_title, commit_description = get_commit_message_from_action(
@@ -1730,7 +1730,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         """
         self.up.actions_handler.run_action(
             actions=ActionName.post_upstream_clone,
-            env=self.common_action_env(),
+            env=self.common_env(),
         )
 
         if update_release is None:
@@ -1840,7 +1840,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         """
         self.up.actions_handler.run_action(
             actions=ActionName.post_upstream_clone,
-            env=self.common_action_env(),
+            env=self.common_env(),
         )
 
         try:

--- a/packit/api.py
+++ b/packit/api.py
@@ -1693,7 +1693,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         """
         self.up.actions_handler.run_action(
             actions=ActionName.post_upstream_clone,
-            env=self.up.package_config.get_package_names_as_env(),
+            env=self.sync_release_env(),
         )
 
         if update_release is None:
@@ -1803,7 +1803,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         """
         self.up.actions_handler.run_action(
             actions=ActionName.post_upstream_clone,
-            env=self.up.package_config.get_package_names_as_env(),
+            env=self.sync_release_env(),
         )
 
         try:

--- a/packit/api.py
+++ b/packit/api.py
@@ -252,6 +252,7 @@ class PackitAPI:
 
         return self.config.pkg_tool
 
+    # [TODO] Rename to something more reasonable
     def sync_release_env(self, version: Optional[str] = None):
         if self.config.command_handler == RunCommandType.sandcastle:
             exec_dir = Path(self._get_sandcastle_exec_dir())
@@ -274,8 +275,12 @@ class PackitAPI:
             }
         else:
             env = {
-                "PACKIT_DOWNSTREAM_REPO": str(self.dg.local_project.working_dir),
-                "PACKIT_UPSTREAM_REPO": str(self.up.local_project.working_dir),
+                variable_name: str(repo.local_project.working_dir)
+                for variable_name, repo in (
+                    ("PACKIT_DOWNSTREAM_REPO", self.dg),
+                    ("PACKIT_UPSTREAM_REPO", self.up),
+                )
+                if repo._local_project is not None
             }
         if version:
             env["PACKIT_PROJECT_VERSION"] = version

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -42,6 +42,7 @@ logger = getLogger(__name__)
 class PackitRepositoryBase:
     # mypy complains when this is a property
     local_project: LocalProject
+    _local_project: Optional[LocalProject]
 
     def __init__(
         self,

--- a/plans/full.fmf
+++ b/plans/full.fmf
@@ -1,6 +1,6 @@
 summary: Unit, integration & functional tests.
 discover+:
-  filter: tier:1
+  filter: tag:full
 adjust:
   - when: "initiator == packit"
     because: "have the latest builds of ogr and specfile available for upstream test jobs"

--- a/tests/full.fmf
+++ b/tests/full.fmf
@@ -38,7 +38,7 @@ component:
   - packit
 tier: 1
 tag:
-  - basic
+  - full
 
 test: pytest-3 -v $TEST_TARGET
 duration: 30m
@@ -49,7 +49,11 @@ duration: 30m
     Custom tests that are useful for debugging as it is much easier to override
     the ‹TEST_TARGET› environment variable, disabled in CI as it is split into
     the separate test suites.
-  enabled: false
+  tag: manual
+  adjust:
+    - when: initiator != human
+      enabled: false
+      because: "This test suite is for manually specifying the target and to be run locally"
 
 /unit:
   summary: Unit tests

--- a/tests/full.fmf
+++ b/tests/full.fmf
@@ -42,5 +42,29 @@ tag:
 
 test: pytest-3 -v $TEST_TARGET
 duration: 30m
-environment:
-  TEST_TARGET: .
+
+/custom-target:
+  summary: Custom tests
+  description: |
+    Custom tests that are useful for debugging as it is much easier to override
+    the ‹TEST_TARGET› environment variable, disabled in CI as it is split into
+    the separate test suites.
+  enabled: false
+
+/unit:
+  summary: Unit tests
+  order: 1
+  environment+:
+    TEST_TARGET: unit/
+
+/integration:
+  summary: Integration tests
+  order: 2
+  environment+:
+    TEST_TARGET: integration/
+
+/functional:
+  summary: Functional tests
+  order: 3
+  environment+:
+    TEST_TARGET: functional/

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -202,14 +202,14 @@ def test_sync_release_create_sync_note(api_mock):
     api_mock.sync_release(versions=["1.1"], dist_git_branch="_")
 
 
-def test_sync_release_env(api_mock):
-    env = api_mock.sync_release_env()
+def test_common_action_env(api_mock):
+    env = api_mock.common_action_env()
     assert env == {
         "PACKIT_DOWNSTREAM_REPO": "/mock_dir/sandcastle/dist-git",
         "PACKIT_UPSTREAM_REPO": "/mock_dir/sandcastle/local-project",
     }
     api_mock.config.command_handler = RunCommandType.sandcastle
-    env = api_mock.sync_release_env()
+    env = api_mock.common_action_env()
     assert env == {
         "PACKIT_DOWNSTREAM_REPO": "/mock_dir/sandcastle/sandcastle-exec-dir/dist-git",
         "PACKIT_UPSTREAM_REPO": "/mock_dir/sandcastle/sandcastle-exec-dir/local-project",

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -202,14 +202,14 @@ def test_sync_release_create_sync_note(api_mock):
     api_mock.sync_release(versions=["1.1"], dist_git_branch="_")
 
 
-def test_common_action_env(api_mock):
-    env = api_mock.common_action_env()
+def test_common_env(api_mock):
+    env = api_mock.common_env()
     assert env == {
         "PACKIT_DOWNSTREAM_REPO": "/mock_dir/sandcastle/dist-git",
         "PACKIT_UPSTREAM_REPO": "/mock_dir/sandcastle/local-project",
     }
     api_mock.config.command_handler = RunCommandType.sandcastle
-    env = api_mock.common_action_env()
+    env = api_mock.common_env()
     assert env == {
         "PACKIT_DOWNSTREAM_REPO": "/mock_dir/sandcastle/sandcastle-exec-dir/dist-git",
         "PACKIT_UPSTREAM_REPO": "/mock_dir/sandcastle/sandcastle-exec-dir/local-project",


### PR DESCRIPTION
We have promised in docs to pass the same variables as in the release-synchronization environment, but we don't.

This has been discovered on pre-DevConf.cz 2024 workshop by @vashirov

<!-- TODO list -->

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.
- [x] ~~Probably rename the `.sync_release_env` to something more reasonable~~
   Can't come up with a reasonable name…
- [ ] Test before merge.

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

<!-- release notes footer -->

RELEASE NOTES BEGIN

We have fixed a bug that caused inconsistency between the promised environment variables (from the docs) and the environment that has been actually provided. Now you should have access to `PACKIT_UPSTREAM_REPO` and `PACKIT_DOWNSTREAM_REPO`, if they have been cloned already, in the `post-upstream-clone` action.

RELEASE NOTES END
