### PR TITLE
Allow pull-from-upstream for non-git upstreams

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -72,7 +72,7 @@ from packit.patches import PatchGenerator
 from packit.source_git import SourceGitGenerator
 from packit.status import Status
 from packit.sync import SyncFilesItem, sync_files
-from packit.upstream import Upstream
+from packit.upstream import GitUpstream
 from packit.utils import commands
 from packit.utils.bodhi import get_bodhi_client
 from packit.utils.changelog_helper import ChangelogHelper
@@ -171,7 +171,7 @@ class PackitAPI:
         self.stage = stage
         self._dist_git_clone_path: Optional[str] = dist_git_clone_path
 
-        self._up: Optional[Upstream] = None
+        self._up: Optional[GitUpstream] = None
         self._dg: Optional[DistGit] = None
         self._copr_helper: Optional[CoprHelper] = None
         self._kerberos_initialized = False
@@ -190,9 +190,9 @@ class PackitAPI:
         )
 
     @property
-    def up(self) -> Upstream:
+    def up(self) -> GitUpstream:
         if self._up is None:
-            self._up = Upstream(
+            self._up = GitUpstream(
                 config=self.config,
                 package_config=self.package_config,
                 local_project=checkout_package_workdir(
@@ -1503,7 +1503,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         pr_title: str,
         pr_description: str,
         git_branch: str,
-        repo: Union[Upstream, DistGit],
+        repo: Union[GitUpstream, DistGit],
         sync_acls: bool = False,
     ) -> PullRequest:
         # the branch may already be up, let's push forcefully
@@ -2360,7 +2360,7 @@ The first dist-git commit to be synced is '{short_hash}'.
                 f"The `mock` command failed:\n{ex}",
             ) from ex
 
-        rpms = Upstream._get_rpms_from_mock_output(cmd_result.stderr)
+        rpms = GitUpstream._get_rpms_from_mock_output(cmd_result.stderr)
         return [Path(rpm) for rpm in rpms]
 
     def submit_vm_image_build(

--- a/packit/api.py
+++ b/packit/api.py
@@ -1200,6 +1200,7 @@ The first dist-git commit to be synced is '{short_hash}'.
             self.dg.refresh_specfile()
             self.dg.local_project.git_repo.git.reset("--hard", "HEAD")
             self.dg.local_project.git_repo.git.clean("-xdf")
+            self.up.clean_working_dir()
 
         return pr
 

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -56,12 +56,14 @@ def sync_release(
     package_config,
     resolved_bugs,
     sync_acls,
+    check_for_non_git_upstream=False,
 ):
     api = get_packit_api(
         config=config,
         package_config=package_config,
         dist_git_path=dist_git_path,
         local_project=path_or_url,
+        check_for_non_git_upstream=check_for_non_git_upstream,
     )
     if pr is None:
         pr = api.package_config.create_pr
@@ -255,4 +257,5 @@ def pull_from_upstream(
         package_config=package_config,
         resolved_bugs=resolve_bug,
         sync_acls=sync_acls,
+        check_for_non_git_upstream=True,
     )

--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -253,6 +253,7 @@ def get_packit_api(
     dist_git_path: Optional[str] = None,
     job_config_index: Optional[int] = None,
     job_type: Optional[JobType] = None,
+    check_for_non_git_upstream: Optional[bool] = False,
 ) -> PackitAPI:
     """
     Load the package config, set other options and return the PackitAPI
@@ -265,6 +266,13 @@ def get_packit_api(
             try_local_dir_last=True,
             package_config_path=config.package_config_path,
         )
+
+    if check_for_non_git_upstream and package_config.upstream_project_url is None:
+        logger.debug("Upstream will be treated as non-git.")
+        non_git_upstream = True
+    else:
+        non_git_upstream = False
+
     logger.debug(f"job_config_index: {job_config_index}")
     if job_config_index is not None and isinstance(package_config, PackageConfig):
         if job_config_index >= len(package_config.jobs):
@@ -291,6 +299,7 @@ def get_packit_api(
             upstream_local_project=None,
             downstream_local_project=local_project,
             dist_git_clone_path=dist_git_path,
+            non_git_upstream=non_git_upstream,
         )
 
     if not local_project.git_repo:
@@ -342,6 +351,7 @@ def get_packit_api(
         upstream_local_project=lp_upstream,
         downstream_local_project=lp_downstream,
         dist_git_clone_path=dist_git_path,
+        non_git_upstream=non_git_upstream,
     )
 
 

--- a/packit/command_handler.py
+++ b/packit/command_handler.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import logging
+import tempfile
 from os import getenv
 from pathlib import Path
 from typing import Optional, Union
@@ -25,9 +26,16 @@ class CommandHandler:
 
     name: RunCommandType
 
-    def __init__(self, local_project: LocalProject, config: Config):
+    def __init__(self, config: Config, local_project: Optional[LocalProject] = None):
         self.local_project = local_project
         self.config = config
+
+    @property
+    def working_dir(self) -> Union[str, Path]:
+        if self.local_project:
+            return self.local_project.working_dir
+
+        return tempfile.mkdtemp()
 
     def run_command(
         self,
@@ -88,7 +96,7 @@ class LocalCommandHandler(CommandHandler):
     ) -> commands.CommandResult:
         return commands.run_command(
             cmd=command,
-            cwd=cwd or self.local_project.working_dir,
+            cwd=cwd or self.working_dir,
             output=return_output,
             env=env,
             print_live=print_live,
@@ -107,7 +115,7 @@ class SandcastleCommandHandler(CommandHandler):
 
     name = RunCommandType.sandcastle
 
-    def __init__(self, local_project: LocalProject, config: Config):
+    def __init__(self, config: Config, local_project: Optional[LocalProject] = None):
         super().__init__(local_project=local_project, config=config)
         self.local_project = local_project
         self.config = config
@@ -142,7 +150,10 @@ class SandcastleCommandHandler(CommandHandler):
                     # Do not mount repository cache when it's not used
                     self.config.repository_cache
                     and vol_spec_dict.get("path") == self.config.repository_cache
-                    and not self.local_project.cache.projects_cloned_using_cache
+                    and not (
+                        self.local_project
+                        and self.local_project.cache.projects_cloned_using_cache
+                    )
                 )
             ]
 
@@ -181,7 +192,7 @@ class SandcastleCommandHandler(CommandHandler):
     ) -> commands.CommandResult:
         from sandcastle.exceptions import SandcastleCommandFailed
 
-        cwd = cwd or Path(self.local_project.working_dir).relative_to(
+        cwd = cwd or Path(self.working_dir).relative_to(
             self.config.command_handler_work_dir,
         )
         logger.info(f"Running command: {' '.join(command)} on dir {cwd}")

--- a/packit/command_handler.py
+++ b/packit/command_handler.py
@@ -26,14 +26,23 @@ class CommandHandler:
 
     name: RunCommandType
 
-    def __init__(self, config: Config, local_project: Optional[LocalProject] = None):
+    def __init__(
+        self,
+        config: Config,
+        local_project: Optional[LocalProject] = None,
+        working_dir: Optional[Path] = None,
+    ):
         self.local_project = local_project
         self.config = config
+        self._working_dir = working_dir
 
     @property
     def working_dir(self) -> Union[str, Path]:
         if self.local_project:
             return self.local_project.working_dir
+
+        if self._working_dir:
+            return self._working_dir
 
         return tempfile.mkdtemp()
 

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -200,14 +200,14 @@ PACKAGE_OPTION_HELP = (
 
 SYNC_RELEASE_DEFAULT_COMMIT_DESCRIPTION = (
     "{resolved_bugs}Upstream tag: {upstream_tag}\n"
-    "Upstream commit: {upstream_commit}\n"
+    "{upstream_commit_info}\n"
     "\n"
     "Commit authored by Packit automation (https://packit.dev/)\n"
 )
 
 SYNC_RELEASE_PR_DESCRIPTION = (
     "Upstream tag: {upstream_tag_info}\n"
-    "Upstream commit: {upstream_commit_info}\n"
+    "{upstream_commit_info}\n"
     "{release_monitoring_info}"
     "{resolved_bugzillas_info}"
 )

--- a/packit/status.py
+++ b/packit/status.py
@@ -11,7 +11,7 @@ from packit.config.common_package_config import MultiplePackages
 from packit.copr_helper import CoprHelper
 from packit.distgit import DistGit
 from packit.exceptions import PackitException
-from packit.upstream import Upstream
+from packit.upstream import GitUpstream
 from packit.utils.bodhi import get_bodhi_client
 from packit.utils.koji_helper import KojiHelper
 
@@ -27,7 +27,7 @@ class Status:
         self,
         config: Config,
         package_config: MultiplePackages,
-        upstream: Upstream,
+        upstream: GitUpstream,
         distgit: DistGit,
     ):
         self.config = config

--- a/packit/status.py
+++ b/packit/status.py
@@ -11,7 +11,7 @@ from packit.config.common_package_config import MultiplePackages
 from packit.copr_helper import CoprHelper
 from packit.distgit import DistGit
 from packit.exceptions import PackitException
-from packit.upstream import GitUpstream
+from packit.upstream import Upstream
 from packit.utils.bodhi import get_bodhi_client
 from packit.utils.koji_helper import KojiHelper
 
@@ -27,7 +27,7 @@ class Status:
         self,
         config: Config,
         package_config: MultiplePackages,
-        upstream: GitUpstream,
+        upstream: Upstream,
         distgit: DistGit,
     ):
         self.config = config
@@ -87,7 +87,7 @@ class Status:
         :param number_of_releases: int
         :return: List
         """
-        if self.up.local_project.git_project is None:
+        if self.up.local_project is None or self.up.local_project.git_project is None:
             logger.info("We couldn't track any upstream releases.")
             return []
 
@@ -157,6 +157,10 @@ class Status:
         return updates
 
     def get_copr_builds(self, number_of_builds: int = 5) -> list:
-        return CoprHelper(upstream_local_project=self.up.local_project).get_copr_builds(
-            number_of_builds=number_of_builds,
+        return (
+            CoprHelper(upstream_local_project=self.up.local_project).get_copr_builds(
+                number_of_builds=number_of_builds,
+            )
+            if self.up.local_project
+            else []
         )

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -43,7 +43,7 @@ from packit.utils.versions import compare_versions
 logger = logging.getLogger(__name__)
 
 
-class Upstream(PackitRepositoryBase):
+class GitUpstream(PackitRepositoryBase):
     """interact with upstream project"""
 
     def __init__(
@@ -110,7 +110,7 @@ class Upstream(PackitRepositoryBase):
         if self._command_handler is None:
             self._command_handler = self.handler_kls(
                 # so that the local_project is evaluated only when needed
-                local_project=Proxy(partial(Upstream.local_project.__get__, self)),  # type: ignore
+                local_project=Proxy(partial(GitUpstream.local_project.__get__, self)),  # type: ignore
                 config=self.config,
             )
         return self._command_handler
@@ -770,7 +770,7 @@ class Upstream(PackitRepositoryBase):
                 f"The `rpmbuild` command failed:\n{ex}",
             ) from ex
 
-        rpms = Upstream._get_rpms_from_rpmbuild_output(out)
+        rpms = GitUpstream._get_rpms_from_rpmbuild_output(out)
         return [Path(rpm) for rpm in rpms]
 
     def create_rpms(self, rpm_dir: Union[str, Path, None] = None) -> list[Path]:
@@ -959,7 +959,7 @@ class Upstream(PackitRepositoryBase):
 class SRPMBuilder:
     def __init__(
         self,
-        upstream: Upstream,
+        upstream: GitUpstream,
         srpm_path: Union[Path, str, None] = None,
         srpm_dir: Union[Path, str, None] = None,
         ref: Optional[str] = None,
@@ -1211,7 +1211,7 @@ class SRPMBuilder:
 
 
 class Archive:
-    def __init__(self, upstream: Upstream, version: Optional[str] = None) -> None:
+    def __init__(self, upstream: GitUpstream, version: Optional[str] = None) -> None:
         """
         Creates an instance of `Archive`.
 

--- a/packit/utils/changelog_helper.py
+++ b/packit/utils/changelog_helper.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 class ChangelogHelper:
     def __init__(
         self,
-        upstream: "packit.upstream.GitUpstream",
+        upstream: "packit.upstream.Upstream",
         downstream: Optional[DistGit] = None,
         package_config: Optional[MultiplePackages] = None,
     ) -> None:
@@ -193,6 +193,10 @@ class ChangelogHelper:
             logger.warning(
                 f"Unable to find a spec file in downstream: {ex}, copying the one from upstream.",
             )
+            # non-git upstream
+            if not self.up.absolute_specfile_path:
+                raise
+
             shutil.copy2(
                 self.up.absolute_specfile_path,
                 self.dg.get_absolute_specfile_path(),

--- a/packit/utils/changelog_helper.py
+++ b/packit/utils/changelog_helper.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 class ChangelogHelper:
     def __init__(
         self,
-        upstream: "packit.upstream.Upstream",
+        upstream: "packit.upstream.GitUpstream",
         downstream: Optional[DistGit] = None,
         package_config: Optional[MultiplePackages] = None,
     ) -> None:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -27,7 +27,7 @@ from packit.constants import FROM_SOURCE_GIT_TOKEN
 from packit.distgit import DistGit
 from packit.local_project import CALCULATE, LocalProject, LocalProjectBuilder
 from packit.pkgtool import PkgTool
-from packit.upstream import Upstream
+from packit.upstream import GitUpstream
 from packit.utils.commands import cwd
 from packit.utils.repo import create_new_repo
 from tests.integration.utils import remove_gpg_key_pair
@@ -176,7 +176,7 @@ def mock_remote_functionality(distgit: Path, upstream: Path):
 
 @pytest.fixture()
 def mock_patching():
-    flexmock(Upstream).should_receive("create_patches").and_return(["patches"])
+    flexmock(GitUpstream).should_receive("create_patches").and_return(["patches"])
     flexmock(DistGit).should_receive("specfile_add_patches").with_args(["patches"])
 
 
@@ -266,7 +266,7 @@ def upstream_instance(upstream_and_remote, tmp_path):
         pc.upstream_project_url = str(u)
         lp = LocalProjectBuilder().build(working_dir=u, git_repo=CALCULATE)
 
-        ups = Upstream(c, pc, lp)
+        ups = GitUpstream(c, pc, lp)
         yield u, ups
 
 

--- a/tests/integration/test_source_git_synch_push.py
+++ b/tests/integration/test_source_git_synch_push.py
@@ -5,7 +5,7 @@ import pytest
 from flexmock import flexmock
 
 from packit.exceptions import PackitException
-from packit.upstream import Upstream
+from packit.upstream import GitUpstream
 
 
 def test_synch_push_and_up_repo_dirty(
@@ -66,11 +66,11 @@ def test_synch_push_one_commit(
 ):
     """Update upstream if dist-git has a new commit"""
 
-    flexmock(Upstream).should_receive("push_to_fork").and_return(
+    flexmock(GitUpstream).should_receive("push_to_fork").and_return(
         "main",
         "packit.dev",
     ).once()
-    flexmock(Upstream).should_receive("create_pull").and_return(None).once()
+    flexmock(GitUpstream).should_receive("create_pull").and_return(None).once()
 
     assert (
         "dist-git commit to be sync back"
@@ -98,11 +98,11 @@ def test_synch_push_two_commits(
         "",
     )
 
-    flexmock(Upstream).should_receive("push_to_fork").and_return(
+    flexmock(GitUpstream).should_receive("push_to_fork").and_return(
         "main",
         "packit.dev",
     ).once()
-    flexmock(Upstream).should_receive("create_pull").and_return(None).once()
+    flexmock(GitUpstream).should_receive("create_pull").and_return(None).once()
 
     commits = api_instance_sync_push.up.local_project.git_repo.iter_commits()
     commits = [c.summary for c in commits]

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -14,7 +14,7 @@ from packit.api import Config, PackitAPI
 from packit.config import parse_loaded_config
 from packit.distgit import DistGit
 from packit.local_project import LocalProject
-from packit.upstream import Upstream
+from packit.upstream import GitUpstream
 from tests.integration.conftest import mock_spec_download_remote_s
 from tests.spellbook import TARBALL_NAME
 
@@ -401,7 +401,9 @@ def test_local_update_generated_spec(
     u, d, api = api_instance
     mock_spec_download_remote_s(d)
     flexmock(api).should_receive("init_kerberos_ticket").at_least().once()
-    flexmock(Upstream).should_receive("get_latest_released_version").and_return("0.1.0")
+    flexmock(GitUpstream).should_receive("get_latest_released_version").and_return(
+        "0.1.0",
+    )
 
     # Simulate generation by moving the spec to a different location
     # We are checking two things:

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -167,6 +167,7 @@ def test_basic_local_update_use_downstream_specfile_non_git_upstream(
     subprocess.check_call(["git", "tag", "0.1.0", "-f"])
     mock_spec_download_remote_s(d)
     flexmock(api).should_receive("init_kerberos_ticket").at_least().once()
+    flexmock(api.up).should_receive("sync_files")
 
     api.sync_release(
         dist_git_branch="main",

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -148,6 +148,62 @@ def test_basic_local_update_use_downstream_specfile(
     assert changelog.count("0.1.0-1") == 1
 
 
+def test_basic_local_update_use_downstream_specfile_non_git_upstream(
+    cwd_upstream,
+    api_instance,
+    distgit_and_remote,
+    mock_remote_functionality_upstream,
+):
+    u, d, api = api_instance
+    api.non_git_upstream = True
+    api._up = None
+
+    # remove the upstream specfile and push the tag that will be checked out
+    u.joinpath("beer.spec").unlink()
+    subprocess.check_call(
+        ["git", "commit", "-m", "remove spec", "-a"],
+        cwd=str(u),
+    )
+    subprocess.check_call(["git", "tag", "0.1.0", "-f"])
+    mock_spec_download_remote_s(d)
+    flexmock(api).should_receive("init_kerberos_ticket").at_least().once()
+
+    api.sync_release(
+        dist_git_branch="main",
+        versions=["0.1.0"],
+        use_downstream_specfile=True,
+    )
+
+    assert (d / TARBALL_NAME).is_file()
+    spec = Specfile(d / "beer.spec")
+    assert spec.expanded_version == "0.1.0"
+    assert (d / "README.packit").is_file()
+    # assert that we have changelog entries for both versions
+    with spec.sections() as sections:
+        changelog = "\n".join(sections.changelog)
+    assert "0.0.0" in changelog
+    assert "0.1.0" in changelog
+
+    # do this second time to see whether the specfile is updated correctly
+    api.sync_release(
+        dist_git_branch="main",
+        versions=["0.1.0"],
+        use_downstream_specfile=True,
+    )
+
+    assert (d / TARBALL_NAME).is_file()
+    spec = Specfile(d / "beer.spec")
+    assert spec.expanded_version == "0.1.0"
+    assert (d / "README.packit").is_file()
+    # assert that we have changelog entries for both versions
+    with spec.sections() as sections:
+        changelog = "\n".join(sections.changelog)
+    assert "0.0.0" in changelog
+    assert "0.1.0" in changelog
+
+    assert changelog.count("0.1.0-1") == 1
+
+
 def test_basic_local_update_with_multiple_sources(
     cwd_upstream,
     api_instance,

--- a/tests/integration/test_upstream.py
+++ b/tests/integration/test_upstream.py
@@ -21,7 +21,7 @@ from packit.actions import ActionName
 from packit.config import Config, get_local_package_config
 from packit.exceptions import PackitSRPMException
 from packit.local_project import LocalProjectBuilder
-from packit.upstream import Archive, SRPMBuilder, Upstream
+from packit.upstream import Archive, GitUpstream, SRPMBuilder
 from packit.utils.commands import cwd
 from packit.utils.repo import create_new_repo
 from tests.spellbook import (
@@ -121,7 +121,7 @@ def test_get_version_no_version_tag(tmp_path):
         pc.upstream_project_url = str(u)
         lp = LocalProjectBuilder().build(working_dir=u)
 
-        ups = Upstream(c, pc, lp)
+        ups = GitUpstream(c, pc, lp)
 
     assert ups.get_specfile_version() == "2.1.1"
 
@@ -154,7 +154,7 @@ def test_set_spec_macro_source(tmp_path):
         pc.upstream_project_url = str(u)
         lp = LocalProjectBuilder().build(working_dir=u)
 
-        ups = Upstream(c, pc, lp)
+        ups = GitUpstream(c, pc, lp)
 
     expected_sources = ups.specfile.sources
     new_ver = "1.2.3"
@@ -189,7 +189,7 @@ def test_set_spec_ver_empty_changelog(tmp_path):
         pc.upstream_project_url = str(u)
         lp = LocalProjectBuilder().build(working_dir=u)
 
-        ups = Upstream(c, pc, lp)
+        ups = GitUpstream(c, pc, lp)
 
     new_ver = "1.2.3"
     ups.specfile.version = new_ver

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -12,7 +12,7 @@ import packit
 from packit.config import Config
 from packit.distgit import DistGit
 from packit.local_project import LocalProjectBuilder
-from packit.upstream import Upstream
+from packit.upstream import GitUpstream
 from tests.spellbook import CRONIE, get_test_config, initiate_git_repo
 
 
@@ -128,7 +128,7 @@ def local_project_mock(git_project_mock, git_repo_mock):
 
 @pytest.fixture
 def upstream_mock(local_project_mock, package_config_mock):
-    upstream = Upstream(
+    upstream = GitUpstream(
         config=get_test_config(),
         package_config=package_config_mock,
         local_project=LocalProjectBuilder().build(

--- a/tests/unit/test_base_git.py
+++ b/tests/unit/test_base_git.py
@@ -18,7 +18,7 @@ from packit.config import CommonPackageConfig, Config, PackageConfig, RunCommand
 from packit.config.sources import SourcesItem
 from packit.distgit import DistGit
 from packit.local_project import LocalProject, LocalProjectBuilder
-from packit.upstream import Upstream
+from packit.upstream import GitUpstream
 from packit.utils import commands
 from packit.utils.repo import create_new_repo
 from tests.spellbook import can_a_module_be_imported, initiate_git_repo
@@ -46,7 +46,7 @@ def distgit_with_actions():
 
 @pytest.fixture()
 def upstream_with_actions():
-    return Upstream(
+    return GitUpstream(
         config=flexmock(Config()),
         package_config=flexmock(
             PackageConfig(

--- a/tests/unit/test_upstream.py
+++ b/tests/unit/test_upstream.py
@@ -11,7 +11,7 @@ import packit
 from packit.actions import ActionName
 from packit.actions_handler import ActionsHandler
 from packit.exceptions import PackitException
-from packit.upstream import Archive, SRPMBuilder, Upstream
+from packit.upstream import Archive, GitUpstream, SRPMBuilder
 
 
 @pytest.fixture
@@ -90,7 +90,7 @@ def test_create_pull(upstream_mock, upstream_pr_mock, fork_username):
     ],
 )
 def test_get_commands_for_actions(action_config, result):
-    ups = Upstream(
+    ups = GitUpstream(
         package_config=flexmock(
             actions={ActionName.create_archive: action_config},
             synced_files=flexmock(),
@@ -327,7 +327,7 @@ def test_convert_version_to_tag(
     ),
 )
 def test_get_rpms_from_rpmbuild_output(output, expected):
-    assert Upstream._get_rpms_from_rpmbuild_output(output) == expected
+    assert GitUpstream._get_rpms_from_rpmbuild_output(output) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests_recording/testbase.py
+++ b/tests_recording/testbase.py
@@ -93,7 +93,7 @@ class PackitTest(unittest.TestCase):
     @property
     def upstream(self):
         if not self._upstream:
-            self._upstream = packit.upstream.Upstream(
+            self._upstream = packit.upstream.GitUpstream(
                 self.config,
                 self.pc,
                 local_project=self.lp,


### PR DESCRIPTION
TODO: 
- [x] change Upstream references to GitUpstream in packit-service
- [ ] document

Fixes #2147 


RELEASE NOTES BEGIN

`packit pull-from-upstream` now allows omitting `upstream_project_url` in the configuration in which case the interaction with the upstream repository is skipped during release syncing.

RELEASE NOTES END
