### PR TITLE
Remove logging of Copr chroots to reduce logs

### DIFF
--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -101,7 +101,6 @@ class CoprHelper:
         build_targets = aliases.get_build_targets(*name, default=default)
         logger.info(f"Build targets: {build_targets} ")
         copr_chroots = self.get_available_chroots()
-        logger.info(f"Copr chroots: {copr_chroots} ")
         logger.info(f"Result set: {set(build_targets) & set(copr_chroots)}")
         return set(build_targets) & set(copr_chroots)
 


### PR DESCRIPTION
The available chroots are cached for 12 hours, so I think logging the full set of chroots is unnecessary and leads to excessively large log entries (+ the intersection result will still be logged).

This is just a suggestion, let me know what you think.