### PR TITLE
Support fast_forward_merge_into in dist-git init

### DIFF
--- a/tests/unit/test_dist_git_init.py
+++ b/tests/unit/test_dist_git_init.py
@@ -21,7 +21,11 @@ from packit.cli.dist_git_init import DistGitInitializer
                     {
                         "job": "pull_from_upstream",
                         "trigger": "release",
-                        "dist_git_branches": ["fedora-rawhide"],
+                        "dist_git_branches": {
+                            "fedora-rawhide": {
+                                "fast_forward_merge_into": ["fedora-branched"],
+                            },
+                        },
                     },
                     {
                         "job": "koji_build",
@@ -57,7 +61,11 @@ from packit.cli.dist_git_init import DistGitInitializer
                     {
                         "job": "pull_from_upstream",
                         "trigger": "release",
-                        "dist_git_branches": ["fedora-rawhide"],
+                        "dist_git_branches": {
+                            "fedora-rawhide": {
+                                "fast_forward_merge_into": ["fedora-branched"],
+                            },
+                        },
                     },
                     {
                         "job": "koji_build",
@@ -116,7 +124,11 @@ from packit.cli.dist_git_init import DistGitInitializer
                     {
                         "job": "pull_from_upstream",
                         "trigger": "release",
-                        "dist_git_branches": ["fedora-rawhide"],
+                        "dist_git_branches": {
+                            "fedora-rawhide": {
+                                "fast_forward_merge_into": ["fedora-branched"],
+                            },
+                        },
                     },
                     {
                         "job": "koji_build",
@@ -146,7 +158,11 @@ from packit.cli.dist_git_init import DistGitInitializer
                     {
                         "job": "pull_from_upstream",
                         "trigger": "release",
-                        "dist_git_branches": ["fedora-rawhide"],
+                        "dist_git_branches": {
+                            "fedora-rawhide": {
+                                "fast_forward_merge_into": ["fedora-branched"],
+                            },
+                        },
                     },
                     {
                         "job": "koji_build",
@@ -175,7 +191,11 @@ from packit.cli.dist_git_init import DistGitInitializer
                     {
                         "job": "pull_from_upstream",
                         "trigger": "release",
-                        "dist_git_branches": ["fedora-rawhide"],
+                        "dist_git_branches": {
+                            "fedora-rawhide": {
+                                "fast_forward_merge_into": ["fedora-branched"],
+                            },
+                        },
                     },
                     {
                         "job": "koji_build",
@@ -199,7 +219,11 @@ from packit.cli.dist_git_init import DistGitInitializer
                     {
                         "job": "pull_from_upstream",
                         "trigger": "release",
-                        "dist_git_branches": ["fedora-rawhide"],
+                        "dist_git_branches": {
+                            "fedora-rawhide": {
+                                "fast_forward_merge_into": ["fedora-branched"],
+                            },
+                        },
                     },
                 ],
             },


### PR DESCRIPTION
And also default to using it (rawhide to fedora-stable mapping). Fixes #2421

With the current implementation, for `koji_build` and `bodhi_update` job, we will use `--dist-git-branches` with default `rawhide` still, I was also thinking if we shouldn't be using all the branches present in `--dist-git-branches-mapping` rather, WDYT?

RELEASE NOTES BEGIN

Packit now supports and defaults to `fast_forward_merge_into` syntax via `--dist-git-branches-mapping` in `dist-git init`.

RELEASE NOTES END
