### PR TITLE
Do not upload git-tracked remote sources to lookaside cache

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -406,6 +406,11 @@ class DistGit(PackitRepositoryBase):
         )
         return archive_names
 
+    @property
+    def git_tracked_files(self) -> list[str]:
+        """List of files tracked by git."""
+        return [p for p, _ in self.local_project.git_repo.index.entries]
+
     def download_upstream_archives(self) -> list[Path]:
         """
         Fetch archives for the current upstream release defined in dist-git's spec

--- a/tests/integration/test_using_cockpit.py
+++ b/tests/integration/test_using_cockpit.py
@@ -54,7 +54,7 @@ def test_update_on_cockpit_ostree(cockpit_ostree):
         push_to_fork=lambda *args, **kwargs: None,
         is_archive_in_lookaside_cache=lambda archive_path: False,
         upload_to_lookaside_cache=lambda archives, pkg_tool, offline: None,
-        download_upstream_archives=lambda: ["the-archive"],
+        download_upstream_archives=lambda: [dist_git_path / "the-archive"],
     )
     flexmock(DistGit).should_receive("existing_pr").and_return(None)
     flexmock(
@@ -99,7 +99,7 @@ def test_update_on_cockpit_ostree_pr_exists(cockpit_ostree):
         push_to_fork=lambda *args, **kwargs: None,
         is_archive_in_lookaside_cache=lambda archive_path: False,
         upload_to_lookaside_cache=lambda archives, pkg_tool, offline: None,
-        download_upstream_archives=lambda: ["the-archive"],
+        download_upstream_archives=lambda: [dist_git_path / "the-archive"],
     )
     pr = flexmock(url="https://example.com/pull/1")
     pr.should_receive("update_info").and_return()


### PR DESCRIPTION
Fixes https://github.com/packit/packit/issues/2460.

RELEASE NOTES BEGIN

Packit doesn't attempt to upload git-tracked remote sources (for example a [GPG keyring](https://docs.fedoraproject.org/en-US/packaging-guidelines/#_verifying_signatures)) to lookaside cache anymore when syncing release.

RELEASE NOTES END
