### PR TITLE
Always include the list of bugs in `BodhiClient.save()` kwargs

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -675,11 +675,10 @@ class DistGit(PackitRepositoryBase):
             if bugzilla_ids_from_changelog:
                 bugs += bugzilla_ids_from_changelog
 
+            save_kwargs["bugs"] = bugs
+
             if sidetag:
                 save_kwargs["from_tag"] = sidetag
-
-            if bugs:
-                save_kwargs["bugs"] = bugs
 
             if alias:
                 save_kwargs["edited"] = alias


### PR DESCRIPTION
It seems there is a bug/feature in Bodhi and when editing an existing update and not supplying the `bugs` parameter, Bodhi returns a failure however the only non-updated property of the update is the list of bugs.

Always including the list of bugs, even if empty, should prevent this.

I've also opened https://github.com/fedora-infra/bodhi/issues/5800.

Fixes https://github.com/packit/packit/issues/2467 and similar.