### PR TITLE
Allow dist_git_branches to be a dictionary

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -978,8 +978,8 @@ The first dist-git commit to be synced is '{short_hash}'.
             pr_description_footer: Footer for the PR description (used by packit-service)
             sync_acls: Whether to sync the ACLs of original repo and
                 fork when creating a PR from fork.
-            fast_forward_merge_branches: a list of branches that can be merged with --ff-only flag
-                using dist_git_branch as source branch (if any).
+            fast_forward_merge_branches: Set of branches `dist_git_branch` should be
+                fast-forward-merged into.
 
         Returns:
             The created (or existing if one already exists) PullRequest if

--- a/packit/api.py
+++ b/packit/api.py
@@ -886,6 +886,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         release_monitoring_project_id: Optional[int] = None,
         pr_description_footer: Optional[str] = None,
         sync_acls: Optional[bool] = False,
+        fast_forward_merge_branches: Optional[set[str]] = None,
     ) -> PullRequest:
         """Overload for type-checking; return PullRequest if create_pr=True."""
 
@@ -913,6 +914,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         release_monitoring_project_id: Optional[int] = None,
         pr_description_footer: Optional[str] = None,
         sync_acls: Optional[bool] = False,
+        fast_forward_merge_branches: Optional[set[str]] = None,
     ) -> None:
         """Overload for type-checking; return None if create_pr=False."""
 
@@ -939,6 +941,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         release_monitoring_project_id: Optional[int] = None,
         pr_description_footer: Optional[str] = None,
         sync_acls: Optional[bool] = False,
+        fast_forward_merge_branches: Optional[set[str]] = None,
     ) -> Optional[PullRequest]:
         """
         Update given package in dist-git
@@ -975,6 +978,8 @@ The first dist-git commit to be synced is '{short_hash}'.
             pr_description_footer: Footer for the PR description (used by packit-service)
             sync_acls: Whether to sync the ACLs of original repo and
                 fork when creating a PR from fork.
+            fast_forward_merge_branches: a list of branches that can be merged with --ff-only flag
+                using dist_git_branch as source branch (if any).
 
         Returns:
             The created (or existing if one already exists) PullRequest if
@@ -1195,6 +1200,18 @@ The first dist-git commit to be synced is '{short_hash}'.
                     repo=self.dg,
                     sync_acls=sync_acls,
                 )
+
+                if fast_forward_merge_branches:
+                    for ff_branch in fast_forward_merge_branches:
+                        pr_title = (
+                            title or f"Update {ff_branch} to upstream release {version}"
+                        )
+                        self.create_or_update_pr(
+                            pr_title=pr_title,
+                            pr_description=f"{pr_description}{pr_instructions}{footer}",
+                            target_branch=ff_branch,
+                            repo=self.dg,
+                        )
             else:
                 self.dg.push(refspec=f"HEAD:{dist_git_branch}")
         finally:
@@ -1541,6 +1558,36 @@ The first dist-git commit to be synced is '{short_hash}'.
                 fork_username=fork_username,
             )
 
+    def create_or_update_pr(
+        self,
+        pr_title: str,
+        pr_description: str,
+        target_branch: str,
+        repo: Union[GitUpstream, DistGit],
+    ) -> PullRequest:
+        pr = repo.existing_pr(
+            target_branch,
+            repo.local_project.ref,
+        )
+        if pr is None:
+            pr = repo.create_pull(
+                pr_title,
+                pr_description,
+                source_branch=repo.local_project.ref,
+                target_branch=target_branch,
+            )
+        else:
+            logger.debug(
+                f"PR already exists: {pr.url},"
+                f' updating title ("{pr_title}") and description',
+            )
+            try:
+                pr.update_info(pr_title, pr_description)
+            except PagureAPIException as exc:
+                logger.error(f"Update of existing PR {pr.url} failed: {exc}")
+                raise PackitException(f"Update of existing PR {pr.url} failed") from exc
+        return pr
+
     def push_and_create_pr(
         self,
         pr_title: str,
@@ -1555,28 +1602,12 @@ The first dist-git commit to be synced is '{short_hash}'.
         except PackitException as exc:
             logger.error(f"Push to fork failed: {exc}")
             raise
-        pr = repo.existing_pr(
-            git_branch,
-            repo.local_project.ref,
+        return self.create_or_update_pr(
+            pr_title,
+            pr_description,
+            target_branch=git_branch,
+            repo=repo,
         )
-        if pr is None:
-            pr = repo.create_pull(
-                pr_title,
-                pr_description,
-                source_branch=repo.local_project.ref,
-                target_branch=git_branch,
-            )
-        else:
-            logger.debug(
-                f"PR already exists: {pr.url},"
-                f' updating title ("{pr_title}") and description',
-            )
-            try:
-                pr.update_info(pr_title, pr_description)
-            except PagureAPIException as exc:
-                logger.error(f"Update of existing PR {pr.url} failed: {exc}")
-                raise PackitException(f"Update of existing PR {pr.url} failed") from exc
-        return pr
 
     def _handle_sources(
         self,

--- a/packit/api.py
+++ b/packit/api.py
@@ -1115,7 +1115,12 @@ The first dist-git commit to be synced is '{short_hash}'.
 
             if create_pr:
                 local_pr_branch = f"{dist_git_branch}-{local_pr_branch_suffix}"
-                self.dg.checkout_branch(local_pr_branch)
+                self.dg.create_branch(
+                    local_pr_branch,
+                )
+                self.dg.switch_branch(local_pr_branch, force=True)
+                self.dg.reset_workdir()
+                self.dg.rebase_branch(dist_git_branch)
 
             if create_sync_note and self.package_config.create_sync_note:
                 readme_path = self.dg.local_project.working_dir / "README.packit"

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -215,7 +215,7 @@ class PackitRepositoryBase:
         except GitCommandError as exc:
             raise PackitException("Failed to reset git working tree") from exc
         try:
-            self.local_project.git_repo.git.execute(["git", "clean", "-xdf"])
+            self.local_project.git_repo.git.clean(x=True, d=True, force=True)
         except GitCommandError as exc:
             raise PackitException("Failed to clean git working dir") from exc
 
@@ -224,20 +224,19 @@ class PackitRepositoryBase:
         onto_branch: str,
     ) -> None:
         """
-        Rebase onto specified branch.
+        Rebase current branch onto specified branch using remote instance of the specified branch.
 
         Args:
-            branch: branch to rebase onto
+            branch: Branch to rebase onto.
         """
         try:
             self.local_project.git_repo.git.rebase(
-                "--onto",
-                onto_branch,
                 f"origin/{onto_branch}",
+                onto=onto_branch,
             )
         except GitCommandError as exc:
             raise PackitException(
-                f"Failed to rebase --onto branch {onto_branch!r}",
+                f"Failed to rebase onto {onto_branch} using origin/{onto_branch}",
             ) from exc
 
     def search_branch(self, name: str, remote="origin") -> bool:

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -230,10 +230,14 @@ class PackitRepositoryBase:
             branch: branch to rebase onto
         """
         try:
-            self.local_project.git_repo.git.rebase(onto_branch)
+            self.local_project.git_repo.git.rebase(
+                "--onto",
+                onto_branch,
+                f"origin/{onto_branch}",
+            )
         except GitCommandError as exc:
             raise PackitException(
-                f"Failed to rebase onto branch {onto_branch!r}",
+                f"Failed to rebase --onto branch {onto_branch!r}",
             ) from exc
 
     def search_branch(self, name: str, remote="origin") -> bool:

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -204,7 +204,39 @@ class PackitRepositoryBase:
         except GitCommandError as exc:
             raise PackitException(f"Failed to switch branch to {branch!r}") from exc
 
-    def search_branch(self, name: str) -> bool:
+    def reset_workdir(
+        self,
+    ) -> None:
+        try:
+            self.local_project.git_repo.head.reset(
+                index=True,
+                working_tree=True,
+            )
+        except GitCommandError as exc:
+            raise PackitException("Failed to reset git working tree") from exc
+        try:
+            self.local_project.git_repo.git.execute(["git", "clean", "-xdf"])
+        except GitCommandError as exc:
+            raise PackitException("Failed to clean git working dir") from exc
+
+    def rebase_branch(
+        self,
+        onto_branch: str,
+    ) -> None:
+        """
+        Rebase onto specified branch.
+
+        Args:
+            branch: branch to rebase onto
+        """
+        try:
+            self.local_project.git_repo.git.rebase(onto_branch)
+        except GitCommandError as exc:
+            raise PackitException(
+                f"Failed to rebase onto branch {onto_branch!r}",
+            ) from exc
+
+    def search_branch(self, name: str, remote="origin") -> bool:
         """
         Does branch exist remotely?
 

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -14,7 +14,7 @@ import click
 from packit.cli.types import LocalProjectParameter
 from packit.cli.utils import cover_packit_exception, get_packit_api, iterate_packages
 from packit.config import PackageConfig, get_context_settings, pass_config
-from packit.config.aliases import get_branches, get_fast_forward_branches_from
+from packit.config.aliases import get_branches, get_fast_forward_merge_branches_for
 from packit.constants import (
     PACKAGE_LONG_OPTION,
     PACKAGE_OPTION_HELP,
@@ -109,7 +109,7 @@ def sync_release(
             use_downstream_specfile=use_downstream_specfile,
             resolved_bugs=resolved_bugs,
             sync_acls=sync_acls,
-            fast_forward_merge_branches=get_fast_forward_branches_from(
+            fast_forward_merge_branches=get_fast_forward_merge_branches_for(
                 dist_git_branches=dist_git_branches,
                 source_branch=branch,
                 default=default_dg_branch,

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -14,7 +14,7 @@ import click
 from packit.cli.types import LocalProjectParameter
 from packit.cli.utils import cover_packit_exception, get_packit_api, iterate_packages
 from packit.config import PackageConfig, get_context_settings, pass_config
-from packit.config.aliases import get_branches
+from packit.config.aliases import get_branches, get_fast_forward_branches_from
 from packit.constants import (
     PACKAGE_LONG_OPTION,
     PACKAGE_OPTION_HELP,
@@ -88,6 +88,15 @@ def sync_release(
         f"Proposing update of the following branches: {', '.join(branches_to_update)}",
     )
 
+    dist_git_branches, default_dg_branch = get_dist_git_branches(
+        api,
+        dist_git_branch,
+        pull_from_upstream=use_downstream_specfile,
+    )
+    branches_to_update = get_branches(
+        *dist_git_branches,
+        default_dg_branch=default_dg_branch,
+    )
     for branch in branches_to_update:
         api.sync_release(
             dist_git_branch=branch,
@@ -100,6 +109,11 @@ def sync_release(
             use_downstream_specfile=use_downstream_specfile,
             resolved_bugs=resolved_bugs,
             sync_acls=sync_acls,
+            fast_forward_merge_branches=get_fast_forward_branches_from(
+                dist_git_branches=dist_git_branches,
+                source_branch=branch,
+                default=default_dg_branch,
+            ),
         )
 
 

--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -3,7 +3,7 @@
 
 import logging
 from datetime import timedelta
-from typing import Optional, Union
+from typing import Union
 
 from cachetools.func import ttl_cache
 
@@ -177,7 +177,7 @@ def get_branches(
     return branches
 
 
-def get_fast_forward_branches_from(
+def get_fast_forward_merge_branches_for(
     dist_git_branches: Union[list, dict, set, None],
     source_branch: str,
     default: str = DEFAULT_VERSION,

--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -211,7 +211,7 @@ def get_fast_forward_branches_from(
             *[key],
             default=default,
             default_dg_branch=default_dg_branch,
-            with_aliases=with_aliases,
+            with_aliases=True,
         )
         expanded_dist_git_branches.update(
             {expanded_key: value for expanded_key in expanded_keys},

--- a/packit/config/aliases.py
+++ b/packit/config/aliases.py
@@ -3,9 +3,11 @@
 
 import logging
 from datetime import timedelta
+from typing import Optional, Union
 
 from cachetools.func import ttl_cache
 
+from packit.constants import FAST_FORWARD_MERGE_INTO_KEY
 from packit.exceptions import PackitException
 from packit.utils.bodhi import get_bodhi_client
 from packit.utils.commands import run_command
@@ -173,6 +175,63 @@ def get_branches(
             branches.add(sys_and_version)
 
     return branches
+
+
+def get_fast_forward_branches_from(
+    dist_git_branches: Union[list, dict, set, None],
+    source_branch: str,
+    default: str = DEFAULT_VERSION,
+    default_dg_branch: str = "main",
+    with_aliases: bool = False,
+) -> set[str]:
+    """
+    Returns a list of target branches that can be fast forwarded merging
+    the specified source_branch
+    The keys can be aliases, expand them into a temporary structure
+    to be sure that source_branch can be found in the first dictionary.
+    In the inner loop of the downstream sync the expanded aliases are used.
+
+    The branches should be specified as in the following example
+        {"rawhide": {"fast_forward_merge_into": ["f40", "f39"]},
+         "epel9": {}
+        }
+
+    dist_git_branches: dist_git_branches config key; can be a list or dict
+    source_branch: source branch with commits to be merged
+    default: the same as get_branches default parameter
+    default_dg_branch: the same as get_branches default_dg_branch parameter
+    with_aliases: the same as get_branches with_aliases parameter
+    """
+    if not isinstance(dist_git_branches, dict):
+        return set()
+
+    expanded_dist_git_branches = {}
+    for key, value in dist_git_branches.items():
+        expanded_keys = get_branches(
+            *[key],
+            default=default,
+            default_dg_branch=default_dg_branch,
+            with_aliases=with_aliases,
+        )
+        expanded_dist_git_branches.update(
+            {expanded_key: value for expanded_key in expanded_keys},
+        )
+
+    if source_branch not in expanded_dist_git_branches:
+        return set()
+
+    if (source_branch_dict := expanded_dist_git_branches[source_branch]) and isinstance(
+        source_branch_dict[FAST_FORWARD_MERGE_INTO_KEY],
+        list,
+    ):
+        return get_branches(
+            *source_branch_dict[FAST_FORWARD_MERGE_INTO_KEY],
+            default=default,
+            default_dg_branch=default_dg_branch,
+            with_aliases=with_aliases,
+        )
+
+    return set()
 
 
 def get_koji_targets(*name: str, default=DEFAULT_VERSION) -> set[str]:

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -211,7 +211,7 @@ class CommonPackageConfig:
         timeout: int = 7200,
         owner: Optional[str] = None,
         project: Optional[str] = None,
-        dist_git_branches: Optional[list[str]] = None,
+        dist_git_branches: Union[list[str], dict[str, dict[str, list]], None] = None,
         branch: Optional[str] = None,
         scratch: bool = False,
         list_on_homepage: bool = False,
@@ -331,8 +331,12 @@ class CommonPackageConfig:
         self.timeout: int = timeout
         self.owner: str = owner
         self.project: str = project
-        self.dist_git_branches: set[str] = (
-            set(dist_git_branches) if dist_git_branches else set()
+        self.dist_git_branches: Union[
+            list[str],
+            dict[str, dict[str, list]],
+            None,
+        ] = (
+            dist_git_branches if dist_git_branches else []
         )
         self.branch: str = branch
         self.scratch: bool = scratch

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -174,9 +174,17 @@ class PackageConfig(MultiplePackages):
             )
         return projects_list[0]
 
-    def get_propose_downstream_dg_branches_value(self) -> Optional[list]:
+    def get_propose_downstream_dg_branches_value(
+        self,
+        pull_from_upstream=False,
+    ) -> Optional[list]:
+        type = (
+            JobType.pull_from_upstream
+            if pull_from_upstream
+            else JobType.propose_downstream
+        )
         for job in self.jobs:
-            if job.type == JobType.propose_downstream:
+            if job.type == type:
                 return job.dist_git_branches
         return []
 

--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -174,11 +174,11 @@ class PackageConfig(MultiplePackages):
             )
         return projects_list[0]
 
-    def get_propose_downstream_dg_branches_value(self) -> Optional[set]:
+    def get_propose_downstream_dg_branches_value(self) -> Optional[list]:
         for job in self.jobs:
             if job.type == JobType.propose_downstream:
                 return job.dist_git_branches
-        return set()
+        return []
 
     def __eq__(self, other: object):
         if not isinstance(other, self.__class__):

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -261,3 +261,5 @@ RELEASE_MONITORING_PACKAGE_CHECK_URL = "https://release-monitoring.org//api/v2/p
 # with connection timeout, the actual value will usually be a multiple of what is configured,
 # depending on the number of IP addresses for the target domain
 HTTP_REQUEST_TIMEOUT = (10, 30)
+
+FAST_FORWARD_MERGE_INTO_KEY = "fast_forward_merge_into"

--- a/tests/integration/test_validate_config.py
+++ b/tests/integration/test_validate_config.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 import pytest
 
 from packit.api import PackitAPI
+from packit.exceptions import PackitConfigException
 from packit.utils.commands import cwd
 
 
@@ -309,6 +310,6 @@ def test_schema_validation(tmpdir, raw_package_config, valid, expected_output):
             output = PackitAPI.validate_package_config(Path("test_dir"))
             assert expected_output in output
         else:
-            with pytest.raises(Exception) as exc_info:
+            with pytest.raises(PackitConfigException) as exc_info:
                 PackitAPI.validate_package_config(Path("test_dir"))
             assert expected_output in str(exc_info.value)

--- a/tests/unit/config/test_config_aliases.py
+++ b/tests/unit/config/test_config_aliases.py
@@ -176,6 +176,24 @@ class TestGetBranches:
         )
         assert get_branches(*names) == versions
 
+    @pytest.mark.parametrize(
+        "names,versions",
+        [
+            (
+                {
+                    "fedora-30": {"fast_forward_merge_into": ["f31"]},
+                    "fedora-stable": {},
+                },
+                {"f30", "f32"},
+            ),
+        ],
+    )
+    def test_get_branches_from_multiple_values_in_dict(self, names, versions):
+        flexmock(packit.config.aliases).should_receive("get_versions").and_return(
+            versions,
+        )
+        assert get_branches(*names) == versions
+
     def test_get_branches_without_default(self):
         assert get_branches(default=None) == set()
 

--- a/tests/unit/config/test_config_aliases.py
+++ b/tests/unit/config/test_config_aliases.py
@@ -206,7 +206,7 @@ class TestGetBranches:
             (
                 CommonPackageConfig(
                     dist_git_branches={
-                        "rawhide": {"open_pull_request_for": ["f33"]},
+                        "rawhide": {"fast_forward_merge_into": ["f33"]},
                         "f35": {},
                         "f34": {},
                     },
@@ -218,7 +218,9 @@ class TestGetBranches:
                 CommonPackageConfig(
                     # no sense but possible!
                     dist_git_branches={
-                        "fedora-branched": {"open_pull_request_for": ["fedora-stable"]},
+                        "fedora-branched": {
+                            "fast_forward_merge_into": ["fedora-stable"],
+                        },
                     },
                 ),
                 {"f39", "f40"},
@@ -251,7 +253,6 @@ class TestGetBranches:
                 get_fast_forward_branches_from(config.dist_git_branches, source_branch)
                 == ff_branches[source_branch]
             )
-
 
 class TestGetKojiTargets:
     @pytest.mark.parametrize("target", ALL_KOJI_TARGETS_SNAPSHOT)

--- a/tests/unit/config/test_config_aliases.py
+++ b/tests/unit/config/test_config_aliases.py
@@ -10,12 +10,10 @@ import packit
 from packit.config import CommonPackageConfig, aliases
 from packit.config.aliases import (
     get_aliases,
-    get_all_fast_forward_branches,
     get_all_koji_targets,
     get_branches,
     get_build_targets,
-    get_fast_forward_branches_from,
-    get_fast_forward_source_branch,
+    get_fast_forward_merge_branches_for,
     get_koji_targets,
     get_versions,
 )
@@ -228,7 +226,7 @@ class TestGetBranches:
             ),
         ],
     )
-    def test_get_fast_forward_branches_from(
+    def test_get_fast_forward_merge_branches_for(
         self,
         config,
         branches,
@@ -250,9 +248,13 @@ class TestGetBranches:
         assert branches == get_branches(*config.dist_git_branches)
         for source_branch in get_branches(*config.dist_git_branches, with_aliases=True):
             assert (
-                get_fast_forward_branches_from(config.dist_git_branches, source_branch)
+                get_fast_forward_merge_branches_for(
+                    config.dist_git_branches,
+                    source_branch,
+                )
                 == ff_branches[source_branch]
             )
+
 
 class TestGetKojiTargets:
     @pytest.mark.parametrize("target", ALL_KOJI_TARGETS_SNAPSHOT)

--- a/tests/unit/config/test_config_aliases.py
+++ b/tests/unit/config/test_config_aliases.py
@@ -212,7 +212,7 @@ class TestGetBranches:
                     },
                 ),
                 {"main", "f35", "f34"},
-                {"main": {"f33"}, "f35": set(), "f34": set()},
+                {"rawhide": {"f33"}, "main": {"f33"}, "f35": set(), "f34": set()},
             ),
             (
                 CommonPackageConfig(
@@ -248,7 +248,7 @@ class TestGetBranches:
         )
 
         assert branches == get_branches(*config.dist_git_branches)
-        for source_branch in branches:
+        for source_branch in get_branches(*config.dist_git_branches, with_aliases=True):
             assert (
                 get_fast_forward_branches_from(config.dist_git_branches, source_branch)
                 == ff_branches[source_branch]

--- a/tests/unit/config/test_package_config.py
+++ b/tests/unit/config/test_package_config.py
@@ -172,9 +172,9 @@ def test_project_from_copr_build_job(package_config, project):
                     ),
                 ],
             ),
-            {
+            [
                 "example",
-            },
+            ],
         ),
         (
             PackageConfig(
@@ -199,7 +199,7 @@ def test_project_from_copr_build_job(package_config, project):
                     ),
                 ],
             ),
-            {"example1", "example2"},
+            ["example1", "example2"],
         ),
         (
             PackageConfig(
@@ -220,7 +220,7 @@ def test_project_from_copr_build_job(package_config, project):
                     ),
                 ],
             ),
-            set(),
+            [],
         ),
     ],
 )
@@ -2342,7 +2342,7 @@ def test_handle_metadata():
         ],
     }
     pc = PackageConfigSchema().load(data)
-    assert pc.jobs[0].dist_git_branches == {"shrek"}
+    assert pc.jobs[0].dist_git_branches == ["shrek"]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -104,10 +104,13 @@ def git_repo_mock():
             reset=lambda *_: None,
             clean=lambda *_: None,
             fetch=lambda *_: None,
+            execute=lambda *_: None,
+            rebase=lambda *_: None,
         ),
         remote=lambda *_: flexmock(refs=[flexmock(remote_head="")]),
         branches=[],
         create_head=lambda *_, **__: None,
+        head=flexmock(reset=lambda *_, **__: None),
     )
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -102,10 +102,10 @@ def git_repo_mock():
         git=flexmock(
             checkout=lambda *_: None,
             reset=lambda *_: None,
-            clean=lambda *_: None,
+            clean=lambda *_, **__: None,
             fetch=lambda *_: None,
             execute=lambda *_: None,
-            rebase=lambda *_: None,
+            rebase=lambda *_, **__: None,
         ),
         remote=lambda *_: flexmock(refs=[flexmock(remote_head="")]),
         branches=[],


### PR DESCRIPTION
now, `dist_git_branches` can be
- or a list of strings:
```
["rawhide", "fedora-stable"]
```

- or a complex dictionary
```
{
  "rawhide": {
    "fast_forward_merge_into": ["f40"]
   },
  "fedora-stable": {}
}
```

Related with packit#1724
Should fix packit#2375

- [ ] update documentation