### PR TITLE
Allow configuring with_opts/without_opts chroot-specific options

### DIFF
--- a/packit/constants.py
+++ b/packit/constants.py
@@ -187,6 +187,8 @@ CHROOT_SPECIFIC_COPR_CONFIGURATION = {
     "additional_repos": [],
     # modules default to string because Copr stores it as string in the DB
     "additional_modules": "",
+    "with_opts": [],
+    "without_opts": [],
 }
 
 PACKAGE_LONG_OPTION = "--package"


### PR DESCRIPTION
RELEASE NOTES BEGIN

You can now define `with_opts` and `without_opts` in target-specific configuration of `copr_build` job to build with `--with` and `--without` rpmbuild options.

RELEASE NOTES END