### PR TITLE
Add a yaml placeholder

### DIFF
--- a/packit/config/package_config.py
+++ b/packit/config/package_config.py
@@ -358,7 +358,10 @@ def load_packit_yaml(
     try:
         # safe_load() returns None when the file is empty, but this needs
         # to return a dict.
-        return safe_load(raw_text) or {}
+        config = safe_load(raw_text) or {}
+        # Ignore yaml anchor placeholders
+        config.pop("_", None)
+        return config
     except YAMLError as ex:
         logger.error(f"Cannot load package config {config_file_path}.")
         if hasattr(ex, "problem_mark"):


### PR DESCRIPTION
Users can use this placeholder to put anchors that would otherwise be invalid keys in the config file, e.g.

```yaml
_:
  internal-test: &internal-test
    job: tests
    use_internal_tf: True
jobs:
  - <<: *internal-test
    targets: [ fedora-latest ]
    tmt_plan: "/plans/core"
  - <<: *internal-test
    targets: [ epel-9 ]
    require:
      label:
        present:
          - full
```
Notice how in this example we cannot create a reusable anchor from either the fedora or the epel job because it would automatically inherit either `tmt_plan` or `require.*` values. Allowing a placeholder where one could define some definitions for later usage would make designing the yaml file a bit easier in some cases.

Feel free to propose any naming convention for this placeholder

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [x] Update or write new documentation in `packit/packit.dev`.
      packit/packit.dev/pull/971

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit configuration file can now have a placeholder top-level key `_` that is ignored when read.
This is useful for storing yaml anchors in complex config files, e.g.:
```yaml
_:
  base-test: &base-test
    job: tests
    fmf_path: .distro
jobs:
  - <<: *base-test
    trigger: pull_request
    manual_trigger: true
  - <<: *internal-test
    trigger: commit
    use_internal_tf: true
``` 

RELEASE NOTES END
