### PR TITLE
Introduce config option for disabling issue creation

### DIFF
--- a/packit/config/notifications.py
+++ b/packit/config/notifications.py
@@ -17,6 +17,13 @@ class FailureCommentNotificationsConfig:
         self.message = message
 
 
+class FailureIssueNotificationsConfig:
+    """Configuration of the failure issue for upstream."""
+
+    def __init__(self, create: bool = True):
+        self.create = create
+
+
 class NotificationsConfig:
     """Configuration of notifications."""
 
@@ -24,6 +31,8 @@ class NotificationsConfig:
         self,
         pull_request: Optional[PullRequestNotificationsConfig] = None,
         failure_comment: Optional[FailureCommentNotificationsConfig] = None,
+        failure_issue: Optional[FailureIssueNotificationsConfig] = None,
     ):
         self.pull_request = pull_request or PullRequestNotificationsConfig()
         self.failure_comment = failure_comment or FailureCommentNotificationsConfig()
+        self.failure_issue = failure_issue or FailureIssueNotificationsConfig()

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -36,6 +36,7 @@ from packit.config.job_config import (
 )
 from packit.config.notifications import (
     FailureCommentNotificationsConfig,
+    FailureIssueNotificationsConfig,
     NotificationsConfig,
     PullRequestNotificationsConfig,
 )
@@ -186,11 +187,22 @@ class FailureCommentNotificationsSchema(Schema):
         return FailureCommentNotificationsConfig(**data)
 
 
+class FailureIssueNotificationsSchema(Schema):
+    """Configuration of createing issues in upstream."""
+
+    create = fields.Bool(default=True)
+
+    @post_load
+    def make_instance(self, data, **kwargs):
+        return FailureIssueNotificationsConfig(**data)
+
+
 class NotificationsSchema(Schema):
     """Configuration of notifications."""
 
     pull_request = fields.Nested(PullRequestNotificationsSchema)
     failure_comment = fields.Nested(FailureCommentNotificationsSchema)
+    failure_issue = fields.Nested(FailureIssueNotificationsSchema)
 
     @post_load
     def make_instance(self, data, **kwargs):

--- a/tests/unit/config/test_package_config.py
+++ b/tests/unit/config/test_package_config.py
@@ -1730,6 +1730,7 @@ def test_notifications_section():
         repo_name="package",
     )
     assert not pc.notifications.pull_request.successful_build
+    assert pc.notifications.failure_issue.create
     assert pc.notifications.failure_comment.message is None
 
 
@@ -1743,7 +1744,20 @@ def test_notifications_section_failure_comment_message():
         repo_name="package",
     )
     assert not pc.notifications.pull_request.successful_build
+    assert pc.notifications.failure_issue.create
     assert pc.notifications.failure_comment.message == message
+
+
+def test_notifications_section_failure_issue_create_false():
+    pc = PackageConfig.get_from_dict(
+        {
+            "specfile_path": "package.spec",
+            "notifications": {"failure_issue": {"create": False}},
+        },
+        repo_name="package",
+    )
+    assert not pc.notifications.pull_request.successful_build
+    assert not pc.notifications.failure_issue.create
 
 
 def test_test_command_labels():


### PR DESCRIPTION
Introduce new config option notifications.failure_issue.create that defaults to True.
Needed for packit/packit-service#2416


RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
