### PR TITLE
Fixes for fast_forward_merge_into 

### DIFF
--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -76,11 +76,23 @@ def test_fast_forward_merge_local_update(
     mock_spec_download_remote_s(d)
     flexmock(api).should_receive("init_kerberos_ticket").at_least().once()
     flexmock(Specfile).should_call("reload").at_least().once()
+    flexmock(api.dg).should_call("create_pull").with_args(
+        str,
+        str,
+        source_branch="main-update",
+        target_branch="main",
+    ).once()
+    flexmock(api.dg).should_call("create_pull").with_args(
+        str,
+        str,
+        source_branch="main-update",
+        target_branch="f30",
+    ).once()
 
     api.sync_release(
         dist_git_branch="main",
         versions=["0.1.0"],
-        fast_forward_merge_branches={"f40"},
+        fast_forward_merge_branches={"f30"},
     )
     assert (d / TARBALL_NAME).is_file()
     spec = Specfile(d / "beer.spec")

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 from flexmock import flexmock
+from ogr.abstract import PullRequest
 from specfile import Specfile
 
 from packit.actions import ActionName
@@ -89,11 +90,14 @@ def test_fast_forward_merge_local_update(
         target_branch="f30",
     ).once()
 
-    api.sync_release(
+    _, additional_prs = api.sync_release(
         dist_git_branch="main",
         versions=["0.1.0"],
         fast_forward_merge_branches={"f30"},
     )
+    assert list(additional_prs.keys()) == ["f30"]
+    assert isinstance(additional_prs["f30"], PullRequest)
+
     assert (d / TARBALL_NAME).is_file()
     spec = Specfile(d / "beer.spec")
     assert spec.expanded_version == "0.1.0"

--- a/tests/integration/test_using_cockpit.py
+++ b/tests/integration/test_using_cockpit.py
@@ -117,12 +117,15 @@ def test_update_on_cockpit_ostree_pr_exists(cockpit_ostree):
     flexmock(api.up, get_specfile_version=lambda: "178")
 
     with cwd(upstream_path):
-        assert pr == api.sync_release(
-            dist_git_branch="main",
-            use_local_content=False,
-            versions=["179"],
-            force_new_sources=False,
-            create_pr=True,
+        assert (
+            pr
+            == api.sync_release(
+                dist_git_branch="main",
+                use_local_content=False,
+                versions=["179"],
+                force_new_sources=False,
+                create_pr=True,
+            )[0]
         )
 
 


### PR DESCRIPTION

Related to packit/packit-service#2701


RELEASE NOTES BEGIN

When using `fast_forward_merge_into`, `version_update_mask` is now correctly being taken into consideration.

RELEASE NOTES END
