### PR TITLE
Pass cache from LocalProjectBuilder to LocalProject

### DIFF
--- a/packit/local_project.py
+++ b/packit/local_project.py
@@ -1083,5 +1083,6 @@ class LocalProjectBuilder:
             merge_pr=merge_pr,
             target_branch=target_branch,
             refresh=False,
+            cache=self._cache,
             **state_dict,
         )


### PR DESCRIPTION
It can be used later on, so it should be passed and initialised.

Fixes #2340

