### PR TITLE
chore(ruff): do not use deprecated settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,14 @@ testpaths = [
     "tests",
 ]
 
+[tool.mypy]
+python_version = "3.9"
+
 [tool.ruff]
+line-length = 100
+target-version = "py39"
+
+[tool.ruff.lint]
 select = [
     "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
@@ -132,9 +139,3 @@ ignore = [
     "RUF001",  # Comment contains ambiguous character
     "RUF003",  # Comment contains ambiguous character
 ]
-
-line-length = 100
-target-version = "py39"
-
-[tool.mypy]
-python_version = "3.9"


### PR DESCRIPTION
After running ruff:

    warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
      - 'ignore' -> 'lint.ignore'
      - 'select' -> 'lint.select'

Therefore switch to those new options.