### PR TITLE
Allow VM image-build without Copr

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -2497,9 +2497,9 @@ The first dist-git commit to be synced is '{short_hash}'.
         image_name: str,
         image_request: dict,
         image_customizations: dict,
-        copr_namespace: str,
-        copr_project: str,
-        copr_chroot: str,
+        copr_namespace: Optional[str] = None,
+        copr_project: Optional[str] = None,
+        copr_chroot: Optional[str] = None,
     ) -> str:
         """
         Submit a VM image build to Image Builder.
@@ -2521,10 +2521,14 @@ The first dist-git commit to be synced is '{short_hash}'.
             Image ID of the submitted image.
         """
         # build_id = self.copr_helper.get_build(build_id=copr_build_id)
-        repo_url = self.copr_helper.get_repo_download_url(
-            owner=copr_namespace,
-            project=copr_project,
-            chroot=copr_chroot,
+        repo_url = (
+            self.copr_helper.get_repo_download_url(
+                owner=copr_namespace,
+                project=copr_project,
+                chroot=copr_chroot,
+            )
+            if copr_project is not None
+            else None
         )
         ib = ImageBuilder(
             refresh_token=self.config.redhat_api_refresh_token,

--- a/packit/vm_image_build.py
+++ b/packit/vm_image_build.py
@@ -176,7 +176,7 @@ class ImageBuilder:
         image_name: str,
         image_request: dict,
         image_customizations: dict,
-        repo_url: str,
+        repo_url: Optional[str] = None,
     ):
         """
         Create an image using the Image Builder API.
@@ -233,16 +233,17 @@ class ImageBuilder:
             "image_requests": [image_request],
             "customizations": image_customizations,
         }
-        payload_repositories.append(
-            {
-                "rhsm": False,
-                "baseurl": repo_url,
-                # needs to be the actual key, not link:
-                # https://issues.redhat.com/browse/HMSIB-14
-                # "gpgkey": "https://download.copr.../@cockpit/cockpit-preview/pubkey.gpg",
-                "check_gpg": False,
-            },
-        )
+        if repo_url is not None:
+            payload_repositories.append(
+                {
+                    "rhsm": False,
+                    "baseurl": repo_url,
+                    # needs to be the actual key, not link:
+                    # https://issues.redhat.com/browse/HMSIB-14
+                    # "gpgkey": "https://download.copr.../@cockpit/cockpit-preview/pubkey.gpg",
+                    "check_gpg": False,
+                },
+            )
         response = self.image_builder_request("POST", "compose", payload=payload)
 
         response_json = response.json()


### PR DESCRIPTION
Fixes #1966

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before packit/packit.dev#945

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit now allows building VM images via CLI without any Copr repository specified.

RELEASE NOTES END
