### PR TITLE
Create Bodhi updates also for rawhide

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -128,7 +128,7 @@ jobs:
       - python-ogr
       - python-specfile
     dist_git_branches:
-      - fedora-branched
+      - fedora-all
       - epel-9
 #  - job: vm_image_build
 #    trigger: pull_request


### PR DESCRIPTION
Bodhi updates for rawhide are not autocreated when the Koji build is tagged into a sidetag.