### PR TITLE
Replace the --resolve-bugzillas for --resolve-bug

### DIFF
--- a/packit/cli/create_update.py
+++ b/packit/cli/create_update.py
@@ -69,7 +69,7 @@ class BugzillaIDs(click.ParamType):
 )
 @click.option(
     "-b",
-    "--resolve-bugzillas",
+    "--resolve-bug",
     help="Bugzilla IDs that are resolved with the update",
     required=False,
     default=None,
@@ -92,7 +92,7 @@ def create_update(
     koji_build,
     update_notes,
     update_type,
-    resolve_bugzillas,
+    resolve_bug,
     package_config,
     path_or_url,
 ):
@@ -136,7 +136,7 @@ def create_update(
                 dist_git_branch=branch,
                 update_notes=update_notes,
                 update_type=update_type,
-                bugzilla_ids=resolve_bugzillas,
+                bugzilla_ids=resolve_bug,
             )
         except PackitException as ex:  # noqa: PERF203
             click.echo(

--- a/packit/cli/create_update.py
+++ b/packit/cli/create_update.py
@@ -21,20 +21,6 @@ from packit.exceptions import PackitException
 logger = logging.getLogger(__name__)
 
 
-class BugzillaIDs(click.ParamType):
-    name = "bugzilla_ids"
-
-    def convert(self, value, param, ctx):
-        str_ids = value.split(",")
-        try:
-            return [int(bugzilla_id) for bugzilla_id in str_ids]
-        except ValueError as err:
-            raise click.BadParameter(
-                "cannot parse non-integer bugzilla ID. Please use following "
-                "format: id[,id]",
-            ) from err
-
-
 @click.command("create-update", context_settings=get_context_settings())
 @click.option(
     "--dist-git-branch",
@@ -72,8 +58,8 @@ class BugzillaIDs(click.ParamType):
     "--resolve-bug",
     help="Bugzilla IDs that are resolved with the update",
     required=False,
-    default=None,
-    type=BugzillaIDs(),
+    multiple=True,
+    type=click.INT,
 )
 @click.option(
     PACKAGE_SHORT_OPTION,

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -64,7 +64,7 @@ def sync_release(
     force,
     use_downstream_specfile,
     package_config,
-    resolved_bugs,
+    resolve_bug,
     sync_acls,
     check_for_non_git_upstream=False,
 ):
@@ -107,7 +107,7 @@ def sync_release(
             create_pr=pr,
             force=force,
             use_downstream_specfile=use_downstream_specfile,
-            resolved_bugs=resolved_bugs,
+            resolve_bug=resolve_bug,
             sync_acls=sync_acls,
             fast_forward_merge_branches=get_fast_forward_merge_branches_for(
                 dist_git_branches=dist_git_branches,
@@ -238,7 +238,7 @@ def propose_downstream(
         upstream_ref=upstream_ref,
         use_downstream_specfile=False,
         package_config=package_config,
-        resolved_bugs=resolve_bug,
+        resolve_bug=resolve_bug,
         sync_acls=sync_acls,
     )
 
@@ -283,7 +283,7 @@ def pull_from_upstream(
         upstream_ref=None,
         use_downstream_specfile=True,
         package_config=package_config,
-        resolved_bugs=resolve_bug,
+        resolve_bug=resolve_bug,
         sync_acls=sync_acls,
         check_for_non_git_upstream=True,
     )

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -154,8 +154,8 @@ def sync_release_common_options(func):
         "--resolve-bug",
         help="Bug(s) that are resolved with the update, e.g. rhbz#123 (multiple can be specified)",
         required=False,
-        default=None,
         multiple=True,
+        type=click.INT,
     )
     @click.option(
         "--sync-acls",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -60,7 +60,7 @@ def test_propose_downstream_command():
         upstream_ref=None,
         use_downstream_specfile=False,
         package_config=PackageConfig,
-        resolved_bugs=None,
+        resolve_bug=None,
         sync_acls=False,
     ).and_return()
     result = call_packit(packit_base, parameters=["propose-downstream", "."])
@@ -84,7 +84,7 @@ def test_pull_from_upstream_command():
         upstream_ref=None,
         use_downstream_specfile=True,
         package_config=PackageConfig,
-        resolved_bugs=None,
+        resolve_bug=None,
         sync_acls=False,
     ).and_return()
     result = call_packit(packit_base, parameters=["pull-from-upstream", "."])


### PR DESCRIPTION
We used two different options for the same thing.
Unifing for better user experience.

Fixes #2258
Fixes #2281

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

Previously, the `--resolve-bugzillas` option has been used for `create-update` and the option `--resolve-bug` has been used for `propose-downstream`. They have been unifed to just `--resolve-bug` for better user experience.
If you used the option `--resolve-bugzillas` for command `create-update` you must use  the `--resolve-bug` now instead.


Previously, the `pull-from-upstream` option took the `--resolve-bug`  option from CLI.
While the `resolved-bugs` option has been used for retriggering an comment command in service. . They have been unifed to just `--resolve-bug` for better user experience.
If you used the option `--resolved-bugs` for retriggering comment command you must use the `--resolve-bug` now instead.

RELEASE NOTES END
