### PR TITLE
Gitignore issue

### DIFF
--- a/packit/cli/init.py
+++ b/packit/cli/init.py
@@ -67,6 +67,9 @@ def init(
         ),
     }
 
+    with open(working_dir / ".gitignore", mode="a") as gitignore:
+        print("prepare_sources_result*/", file=gitignore)
+
     generate_config(
         config_file=config_path,
         write_to_file=True,


### PR DESCRIPTION
<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

`packit init` now adds working directories that are used in `packit prepare-sources` into the `.gitignore` file in the same directory where Packit config resides.

RELEASE NOTES END
