### PR TITLE
Fix passing BZs when running `packit propose-downstream`

### DIFF
--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -107,7 +107,7 @@ def sync_release(
             create_pr=pr,
             force=force,
             use_downstream_specfile=use_downstream_specfile,
-            resolve_bug=resolve_bug,
+            resolved_bugs=resolve_bug,
             sync_acls=sync_acls,
             fast_forward_merge_branches=get_fast_forward_merge_branches_for(
                 dist_git_branches=dist_git_branches,


### PR DESCRIPTION
Fixes:
```
2024-10-14 16:54:43.199 utils.py          ERROR  PackitAPI.sync_release() got an unexpected keyword argument 'resolve_bug'
Traceback (most recent call last):
  File "/home/nforro/devel/packit/packit/cli/utils.py", line 47, in covered_func
    func(config=config, *args, **kwargs)  # noqa: B026
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nforro/devel/packit/packit/cli/utils.py", line 143, in covered_func
    func(*args, **decorated_func_kwargs)
  File "/home/nforro/devel/packit/packit/cli/propose_downstream.py", line 228, in propose_downstream
    sync_release(
  File "/home/nforro/devel/packit/packit/cli/propose_downstream.py", line 101, in sync_release
    api.sync_release(
TypeError: PackitAPI.sync_release() got an unexpected keyword argument 'resolve_bug'
```