### PR TITLE
Do not traceback on reloading downstream spec if it doesn't yet exist

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1122,7 +1122,9 @@ The first dist-git commit to be synced is '{short_hash}'.
 
             # reload spec files as they could have been changed by the action
             self.up.specfile.reload()
-            self.dg.specfile.reload()
+            # downstream spec file doesn't have to exist yet
+            with contextlib.suppress(FileNotFoundError):
+                self.dg.specfile.reload()
 
             # compare versions here because users can mangle with specfile in
             # post_upstream_clone action
@@ -1149,7 +1151,9 @@ The first dist-git commit to be synced is '{short_hash}'.
 
             # reload spec files as they could have been changed by the action
             self.up.specfile.reload()
-            self.dg.specfile.reload()
+            # downstream spec file doesn't have to exist yet
+            with contextlib.suppress(FileNotFoundError):
+                self.dg.specfile.reload()
 
             if create_pr:
                 local_pr_branch = f"{dist_git_branch}-{local_pr_branch_suffix}"

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -126,6 +126,50 @@ def test_basic_local_update_no_upload_to_lookaside(
     assert "0.1.0" in changelog
 
 
+def test_basic_local_update_missing_downstream_specfile(
+    cwd_upstream,
+    api_instance,
+    distgit_and_remote,
+    mock_remote_functionality_upstream,
+    caplog,
+):
+    # log specfile debug messages
+    caplog.set_level(logging.DEBUG)
+
+    u, d, api = api_instance
+    # remove the downstream specfile
+    d.joinpath("beer.spec").unlink()
+    subprocess.check_call(
+        ["git", "commit", "-m", "remove spec", "-a"],
+        cwd=str(d),
+    )
+    subprocess.check_call(["git", "push", "-u", "origin", "main:main"], cwd=str(d))
+    mock_spec_download_remote_s(d)
+    flexmock(api).should_receive("init_kerberos_ticket").at_least().once()
+
+    api.sync_release(
+        dist_git_branch="main",
+        versions=["0.1.0"],
+    )
+
+    assert (d / TARBALL_NAME).is_file()
+    spec = Specfile(d / "beer.spec")
+    assert spec.expanded_version == "0.1.0"
+    assert (d / "README.packit").is_file()
+    # assert that we have changelog entries for both versions
+    with spec.sections() as sections:
+        changelog = "\n".join(sections.changelog)
+    assert "0.0.0" in changelog
+    assert "0.1.0" in changelog
+
+    with pytest.raises(FileNotFoundError):
+        api.sync_release(
+            dist_git_branch="main",
+            versions=["0.1.0"],
+            use_downstream_specfile=True,
+        )
+
+
 def test_basic_local_update_use_downstream_specfile(
     cwd_upstream,
     api_instance,


### PR DESCRIPTION
If there is no spec file in the target dist-git branch trying to reload it tracebacks. But it can be a valid scenario
(freshly created dist-git repo/branch) and the spec file would be later copied from upstream (if possible).

Fixes https://github.com/packit/packit/issues/2562.

Related to https://github.com/packit/specfile/issues/462.