### PR TITLE
Add `--csmock-args` option to `scan-in-osh`

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -2152,6 +2152,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         release_suffix: Optional[str] = None,
         base_srpm: Optional[Path] = None,
         comment: Optional[str] = "Submitted through Packit.",
+        csmock_args: Optional[str] = None,
     ) -> str:
         """
         Perform a build through OpenScanHub.
@@ -2175,6 +2176,12 @@ The first dist-git commit to be synced is '{short_hash}'.
             ]
         else:
             cmd = ["osh-cli", "mock-build", str(srpm_path)]
+
+        if csmock_args is None:
+            csmock_args = self.package_config.csmock_args
+
+        if csmock_args:
+            cmd.append("--csmock-args=" + str(csmock_args))
 
         cmd.append("--config=" + str(chroot))
         cmd.append("--nowait")

--- a/packit/cli/scan_in_osh.py
+++ b/packit/cli/scan_in_osh.py
@@ -48,6 +48,11 @@ logger = logging.getLogger(__name__)
     help="Comment for the build",
     default="Submitted through Packit.",
 )
+@click.option(
+    "--csmock-args",
+    help="Pass additional arguments to csmock",
+    default=None,
+)
 @click.argument("path_or_url", type=LocalProjectParameter(), default=os.path.curdir)
 def scan_in_osh(
     config,
@@ -56,6 +61,7 @@ def scan_in_osh(
     target,
     base_srpm,
     comment,
+    csmock_args,
 ):
     """
     Perform a scan through OpenScanHub.
@@ -76,6 +82,7 @@ def scan_in_osh(
         chroot=target,
         base_srpm=base_srpm,
         comment=comment,
+        csmock_args=csmock_args,
     )
 
     if cmd_result_stdout:

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -169,6 +169,7 @@ class CommonPackageConfig:
         sig: Special interest group (SIG) that maintains the “downstream” package.
         osh_diff_scan_after_copr_build: Whether to run a differential scan in
             OpenScanHub after successful Copr build.
+        csmock_args: Pass additional arguments to csmock
     """
 
     def __init__(
@@ -252,6 +253,7 @@ class CommonPackageConfig:
         sync_test_job_statuses_with_builds: bool = True,
         sig: Optional[str] = None,
         osh_diff_scan_after_copr_build: Optional[bool] = True,
+        csmock_args: Optional[str] = None,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -368,6 +370,8 @@ class CommonPackageConfig:
         self.parse_time_macros = parse_time_macros or {}
 
         self.osh_diff_scan_after_copr_build = osh_diff_scan_after_copr_build
+
+        self.csmock_args = csmock_args
 
     @property
     def dist_git_base_url(self) -> str:

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -453,6 +453,8 @@ class CommonConfigSchema(Schema):
     parse_time_macros = fields.Dict(missing=None)
     osh_diff_scan_after_copr_build = fields.Boolean(missing=True)
 
+    csmock_args = fields.String(missing=None)
+
     @staticmethod
     def spec_source_id_serialize(value: CommonPackageConfig):
         return value.spec_source_id


### PR DESCRIPTION
... subcommand and `csmock_args` configuration option.

Related: https://github.com/packit/packit/issues/2391

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Test command:

`packit scan-in-osh --csmock-args="--cppcheck-add-flag=--enable=style"`

Fixes

Related to

https://github.com/packit/packit/issues/2391

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit now supports passing custom arguments to various static analyzers through `--csmock-args` CLI option and `csmock_args` configuration.

RELEASE NOTES END

EDIT: Added reference to `csmock_args` configuration option.
