### PR TITLE
Add explicit no-release to prepare-release pull requests

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -28,5 +28,10 @@ jobs:
           labels: release
           commit-message: Release ${{ inputs.version }}
           title: Release ${{ inputs.version }}
-          body: Update the changelog and the specfile for release ${{ inputs.version }}.
+          body: |
+            Update the changelog and the specfile for release ${{ inputs.version }}.
+
+            RELEASE NOTES BEGIN
+            N/A
+            RELEASE NOTES END
           delete-branch: true


### PR DESCRIPTION
This will make the CI happy..;)

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
