### PR TITLE
Implement getting candidate tag also for rawhide

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -539,7 +539,8 @@ class DistGit(PackitRepositoryBase):
         )
 
         koji_helper = KojiHelper()
-        tag = koji_helper.get_candidate_tag(dist_git_branch)
+        if not (tag := koji_helper.get_candidate_tag(dist_git_branch)):
+            raise PackitException(f"Failed to get candidate tag for {dist_git_branch}")
         build = koji_helper.get_latest_nvr_in_tag(downstream_package_name, tag)
 
         if not build:


### PR DESCRIPTION
Bodhi updates from sidetags will be created also for rawhide, so it is no longer possible to construct candidate tag name based solely on branch name.

Related to https://github.com/packit/packit-service/issues/2379.