### PR TITLE
Use releasebot token for prepare-release PR creation to trigger workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -30,3 +30,4 @@ jobs:
           title: Release ${{ inputs.version }}
           body: Update the changelog and the specfile for release ${{ inputs.version }}.
           delete-branch: true
+          token: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
Instead of using the default GITHUB_TOKEN, use the releasebot token to ensure workflows run on pull requests created by these PRs. Docs: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow?utm_source=chatgpt.com#triggering-a-workflow-from-a-workflow
