### PR TITLE
Automatically propose updates for aliases fallback

### DIFF
--- a/.github/workflows/update-aliases-fallback.yml
+++ b/.github/workflows/update-aliases-fallback.yml
@@ -1,0 +1,42 @@
+name: Update aliases fallback
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 1 * *"
+
+jobs:
+  update-aliases-fallback:
+    # To not run in forks
+    if: github.repository_owner == 'packit'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Install Python dependencies
+        run: pip install --upgrade fedora-distro-aliases black
+      - name: Update aliases fallback
+        id: update_aliases_fallback
+        run: |
+          python files/scripts/update_aliases_fallback.py
+          case $? in
+            0) echo "pr=true" >> $GITHUB_OUTPUT;;
+            100) echo "pr=false" >> $GITHUB_OUTPUT; exit 0;;
+            *) exit $?;;
+          esac
+      - name: Create Pull Request
+        if: steps.update_aliases_fallback.outputs.pr == 'true'
+        uses: peter-evans/create-pull-request@v4
+        with:
+          add-paths: packit/config/aliases.py
+          commit-message: Update aliases fallback
+          title: Update aliases fallback
+          body: Update aliases fallback in `packit/config/aliases.py`
+          delete-branch: true

--- a/files/scripts/update_aliases_fallback.py
+++ b/files/scripts/update_aliases_fallback.py
@@ -1,0 +1,52 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+import pprint
+import re
+import sys
+from pathlib import Path
+
+import black
+import fedora_distro_aliases
+
+ALIASES_SOURCE = Path("packit/config/aliases.py")
+
+ALIASES_FALLBACK_PATTERN = re.compile(
+    r"^(ALIASES.*?\s+=\s+){.*?}",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def get_aliases():
+    def format_name(distro):
+        if distro.id_prefix == "FEDORA":
+            return distro.long_name.lower().replace(" ", "-")
+        return distro.name.lower()
+
+    return {
+        alias: [format_name(d) for d in distros]
+        for alias, distros in fedora_distro_aliases.get_distro_aliases().items()
+    }
+
+
+def update_aliases_fallback():
+    aliases = black.format_str(pprint.pformat(get_aliases()), mode=black.Mode())
+    original_code = ALIASES_SOURCE.read_text()
+    updated_code = re.sub(
+        ALIASES_FALLBACK_PATTERN,
+        rf"\g<1>{aliases[:-1]}",
+        original_code,
+    )
+    if updated_code == original_code:
+        return False
+    ALIASES_SOURCE.write_text(updated_code)
+    return True
+
+
+def main():
+    if not update_aliases_fallback():
+        sys.exit(100)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Initially I wanted to use [`get_aliases()`](https://github.com/packit/packit/blob/e78e9e3b33fb65157c4884deccf42de22dfc4783/packit/config/aliases.py#L279) directly, but it uses Bodhi client that doesn't work without authentication, so I had to resort to [fedora-distro-aliases](https://github.com/rpm-software-management/fedora-distro-aliases).