### PR TITLE
[WIP] Add -c option to validate-config 

### DIFF
--- a/packit/cli/validate_config.py
+++ b/packit/cli/validate_config.py
@@ -27,8 +27,13 @@ logger = logging.getLogger(__name__)
     is_flag=True,
     help="Do not make remote API calls requiring network access.",
 )
+@click.option(
+    "-c", "--config",
+    type=click.Path(exists=True),  
+    help="Path to a specific Packit configuration file.",
+)
 @cover_packit_exception
-def validate_config(path_or_url: LocalProject, offline: bool):
+def validate_config(path_or_url: LocalProject, offline: bool,config: str):
     """
     Validate PackageConfig.
 
@@ -39,6 +44,11 @@ def validate_config(path_or_url: LocalProject, offline: bool):
 
     PATH_OR_URL argument is a local path or a URL to a git repository with packit configuration file
     """
+
+    
+    logger.info(config)
     output = PackitAPI.validate_package_config(path_or_url.working_dir, offline)
     logger.info(output)
+    
+    # logger.info(path_or_url)
     # TODO: print more if config.debug

--- a/packit/cli/validate_config.py
+++ b/packit/cli/validate_config.py
@@ -28,12 +28,13 @@ logger = logging.getLogger(__name__)
     help="Do not make remote API calls requiring network access.",
 )
 @click.option(
-    "-c", "--config",
-    type=click.Path(exists=True),  
+    "-c",
+    "--config",
+    type=click.Path(exists=True),
     help="Path to a specific Packit configuration file.",
 )
 @cover_packit_exception
-def validate_config(path_or_url: LocalProject, offline: bool,config: str):
+def validate_config(path_or_url: LocalProject, offline: bool, config: str):
     """
     Validate PackageConfig.
 
@@ -45,10 +46,9 @@ def validate_config(path_or_url: LocalProject, offline: bool,config: str):
     PATH_OR_URL argument is a local path or a URL to a git repository with packit configuration file
     """
 
-    
     logger.info(config)
     output = PackitAPI.validate_package_config(path_or_url.working_dir, offline)
     logger.info(output)
-    
+
     # logger.info(path_or_url)
     # TODO: print more if config.debug


### PR DESCRIPTION
## Description
This PR is a work-in-progress to solve this issue https://github.com/packit/packit/issues/2451
 i added a `-c / --config` option to the `validate-config` command.  
I need some guidance on correctly overriding `path_or_url.working_dir` when a config file is passed.
can you review it.

### How to override the path correctly:
 How should I correctly override `path_or_url.working_dir` when `-c` is provided?  
 Are there existing helper functions to handle this? 

## How to Test (So Far)
```bash
# Default behavior (should use packit.yaml in working_dir)
packit validate-config

# New behavior (pass a custom config file)
packit validate-config -c /home/mohamed/custom-packit.yaml 
