### PR TITLE
Make it possible to directly get upstream_project_url with monorepo configs

### DIFF
--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -560,6 +560,11 @@ class MultiplePackages:
                 "there is more than one package in the config.",
             )
 
+    @property
+    def upstream_project_url(self) -> Optional[str]:
+        # upstream_project_url is common for all packages
+        return self._packages[self._first_package].upstream_project_url
+
     def get_package_names_as_env(self) -> dict[str, str]:
         """Creates a dict with package_name,
         downstream_package_name and upstream_package_name.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -335,7 +335,7 @@ def mock_api_for_source_git(
         pc = get_local_package_config(
             package_config_path=sourcegit / ".distro" / "source-git.yaml",
         )
-        pc.upstream_project_url = str(sourcegit)
+        pc = flexmock(pc, upstream_project_url=str(sourcegit))
         return PackitAPI(c, pc, up_local_project, dist_git_clone_path=str(distgit))
 
 


### PR DESCRIPTION
Fixes https://github.com/packit/packit-service/issues/2172.

Merge before https://github.com/packit/packit-service/pull/2507.