### PR TITLE
Add `post-modifications` action

### DIFF
--- a/packit/actions.py
+++ b/packit/actions.py
@@ -28,6 +28,7 @@ class ActionName(Enum):
     create_archive = "create-archive"
     get_current_version = "get-current-version"
     fix_spec = "fix-spec-file"
+    post_modifications = "post-modifications"
     changelog_entry = "changelog-entry"
     commit_message = "commit-message"
 

--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -311,6 +311,7 @@ class Upstream:
         release_suffix: Optional[str] = None,
         create_symlinks: Optional[bool] = True,
         merged_ref: Optional[str] = None,
+        env: Optional[dict] = None,
     ):
         raise NotImplementedError()
 
@@ -1029,6 +1030,7 @@ class GitUpstream(PackitRepositoryBase, Upstream):
         release_suffix: Optional[str] = None,
         create_symlinks: Optional[bool] = True,
         merged_ref: Optional[str] = None,
+        env: Optional[dict] = None,
     ):
         """
         1. determine version
@@ -1043,6 +1045,7 @@ class GitUpstream(PackitRepositoryBase, Upstream):
             create_symlinks: whether symlinks should be created instead of copying the files
                 (e.g. when the archive is created outside the specfile dir)
             merged_ref: git ref in the upstream repo used to identify correct most recent tag
+            env: environment to pass to the `post-modifications` action
         """
         try:
             self._merged_ref = merged_ref
@@ -1050,6 +1053,7 @@ class GitUpstream(PackitRepositoryBase, Upstream):
                 update_release=update_release,
                 release_suffix=release_suffix,
                 create_symlinks=create_symlinks,
+                env=env,
             )
         finally:
             self._merged_ref = None
@@ -1534,6 +1538,7 @@ class SRPMBuilder:
         update_release: bool,
         release_suffix: Optional[str] = None,
         create_symlinks: Optional[bool] = True,
+        env: Optional[dict] = None,
     ):
         if self.upstream_ref:
             self._prepare_upstream_using_source_git(update_release, release_suffix)
@@ -1558,6 +1563,11 @@ class SRPMBuilder:
             logger.warning("Therefore skipping downloading of remote sources.")
         else:
             self.upstream.download_remote_sources()
+
+        self.upstream.actions_handler.run_action(
+            actions=ActionName.post_modifications,
+            env=env,
+        )
 
 
 class Archive:

--- a/tests/functional/test_srpm.py
+++ b/tests/functional/test_srpm.py
@@ -60,8 +60,10 @@ def test_action_output(upstream_and_remote):
     packit_yaml_dict = yaml.safe_load(packit_yaml_path.read_text())
     # http://www.atlaspiv.cz/?page=detail&beer_id=4187
     the_line_we_want = "MadCat - Imperial Stout Rum Barrel Aged 20°"
+    another_line_we_want = "Zichovec - Malý Ježíšek, Session IPA 10°"
     packit_yaml_dict["actions"] = {
         "post-upstream-clone": [f"bash -c 'echo {the_line_we_want}'"],
+        "post-modifications": [f"bash -c 'echo {another_line_we_want}'"],
     }
     packit_yaml_path.write_text(yaml.dump(packit_yaml_dict))
     out = call_real_packit(
@@ -71,6 +73,7 @@ def test_action_output(upstream_and_remote):
     )
 
     assert f"INFO   {the_line_we_want}\n" in out.decode()
+    assert f"INFO   {another_line_we_want}\n" in out.decode()
     srpm_path = next(upstream_repo_path.glob("*.src.rpm"))
     assert srpm_path.exists()
     build_srpm(srpm_path)


### PR DESCRIPTION
Fixes https://github.com/packit/packit/issues/2416.

If you can think of a better name for the action, I'm all ears.

I was thinking that having upstream git repo as a working dir for this action doesn't make much sense during `sync_release`, but it would be probably non-trivial to change that and users still have `$PACKIT_DOWNSTREAM_REPO` available. At least now it is consistent with other actions. WDYT?

In the integration test case I wanted to test creating an additional source based on the primary source in the action, but `$PACKIT_DOWNSTREAM_REPO` is not set on the account of `dg._local_project` being `None`, so I eventually gave up. Do you think it's worth the effort?

RELEASE NOTES BEGIN

There is a new action/hook, `post-modifications`, that is executed after all modifications to the spec file are done and in case of syncing release after all remote sources are downloaded and before uploading to lookaside cache. You can use it for example to construct an additional source that depends on the primary source (that may not yet be available in other actions).

RELEASE NOTES END
