### PR TITLE
Sanitize environment before running actions locally

### DIFF
--- a/packit/utils/commands.py
+++ b/packit/utils/commands.py
@@ -85,7 +85,8 @@ def run_command(
     # we need to pass complete env to Popen, otherwise we lose everything from os.environ
     cmd_env = os.environ
     if env:
-        cmd_env.update(env)
+        # before updating the env, replace any potential None values with empty strings
+        cmd_env.update({k: v if v is not None else "" for k, v in env.items()})
 
     # we can't use universal newlines here b/c the output from the command can be encoded
     # in something alien and we would "can't decode this using utf-8" errors


### PR DESCRIPTION
Some environment variables passed to actions can be `None`, deal with that.

This is not an issue in Sandcastle, only when using CLI.