### PR TITLE
CLI: Add support for specifying base nvr in Packit

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -2315,12 +2315,20 @@ The first dist-git commit to be synced is '{short_hash}'.
         upstream_ref: Optional[str] = None,
         release_suffix: Optional[str] = None,
         base_srpm: Optional[Path] = None,
+        base_nvr: Optional[str] = None,
         comment: Optional[str] = "Submitted through Packit.",
         csmock_args: Optional[str] = None,
     ) -> str:
         """
         Perform a build through OpenScanHub.
         """
+
+        if base_srpm and base_nvr:
+            logger.error(
+                "Either base SRPM or NVR can be specified for differential scans but not both",
+            )
+            return None
+
         # `osh-cli` requires a kerberos ticket.
         self.init_kerberos_ticket()
 
@@ -2337,6 +2345,13 @@ The first dist-git commit to be synced is '{short_hash}'.
                 "version-diff-build",
                 "--srpm=" + str(srpm_path),
                 "--base-srpm=" + str(base_srpm),
+            ]
+        elif base_nvr:
+            cmd = [
+                "osh-cli",
+                "version-diff-build",
+                "--srpm=" + str(srpm_path),
+                "--base-nvr=" + base_nvr,
             ]
         else:
             cmd = ["osh-cli", "mock-build", str(srpm_path)]

--- a/packit/cli/scan_in_osh.py
+++ b/packit/cli/scan_in_osh.py
@@ -44,6 +44,11 @@ logger = logging.getLogger(__name__)
     default=None,
 )
 @click.option(
+    "--base-nvr",
+    help="Base NVR in Koji to perform a differential build against",
+    default=None,
+)
+@click.option(
     "--comment",
     help="Comment for the build",
     default="Submitted through Packit.",
@@ -60,6 +65,7 @@ def scan_in_osh(
     package_config,
     target,
     base_srpm,
+    base_nvr,
     comment,
     csmock_args,
 ):
@@ -81,6 +87,7 @@ def scan_in_osh(
     cmd_result_stdout = api.run_osh_build(
         chroot=target,
         base_srpm=base_srpm,
+        base_nvr=base_nvr,
         comment=comment,
         csmock_args=csmock_args,
     )


### PR DESCRIPTION
... API and CLI for OpenScanHub scans.

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.


<!-- notes for reviewers -->

Steps to test:

```
git clone git@github.com:util-linux/util-linux.git
cd util-linux
packit scan-in-osh --base-nvr=util-linux-2.40.2-4.fc41
```
The base nvr would be pulled in from Koji.

Example result https://openscanhub.fedoraproject.org/task/45316/

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit now supports `--base-nvr` option while submitting scans to OpenScanHub. The base nvr is pulled in from koji to perform a differential scan.

RELEASE NOTES END
