### PR TITLE
Log all arguments passed to `BodhiClient.save()`

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -684,6 +684,8 @@ class DistGit(PackitRepositoryBase):
             if alias:
                 save_kwargs["edited"] = alias
 
+            logger.debug(f"Saving Bodhi update with args: {save_kwargs}")
+
             result = bodhi_client.save(**save_kwargs)
 
             logger.debug(f"Bodhi response:\n{result}")


### PR DESCRIPTION
There was an instance of failed Bodhi update with `Unable to create update.  argument of type 'NoneType' is not iterable`.
Logging all arguments passed to `BodhiClient.save()` could help identifying potential issue on our side (even though it could be a bug on Bodhi side as well).