### PR TITLE
feat: add obs build support

### DIFF
--- a/.github/workflows/obs-build-smoke-test.yml
+++ b/.github/workflows/obs-build-smoke-test.yml
@@ -1,0 +1,40 @@
+name: build in-obs smoke test
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+  workflow_dispatch:
+
+jobs:
+  build-packit-in-obs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - name: Create osc config
+        env:
+          OBS_USERNAME: ${{ secrets.OBS_USERNAME }}
+          OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}
+
+        run: |
+          mkdir -p $HOME/.config/osc/
+          cat << EOF > $HOME/.config/osc/oscrc
+          [general]
+          apiurl=https://api.opensuse.org
+          [https://api.opensuse.org]
+          user=$OBS_USERNAME
+          pass=$OBS_PASSWORD
+          credentials_mgr_class=osc.credentials.PlaintextConfigFileCredentialsManager
+          EOF
+
+      - name: build_packit
+        run: |
+          sudo apt-get install -y libkrb5-dev rpm python3-rpm
+          pip install rpm hatch
+          python -m pip install build
+          pip3 install --user --editable .
+          packit build in-obs --targets fedora-rawhide-aarch64,fedora-rawhide-x86_64,opensuse-leap-15.6-x86_64,opensuse-tumbleweed-x86_64,opensuse-tumbleweed-aarch64 --no-wait

--- a/packit/api.py
+++ b/packit/api.py
@@ -74,7 +74,7 @@ from packit.source_git import SourceGitGenerator
 from packit.status import Status
 from packit.sync import SyncFilesItem, sync_files
 from packit.upstream import GitUpstream, NonGitUpstream, Upstream
-from packit.utils import commands
+from packit.utils import commands, obs_helper
 from packit.utils.bodhi import get_bodhi_client
 from packit.utils.changelog_helper import ChangelogHelper
 from packit.utils.extensions import assert_existence
@@ -177,6 +177,7 @@ class PackitAPI:
         self._up: Optional[Upstream] = None
         self._dg: Optional[DistGit] = None
         self._copr_helper: Optional[CoprHelper] = None
+        self.obs_helper = obs_helper
         self._kerberos_initialized = False
 
     def __repr__(self):
@@ -189,6 +190,7 @@ class PackitAPI:
             f"up='{self.up}', "
             f"dg='{self.dg}', "
             f"copr_helper='{self.copr_helper}', "
+            f"obs_helper='{self.obs_helper}', "
             f"stage='{self.stage}')"
         )
 
@@ -2188,6 +2190,37 @@ The first dist-git commit to be synced is '{short_hash}'.
             return None
 
         return cmd_result.stdout
+
+    def run_obs_build(
+        self,
+        build_dir: str,
+        package_name: str,
+        project_name: str,
+        upstream_ref: Optional[str],
+        wait: bool = False,
+    ):
+        """
+        Commit a build to the Open Build Service
+        """
+
+        # Initialise project directory
+        package_dir = self.obs_helper.init_obs_project(
+            build_dir,
+            package_name,
+            project_name,
+        )
+        logger.info(f"build: dir: {build_dir}")
+        srpm = self.create_srpm(upstream_ref=upstream_ref, release_suffix="0")
+
+        # Commit srpm to OBS
+        self.obs_helper.commit_srpm_and_get_build_results(
+            srpm,
+            project_name,
+            package_name,
+            package_dir,
+            upstream_ref,
+            wait,
+        )
 
     def push_bodhi_update(self, update_alias: str):
         """Push selected bodhi update from testing to stable."""

--- a/packit/cli/build.py
+++ b/packit/cli/build.py
@@ -12,6 +12,7 @@ from packit.cli.builds.in_image_builder import in_image_builder
 from packit.cli.builds.koji_build import koji
 from packit.cli.builds.local_build import local
 from packit.cli.builds.mock_build import mock
+from packit.cli.builds.obs_build import obs
 
 logger = logging.getLogger(__name__)
 
@@ -34,3 +35,4 @@ build.add_command(koji)
 build.add_command(local)
 build.add_command(mock)
 build.add_command(in_image_builder)
+build.add_command(obs)

--- a/packit/cli/builds/obs_build.py
+++ b/packit/cli/builds/obs_build.py
@@ -1,0 +1,101 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+import os.path
+from tempfile import TemporaryDirectory
+from typing import Optional
+
+import click
+
+from packit.cli.types import LocalProjectParameter
+from packit.cli.utils import cover_packit_exception, get_packit_api, iterate_packages
+from packit.config import get_context_settings, pass_config
+from packit.config.config import Config
+from packit.config.package_config import PackageConfig
+from packit.constants import (
+    PACKAGE_LONG_OPTION,
+    PACKAGE_OPTION_HELP,
+    PACKAGE_SHORT_OPTION,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@click.command("in-obs", context_settings=get_context_settings())
+@click.option(
+    "--owner",
+    help="OBS user, owner of the project. (defaults to the username from the oscrc)",
+)
+@click.option(
+    "--project",
+    help="Project name to build in. It will be created if does not exist."
+    " It defaults to home:$owner:packit:$pkg",
+)
+@click.option(
+    "--targets",
+    help="Comma separated list of chroots to build in. (defaults to 'fedora-rawhide-x86_64')",
+    default="fedora-rawhide-x86_64",
+)
+@click.option(
+    "--description",
+    help="Description of the project to build in.",
+    default=None,
+)
+@click.option(
+    "--upstream-ref",
+    default=None,
+    help="Git ref of the last upstream commit in the current branch "
+    "from which packit should generate patches "
+    "(this option implies the repository is source-git).",
+)
+@click.option("--wait/--no-wait", default=True, help="Wait for the build to finish")
+@click.option(
+    PACKAGE_SHORT_OPTION,
+    PACKAGE_LONG_OPTION,
+    multiple=True,
+    help=PACKAGE_OPTION_HELP.format(action="build"),
+)
+@click.argument("path_or_url", type=LocalProjectParameter(), default=os.path.curdir)
+@pass_config
+@cover_packit_exception
+@iterate_packages
+def obs(
+    config: Config,
+    owner: Optional[str],
+    project: str,
+    targets: str,
+    description: Optional[str],
+    upstream_ref: Optional[str],
+    wait: bool,
+    package_config: PackageConfig,
+    path_or_url,
+) -> None:
+    """
+    Build selected project in OBS
+
+    Before Running this command, your opensuse user account and password needs to be
+    configured in osc configuration file ~/.config/osc/oscrc. This can be done by running `osc`.
+    """
+    api = get_packit_api(
+        config=config,
+        package_config=package_config,
+        local_project=path_or_url,
+    )
+
+    project_name, package_name = api.obs_helper.create_obs_project(
+        owner=owner,
+        package_config=package_config,
+        project=project,
+        targets=targets,
+        description=description,
+    )
+
+    with TemporaryDirectory() as tmp_dir:
+        api.run_obs_build(
+            build_dir=tmp_dir,
+            package_name=package_name,
+            project_name=project_name,
+            wait=wait,
+            upstream_ref=upstream_ref,
+        )

--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -20,6 +20,10 @@ ALIASES: dict[str, list[str]] = {
     "fedora-latest-stable": ["fedora-39"],
     "fedora-branched": ["fedora-38", "fedora-39"],
     "epel-all": ["epel-7", "epel-8", "epel-9"],
+    "opensuse-leap-all": (
+        leap_all := ["opensuse-leap-15.6", "opensuse-leap-15.5", "opensuse-leap-15.4"]
+    ),
+    "opensuse-all": ["opensuse-tumbleweed", *leap_all],
 }
 
 ARCHITECTURE_LIST: list[str] = [
@@ -79,7 +83,7 @@ def get_build_targets(*name: str, default: str = DEFAULT_VERSION) -> set[str]:
     names = list(name) or [default]
     possible_sys_and_versions: set[str] = set()
     for one_name in names:
-        name_split = one_name.rsplit("-", maxsplit=2)
+        name_split = one_name.rsplit("-", maxsplit=3)
         l_name_split = len(name_split)
 
         if l_name_split < 2:  # only one part
@@ -99,7 +103,8 @@ def get_build_targets(*name: str, default: str = DEFAULT_VERSION) -> set[str]:
             architecture = "x86_64"  # use the x86_64 as a default
 
         else:  # "name-version-architecture"
-            sys_name, version, architecture = name_split
+            sys_name, architecture = name_split[0], name_split[-1]
+            version = "-".join(name_split[1:-1])
             if architecture not in ARCHITECTURE_LIST:
                 # we don't know the architecture => probably wrongly parsed
                 # (e.g. "opensuse-leap-15.0")

--- a/packit/utils/obs_helper.py
+++ b/packit/utils/obs_helper.py
@@ -1,0 +1,456 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import logging
+import os
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from osc import conf, core
+
+from packit.config import PackageConfig
+from packit.config.aliases import DEPRECATED_TARGET_MAP
+
+logger = logging.getLogger(__name__)
+
+_API_URL = "https://api.opensuse.org"
+
+
+@dataclass(frozen=True)
+class XmlPathEntry:
+    """Representation of a path entry in the XML repository configuration of
+    OBS.
+
+
+    """
+
+    project: str
+    repository: str
+
+
+@dataclass(frozen=True)
+class OBSRepository:
+    """Minimal representation of a repository on OBS that is part of the project
+    meta configuration:
+
+    .. code-block:: xml
+
+       <repository name="images">
+         <path project="openSUSE:Factory" repository="containerfile"/>
+         <path project="openSUSE:Factory" repository="standard"/>
+         <arch>x86_64</arch>
+       </repository>
+
+    """
+
+    name: str
+    arch: list[str]
+    path: list[XmlPathEntry]
+
+
+def target_to_path(target: str) -> list[XmlPathEntry]:
+    """Converts a packit target name like ``fedora-rawhide-x86_64`` or
+    ``opensuse-leap-15.5`` to a list of xml path entries of the respective
+    projects on OBS. This function relies on the project setup on
+    build.opensuse.org and is not directly re-usable on other OBS instances.
+
+    """
+
+    target_split = target.split("-")
+    version, arch = target_split[-2:]
+    distro = "-".join(target_split[:-2])
+
+    if distro == "fedora":
+        if version == "rawhide":
+            return [XmlPathEntry(project="Fedora:Rawhide", repository="standard")]
+        return [
+            XmlPathEntry(project=f"Fedora:{version}", repository="standard"),
+            XmlPathEntry(project=f"Fedora:{version}", repository="update"),
+        ]
+
+    if distro == "epel":
+        if version == "9":
+            return [
+                XmlPathEntry(project=f"Fedora:EPEL:{version}", repository="stream"),
+            ]
+        if version in ("8", "7"):
+            return [
+                XmlPathEntry(project=f"Fedora:EPEL:{version}", repository="CentOS"),
+            ]
+
+    if distro == "opensuse-leap":
+        return [
+            XmlPathEntry(project=f"openSUSE:Leap:{version}", repository="standard"),
+        ]
+
+    if distro == "opensuse":
+        if arch == "x86_64":
+            return [XmlPathEntry(project="openSUSE:Factory", repository="snapshot")]
+        if arch in ("s390x", "aarch64", "ppc64le"):
+            postfix = {"s390x": "zSystem", "aarch64": "ARM", "ppc64le": "PowerPC"}[arch]
+            return [
+                XmlPathEntry(
+                    project=f"openSUSE:Factory:{postfix}",
+                    repository="standard",
+                ),
+            ]
+
+    raise ValueError(f"No preset available for {distro=}, {version=}, {arch=}")
+
+
+def targets_to_project_meta(
+    targets: list[str],
+    owner: str,
+    project_name: str,
+    description: Optional[str] = None,
+) -> ET.Element:
+    """Converts the list of packit targets (like `fedora-rawhide`) to a project
+    meta xml configuration for the respective project in OBS.
+
+    """
+    repos: list[OBSRepository] = []
+    for target in targets:
+        path = target_to_path(target)
+        arch = target.split("-")[-1]
+        name = target
+        added = False
+
+        for ind, repo in enumerate(repos):
+            if repo.path == path:
+                repos[ind] = OBSRepository(
+                    name=f"{repo.name}-{arch}",
+                    path=path,
+                    arch=[*repo.arch, arch],
+                )
+                added = True
+
+        if not added:
+            repos.append(OBSRepository(name=name, path=path, arch=[arch]))
+
+    root = ET.Element("project")
+    root.attrib["name"] = project_name
+
+    (title_elem := ET.Element("title")).text = "Packit project"
+    (descr_elem := ET.Element("description")).text = description or ""
+    (person_elem := ET.Element("person")).attrib["userid"] = owner
+    person_elem.attrib["role"] = "maintainer"
+
+    for elem in (title_elem, descr_elem, person_elem):
+        root.append(elem)
+
+    for repo in repos:
+        (repo_elem := ET.Element("repository")).attrib["name"] = repo.name
+
+        for path_entry in repo.path:
+            (path_elem := ET.Element("path")).attrib["project"] = path_entry.project
+            path_elem.attrib["repository"] = path_entry.repository
+            repo_elem.append(path_elem)
+
+        for arch in repo.arch:
+            (arch_elem := ET.Element("arch")).text = arch
+            repo_elem.append(arch_elem)
+
+        root.append(repo_elem)
+
+    return root
+
+
+def parse_changelog_subject(line: str):
+    date: list[str]
+    author: list[str] = []
+    email: str = ""
+    version: str = ""
+
+    toks = [tok.strip() for tok in line.split(" ") if tok.strip()]
+
+    toks.pop(0)  # Remove leading "*"
+    date = toks[:4]
+
+    del toks[:4]
+    for index, element in enumerate(toks):
+        if not element.startswith("<"):
+            author.append(element)
+        else:
+            email += element
+            del toks[: index + 1]
+            break
+
+    if toks and toks[0] == "-":
+        toks.pop(0)
+
+    if toks:
+        version = toks[0]
+
+    return date, author, email, version
+
+
+def format_changelog(changelog_str: str) -> str:
+    """Converts spec changelog to OBS .changes format"""
+    output: list[str] = []
+    changelog_time = "12:00:00 UTC"
+    changelog = changelog_str.splitlines()
+
+    version_pattern = re.compile(r"-\s[0-9]+[\.\-]*")  # Precompile regex
+
+    for line in changelog:
+        if not line.strip():
+            continue
+        if line.strip().startswith("*"):
+            if output:
+                output[-1] += "\n"
+
+            date, author, email, version = parse_changelog_subject(line)
+            date.insert(3, changelog_time)
+
+            output.append("-" * 68)  # Set demarcator
+            output.append(f"{' '.join(date)} - {' '.join(author)} {email}\n")
+            if version:
+                output.append(f"- {version}")
+        else:
+            if version_pattern.match(line):  # Match version line
+                output.append(line)
+            else:
+                output.append(f"  {line}")
+
+    return "\n".join(output)
+
+
+def create_changes_file(package_dir: Path) -> None:
+    """
+    Creates a changelog file from a by copying the changelog section from the spec file.
+    Sets release to 0 since obs handles release numbers
+
+    Args:
+        package_dir (Path): Path to the directory containing the package spec file.
+
+    Returns:
+        None
+    """
+    specfile: str
+    content: str
+    release_line = "Release:    0"
+
+    for file in list(filter(os.path.isfile, os.listdir(package_dir))):
+        if file.endswith(".spec"):
+            specfile = file
+            break
+
+        if file.endswith(".changes"):
+            logger.info(".changes file already exists in package")
+            return
+
+    if not specfile:
+        raise ValueError("Cannot find spec file in package")
+
+    with open(specfile) as s_file:
+        content = s_file.read()
+
+    split_content = re.split(r"%changelog", content, flags=re.IGNORECASE)
+    if len(split_content) < 2:
+        logger.info("Project has no changelog")
+        return
+
+    specfile_content, changes_file_content = split_content[0], "".join(
+        split_content[1:],
+    )
+
+    with open(package_dir / specfile, "w") as s_file:
+        specfile_content = "\n".join(
+            [
+                release_line if line.lower().startswith("release:") else line
+                for line in specfile_content.splitlines()
+            ],
+        )
+        s_file.write(specfile_content)
+
+    changes_filename = package_dir / f"{specfile[:-5]}.changes"
+
+    changes_file_content = format_changelog(changes_file_content)
+
+    try:
+        with open(changes_filename, "w") as changes_file:
+            changes_file.write(changes_file_content)
+    except OSError as err:
+        logger.warn(f"Error writing {changes_filename} file: {err}")
+
+
+def create_package(project_name: str, package_name: str) -> None:
+    """Creates the package with the name ``package_name`` in the project
+    ``project_name`` on OBS. No sources are uploaded in the process.
+
+    """
+    (root := ET.Element("package")).attrib["name"] = package_name
+    root.attrib["project"] = project_name
+
+    (title := ET.Element("title")).text = f"The {package_name} package"
+    descr = ET.Element("description")
+
+    root.append(title)
+    root.append(descr)
+
+    package_url = core.makeurl(
+        _API_URL,
+        ["source", project_name, package_name, "_meta"],
+    )
+    metafile = core.metafile(package_url, ET.tostring(root))
+    metafile.sync()
+
+
+def create_obs_project(
+    project: str,
+    targets: str,
+    owner: Optional[str],
+    package_config: PackageConfig,
+    description: Optional[str],
+):
+    """
+    Creates a new OBS project and its associated package, ensuring only a single
+    package is included per call.
+
+    Args:
+        project (str, optional): The desired name for the OBS project. Defaults to None.
+        targets (str): Comma-separated list of build targets for the project. Defaults to "".
+        owner (Optional[str], optional): The owner of the project. Defaults to None.
+        package_config (PackageConfig): The config for the package to be included in the project.
+        description (Optional[str], optional): A description for the project. Defaults to None.
+
+    Returns:
+        Tuple[str, str]: A tuple containing the created project name and associated package name.
+
+    Raises:
+        ValueError: If the provided package_config contains multiple packages.
+    """
+    conf.get_config()
+    owner = owner or conf.config["api_host_options"][_API_URL]["user"]
+    project_name = project or f"home:{owner}:packit"
+
+    targets_list = targets.split(",")
+    for target in targets_list:
+        if target in DEPRECATED_TARGET_MAP:
+            logger.warning(
+                f"Target '{target}' is deprecated. "
+                f"Please use '{DEPRECATED_TARGET_MAP[target]}' instead.",
+            )
+
+    project_metadata = targets_to_project_meta(
+        targets=targets_list,
+        owner=owner,
+        project_name=project_name,
+        description=description,
+    )
+
+    logger.info(f"Using OBS project name = {project_name}")
+
+    project_url = core.makeurl(
+        _API_URL,
+        ["source", project_name, "_meta"],
+    )
+    metafile = core.metafile(project_url, ET.tostring(project_metadata))
+    metafile.sync()
+
+    package_names = list(package_config.packages.keys())
+
+    if len(package_names) != 1:
+        raise ValueError("Cannot handle multiple packages in package_config")
+
+    create_package(project_name, (package_name := package_names[0]))
+
+    return project_name, package_name
+
+
+def init_obs_project(
+    build_dir: str,
+    package_name: str,
+    project_name: str,
+) -> Path:
+    """
+    Initializes an Open Build Service (OBS) project.
+
+    Args:
+        build_dir (str): Base directory for the project (local path).
+        package_name (str): Name of the package to be built.
+        project_name (str): Name of the OBS project to create.
+
+    Returns:
+        Path: Path to the empty package directory within the OBS project.
+    """
+    core.Project.init_project(
+        _API_URL,
+        (prj_dir := Path(build_dir)),
+        project_name,
+    )
+
+    (pkg_dir := (prj_dir / package_name)).mkdir()
+    core.checkout_package(
+        _API_URL,
+        project_name,
+        package_name,
+        prj_dir=prj_dir,
+        pathname=pkg_dir,
+    )
+
+    pkg = core.Package(pkg_dir)
+
+    for fname in os.listdir(pkg_dir):
+        pkg.delete_file(fname)
+
+    return pkg_dir
+
+
+def commit_srpm_and_get_build_results(
+    srpm: Path,
+    project_name: str,
+    package_name: str,
+    package_dir: Path,
+    upstream_ref: Optional[str],
+    wait: bool,
+):
+    """
+    Commits an SRPM and retrieves build results.
+
+    This function unpacks the provided SRPM, and commits all files in the package_dir to OBS,
+    and optionally waits for and retrieves the build results.
+
+    Args:
+        srpm (Path): Path to the SRPM file.
+        project_name (str): Name of the OBS project the package belongs to.
+        package_name (str): Name of the package.
+        package_dir (Path): Path to the directory where the SRPM is unpacked.
+        upstream_ref (Optional[str]): Git ref of the last upstream commit in the current branch
+        from which packit should generate patches. Defaults to None.
+        wait (bool, optional): Whether to wait for and retrieve build results. Defaults to True.
+
+    Returns:
+        None
+    """
+    # don't use the files argument of unpack_srcrpm, it allows for shell
+    # injection unless sanitized carefully
+    core.unpack_srcrpm(str(srpm), package_dir)
+
+    create_changes_file(package_dir=package_dir)
+
+    core.addFiles(
+        [
+            str(package_dir / fname)
+            for fname in os.listdir(package_dir)
+            if os.path.isfile(package_dir / fname)
+        ],
+    )
+    pkg = core.Package(package_dir)
+    msg = "Created by packit"
+    if upstream_ref:
+        msg += f" from upstream revision {upstream_ref}"
+    pkg.commit(msg=msg)
+
+    # wait for the build result
+    if wait:
+        core.get_results(
+            _API_URL,
+            project_name,
+            package_name,
+            printJoin="",
+            wait=True,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,8 @@ dependencies = [
     "koji",
     "rpkg",
     "cachetools",
-    "python-bugzilla"
+    "python-bugzilla",
+    "osc >= 1.6.2, != 1.8.2",
 ]
 
 [project.urls]

--- a/tests/unit/config/test_config_aliases.py
+++ b/tests/unit/config/test_config_aliases.py
@@ -95,6 +95,25 @@ class TestGetBuildTargets:
                     "fedora-rawhide-x86_64",
                 },
             ),
+            (
+                "opensuse-leap-all",
+                {
+                    "opensuse-leap-15.5-x86_64",
+                    "opensuse-leap-15.4-x86_64",
+                    "opensuse-leap-15.3-x86_64",
+                },
+            ),
+            (
+                "opensuse-all",
+                {
+                    "opensuse-tumbleweed-x86_64",
+                    "opensuse-leap-15.5-x86_64",
+                    "opensuse-leap-15.4-x86_64",
+                    "opensuse-leap-15.3-x86_64",
+                },
+            ),
+            ("opensuse-leap-15.5-aarch64", {"opensuse-leap-15.5-aarch64"}),
+            ("opensuse-tumbleweed-ppc64le", {"opensuse-tumbleweed-ppc64le"}),
         ],
     )
     def test_get_build_targets(self, name, targets, mock_get_aliases):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -43,6 +43,17 @@ def mock_get_aliases():
             "fedora-stable": ["fedora-31", "fedora-32"],
             "fedora-development": ["fedora-33", "fedora-rawhide"],
             "epel-all": ["epel-6", "epel-7", "epel-8"],
+            "opensuse-leap-all": [
+                "opensuse-leap-15.5",
+                "opensuse-leap-15.4",
+                "opensuse-leap-15.3",
+            ],
+            "opensuse-all": [
+                "opensuse-tumbleweed",
+                "opensuse-leap-15.5",
+                "opensuse-leap-15.4",
+                "opensuse-leap-15.3",
+            ],
         },
     )
 

--- a/tests/unit/test_obs_build.py
+++ b/tests/unit/test_obs_build.py
@@ -1,0 +1,134 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from packit.utils import obs_helper
+
+_NAME = "home:me:packit"
+_TITLE = "Packit project"
+_PERSON = "me"
+
+head = f"""<project name="{_NAME}">
+  <title>{_TITLE}</title>
+  <description/>
+  <person userid="{_PERSON}" role="maintainer"/>
+"""
+tail = """</repository>
+</project>
+"""
+
+
+@pytest.mark.usefixtures("mock_get_aliases")
+class TestTargetsToProject:
+    @pytest.mark.parametrize(
+        "targets,project_meta",
+        [
+            (
+                ["fedora-rawhide-x86_64"],
+                head
+                + """
+<repository name="fedora-rawhide-x86_64">
+  <path project="Fedora:Rawhide" repository="standard"/>
+  <arch>x86_64</arch>
+"""
+                + tail,
+            ),
+            (
+                ["fedora-rawhide-x86_64", "fedora-rawhide-aarch64"],
+                head
+                + """
+<repository name="fedora-rawhide-x86_64-aarch64">
+  <path project="Fedora:Rawhide" repository="standard"/>
+  <arch>x86_64</arch>
+  <arch>aarch64</arch>
+"""
+                + tail,
+            ),
+            (
+                [
+                    "fedora-rawhide-x86_64",
+                    "opensuse-leap-15.5-x86_64",
+                    "fedora-rawhide-aarch64",
+                    "opensuse-leap-15.5-ppc64le",
+                    "opensuse-tumbleweed-x86_64",
+                ],
+                head
+                + """
+<repository name="fedora-rawhide-x86_64-aarch64">
+  <path project="Fedora:Rawhide" repository="standard"/>
+  <arch>x86_64</arch>
+  <arch>aarch64</arch>
+</repository>
+<repository name="opensuse-leap-15.5-x86_64-ppc64le">
+  <path project="openSUSE:Leap:15.5" repository="standard"/>
+  <arch>x86_64</arch>
+  <arch>ppc64le</arch>
+</repository>
+<repository name="opensuse-tumbleweed-x86_64">
+  <path project="openSUSE:Factory" repository="snapshot"/>
+  <arch>x86_64</arch>
+"""
+                + tail,
+            ),
+        ],
+    )
+    def test_targets_to_project(
+        self,
+        targets: list[str],
+        project_meta: str,
+        mock_get_aliases,
+    ) -> None:
+        assert ET.canonicalize(project_meta, strip_text=True) == ET.canonicalize(
+            ET.tostring(
+                obs_helper.targets_to_project_meta(
+                    targets,
+                    owner=_PERSON,
+                    project_name=f"home:{_PERSON}:packit",
+                ),
+            ),
+            strip_text=True,
+        )
+
+
+changelog = (
+    "* Thu Aug 01 2024 Packit Team <hello@packit.dev> - 0.100.1-1\n"
+    + "- New upstream release 0.100.1\n"
+    + "* Mon Jul 29 2024 Packit Team <hello@packit.dev> - 0.100.0-1\n"
+    + "- New upstream release 0.100.0\n"
+    + "* Fri May  2 2003 Elliot Lee <sopwith@redhat.com>\n"
+    + "- Add emacs-21.3-ppc64.patch\n"
+    + "* Fri Jun 23 2006 Jesse Keating <jkeating@redhat.com> 0.6-4\n"
+    + "- And fix the link syntax.\n"
+    + "* Fri Jun 23 2006 Jesse Keating <jkeating@redhat.com>\n"
+    + "- 0.6-4\n"
+    + "- And fix the link syntax."
+)
+
+obs_changelog = (
+    "--------------------------------------------------------------------\n"
+    + "Thu Aug 01 12:00:00 UTC 2024 - Packit Team <hello@packit.dev>\n\n"
+    + "- 0.100.1-1\n"
+    + "  - New upstream release 0.100.1\n\n"
+    + "--------------------------------------------------------------------\n"
+    + "Mon Jul 29 12:00:00 UTC 2024 - Packit Team <hello@packit.dev>\n\n"
+    + "- 0.100.0-1\n"
+    + "  - New upstream release 0.100.0\n\n"
+    + "--------------------------------------------------------------------\n"
+    + "Fri May 2 12:00:00 UTC 2003 - Elliot Lee <sopwith@redhat.com>\n\n"
+    + "  - Add emacs-21.3-ppc64.patch\n\n"
+    + "--------------------------------------------------------------------\n"
+    + "Fri Jun 23 12:00:00 UTC 2006 - Jesse Keating <jkeating@redhat.com>\n\n"
+    + "- 0.6-4\n"
+    + "  - And fix the link syntax.\n\n"
+    + "--------------------------------------------------------------------\n"
+    + "Fri Jun 23 12:00:00 UTC 2006 - Jesse Keating <jkeating@redhat.com>\n\n"
+    + "- 0.6-4\n"
+    + "  - And fix the link syntax."
+)
+
+
+def test_format_changelog_to_obs_format():
+    assert obs_changelog == obs_helper.format_changelog(changelog)


### PR DESCRIPTION
Adds support for building rpms in the open build service. This pr builds off the work done by @dcermak https://github.com/packit/packit/pull/2067.

I somehow broke the branch I used for the previous pr #2337 

RELEASE NOTES BEGIN

Thanks to the work of [Bryan Elee](https://github.com/rxbryan) (as part of his Google Summer of Code work), there is a new `packit build in-obs` CLI command to trigger a build in [OBS](https://build.opensuse.org/). Please, try it and let us know how it works and if you find it useful.

RELEASE NOTES END