### PR TITLE
Switch the `setuptools_scm` workaround

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -27,9 +27,6 @@ copy_upstream_release_description: true
 issue_repository: https://github.com/packit/packit
 
 actions:
-  create-archive:
-    - "python3 -m build --sdist --outdir ."
-    - "sh -c 'echo packitos-$(hatch version).tar.gz'"
   get-current-version:
     - "hatch version"
   pre-sync:

--- a/packit.spec
+++ b/packit.spec
@@ -48,11 +48,18 @@ check out packit package for the executable.
 
 
 %generate_buildrequires
+%if 0%{?el9}
+# Workaround for hatch-vcs/setuptools_scm not taking the version from git archive correctly
+export SETUPTOOLS_SCM_PRETEND_VERSION="%{version}"
+%endif
 # The -w flag is required for EPEL 9's older hatchling
 %pyproject_buildrequires %{?with_tests:-x testing} %{?el9:-w}
 
 
 %build
+%if 0%{?el9}
+export SETUPTOOLS_SCM_PRETEND_VERSION="%{version}"
+%endif
 %pyproject_wheel
 
 


### PR DESCRIPTION
Found out that although `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_PACKITOS` would not work in this case, `SETUPTOOLS_SCM_PRETEND_VERSION` still works. Just putting it out there if you want to refactor and remove the `srpm_build_deps` and such