### PR TITLE
Feat/mock improvements

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -2469,6 +2469,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         self,
         srpm_path: Path,
         root: str = "default",
+        resultdir: Union[Path, str, None] = None,
     ) -> list[Path]:
         """
         Performs a mock build with given SRPM and root.
@@ -2479,11 +2480,18 @@ The first dist-git commit to be synced is '{short_hash}'.
                 Defaults to `"default"` mock config which should be a Fedora
                 rawhide.
             srpm_path: Path to the SRPM to be built.
+            resultdir: Path where the mock results should be stored, for details
+                see mock(1).
 
         Returns:
             List of paths to the built RPMs.
         """
-        cmd = ["mock", "--root", root, str(srpm_path)]
+        cmd = ["mock", "--root", root]
+        if resultdir is not None:
+            cmd.append("--resultdir")
+            cmd.append(str(resultdir))
+
+        cmd.append(str(srpm_path))
         escaped_command = " ".join(cmd)
         logger.debug(f"Mock build command: {escaped_command}")
 

--- a/packit/cli/builds/mock_build.py
+++ b/packit/cli/builds/mock_build.py
@@ -53,6 +53,12 @@ logger = logging.getLogger("packit")
     ),
 )
 @click.option(
+    "--resultdir",
+    default=None,
+    type=click.Path(file_okay=False),
+    help="Specifies the resultdir option for ‹mock› command, for details see mock(1)",
+)
+@click.option(
     PACKAGE_SHORT_OPTION,
     PACKAGE_LONG_OPTION,
     multiple=True,
@@ -72,6 +78,7 @@ def mock(
     release_suffix,
     default_release_suffix,
     root,
+    resultdir,
     package_config,
     path_or_url,
 ):
@@ -99,7 +106,11 @@ def mock(
             release_suffix=release_suffix,
         )
 
-    rpm_paths = api.run_mock_build(root=root, srpm_path=config.srpm_path)
+    rpm_paths = api.run_mock_build(
+        root=root,
+        srpm_path=config.srpm_path,
+        resultdir=resultdir,
+    )
     logger.info("RPMs:")
     for path in rpm_paths:
         logger.info(f" * {path}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,9 +124,10 @@ select = [
     "W",   # pycodestyle Warning
 ]
 ignore = [
-    "B017", # assert-raises-exception
-    "B022", # useless-contextlib-suppress
-    "RUF003"# Comment contains ambiguous character
+    "B017",    # assert-raises-exception
+    "B022",    # useless-contextlib-suppress
+    "RUF001",  # Comment contains ambiguous character
+    "RUF003",  # Comment contains ambiguous character
 ]
 
 line-length = 100

--- a/tests/integration/test_base_git.py
+++ b/tests/integration/test_base_git.py
@@ -64,7 +64,7 @@ def test_get_output_from_action_defined_in_sandcastle():
         ),
     )
     packit_repository_base.local_project = LocalProjectBuilder().build(
-        working_dir="/tmp",
+        working_dir="/sandcastle",
     )
 
     flexmock(Sandcastle).should_receive("run")


### PR DESCRIPTION
<!-- TODO list -->

TODO:

- [x] resultdir
- [x] mock group / permissions
  - As we discussed with @nforro, it might be for the best to split the packit RPM package into multiple subpackages that would allow better handling of the RPM dependencies (as of now we pull in a lot of deps, and the best handling for this point would introduce another one, therefore leave it out for now)

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #2473

<!-- release notes footer -->

RELEASE NOTES BEGIN

We have added a `--resultdir` option for building in mock via our CLI (`packit build in-mock`).

RELEASE NOTES END
