### PR TITLE
Report Copr Internal Server Error to user

### DIFF
--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -230,10 +230,21 @@ class CoprHelper:
                 exist_ok=True,
             )
         except (CoprException, CoprRequestException) as ex:
-            error = (
-                f"Cannot create a new Copr project "
-                f"(owner={owner} project={project} chroots={chroots}): {ex}"
-            )
+            response_status_code = ex.result.__response__.status_code
+            response_reason = ex.result.__response__.reason
+            if response_status_code >= 500:
+                error = (
+                    f"Packit received HTTP {response_status_code} {response_reason} "
+                    "from Copr Service. "
+                    "Check the Copr status page: https://copr.fedorainfracloud.org/status/stats/, "
+                    "or ask for help in Fedora Build System matrix channel https://matrix.to/#/#buildsys:fedoraproject.org."
+                )
+            else:
+                error = (
+                    f"Cannot create a new Copr project "
+                    f"(owner={owner} project={project} chroots={chroots}): {ex}. "
+                    f"Copr HTTP response is {response_status_code} {response_reason}."
+                )
             logger.error(error)
             logger.error(ex.result)
             raise PackitCoprProjectException(error) from ex


### PR DESCRIPTION
<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.

<!-- notes for reviewers -->

Probably we should also suggest a change in copr client library to be able to access `error status codes` without accessing a private attribute, WDYT?

Fixes packit/packit-service#2459
