### PR TITLE
fix(cli): correctly type the resolved bugs

### DIFF
--- a/packit/cli/create_update.py
+++ b/packit/cli/create_update.py
@@ -56,10 +56,10 @@ logger = logging.getLogger(__name__)
 @click.option(
     "-b",
     "--resolve-bug",
-    help="Bugzilla IDs that are resolved with the update",
+    help="Bugzilla IDs that are resolved with the update, e.g., rhbz#1234",
     required=False,
     multiple=True,
-    type=click.INT,
+    type=click.STRING,
 )
 @click.option(
     PACKAGE_SHORT_OPTION,

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -152,10 +152,10 @@ def sync_release_common_options(func):
     @click.option(
         "-b",
         "--resolve-bug",
-        help="Bug(s) that are resolved with the update, e.g. rhbz#123 (multiple can be specified)",
+        help="Bug(s) that are resolved with the update, e.g., rhbz#123 (multiple can be specified)",
         required=False,
         multiple=True,
-        type=click.INT,
+        type=click.STRING,
     )
     @click.option(
         "--sync-acls",


### PR DESCRIPTION
During the changes in #2428 we have incorrectly assumed the type of the bugs that are passed to the ‹-b› (or ‹--resolve-bug›) switch.

The previous assumption expected that the bugs are represented by simple number (integer) whereas they are represented in a bit more complex form, such as ‹rhbz#1234› (Bugzilla) or even ‹PROJECT-1234› (Jira).

Revert such assumption to accept plain strings as it makes the ‹-b› swich unusable with such precondition.

<!-- release notes footer -->

RELEASE NOTES BEGIN

We have fixed an issue that was introduced during the unification of the interface for passing resolved Bugzillas / Jira tickets to the `sync-release` or `bodhi_update` jobs.

RELEASE NOTES END
