### PR TITLE
pass custom options to osh-cli from yaml config

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -2402,10 +2402,22 @@ The first dist-git commit to be synced is '{short_hash}'.
         if csmock_args:
             cmd.append("--csmock-args=" + shlex.quote(csmock_args))
 
-        cmd.append("--config=" + str(chroot))
+        osh_config = str(chroot)
+
+        if osh_options := self.package_config.osh_options:
+            if analyzer := osh_options.analyzer:
+                cmd.append("--analyzer=" + shlex.quote(analyzer))
+            if profile := osh_options.profile:
+                cmd.append("--profile=" + shlex.quote(profile))
+            if config := osh_options.config:
+                osh_config = shlex.quote(config)
+
+        cmd.append("--config=" + osh_config)
         cmd.append("--nowait")
         cmd.append("--json")
         cmd.append("--comment=" + comment)
+
+        logger.info(f"Full command passed to osh-cli -> {cmd}")
 
         try:
             cmd_result = commands.run_command(cmd, output=True)

--- a/packit/config/__init__.py
+++ b/packit/config/__init__.py
@@ -5,6 +5,7 @@ from packit.config.common_package_config import (
     CommonPackageConfig,
     Deployment,
     MultiplePackages,
+    OshOptionsConfig,
 )
 from packit.config.config import (
     Config,
@@ -37,6 +38,7 @@ __all__ = [
     MultiplePackages.__name__,
     PackageConfig.__name__,
     RunCommandType.__name__,
+    OshOptionsConfig.__name__,
     "get_context_settings",
     "get_default_map_from_file",
     "parse_loaded_config",

--- a/packit/config/common_package_config.py
+++ b/packit/config/common_package_config.py
@@ -74,6 +74,36 @@ def _construct_dist_git_instance(
     return DISTGIT_INSTANCES["fedpkg"]
 
 
+class OshOptionsConfig:
+    """
+    Configuration class for processing additional OpenScanHub (OSH) options.
+    """
+
+    def __init__(
+        self,
+        analyzer: Optional[str] = None,
+        config: Optional[str] = None,
+        profile: Optional[str] = None,
+    ):
+        self.analyzer = analyzer
+        self.config = config
+        self.profile = profile
+
+    def __repr__(self):
+        from packit.schema import OshOptionsSchema  # For Avoiding cyclical imports
+
+        schema = OshOptionsSchema()
+        return f"OshOptionsConfig: {schema.dumps(self)}"
+
+    def __eq__(self, other: object):
+        if not isinstance(other, OshOptionsConfig):
+            return False
+        from packit.schema import OshOptionsSchema
+
+        schema = OshOptionsSchema()
+        return schema.dump(self) == schema.dump(other)
+
+
 class CommonPackageConfig:
     """Common configuration
 
@@ -260,6 +290,7 @@ class CommonPackageConfig:
         osh_diff_scan_after_copr_build: Optional[bool] = True,
         csmock_args: Optional[str] = None,
         use_target_repo_for_fmf_url: Optional[bool] = False,
+        osh_options: Optional[OshOptionsConfig] = None,
     ):
         self.config_file_path: Optional[str] = config_file_path
         self.specfile_path: Optional[str] = specfile_path
@@ -378,6 +409,7 @@ class CommonPackageConfig:
         self.osh_diff_scan_after_copr_build = osh_diff_scan_after_copr_build
 
         self.csmock_args = csmock_args
+        self.osh_options = osh_options or OshOptionsConfig()
 
         self.use_target_repo_for_fmf_url = use_target_repo_for_fmf_url
 

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -23,6 +23,7 @@ from packit.config import (
     CommonPackageConfig,
     Config,
     Deployment,
+    OshOptionsConfig,
     PackageConfig,
 )
 from packit.config.aliases import DEPRECATED_TARGET_MAP
@@ -411,6 +412,20 @@ def validate_repo_name(value):
     return True
 
 
+class OshOptionsSchema(Schema):
+    """
+    Schema for processing additional osh options
+    """
+
+    analyzer = fields.String(missing=None)
+    config = fields.String(missing=None)
+    profile = fields.String(missing=None)
+
+    @post_load
+    def make_instance(self, data, **_):
+        return OshOptionsConfig(**data)
+
+
 class CommonConfigSchema(Schema):
     """
     Common configuration options and methods for a package.
@@ -510,6 +525,7 @@ class CommonConfigSchema(Schema):
     osh_diff_scan_after_copr_build = fields.Boolean(missing=True)
 
     csmock_args = fields.String(missing=None)
+    osh_options = fields.Nested(OshOptionsSchema)
 
     use_target_repo_for_fmf_url = fields.Boolean(missing=False)
 


### PR DESCRIPTION
<!-- TODO list -->

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #2391

Merge before packit/packit.dev#1024

<!-- release notes footer -->

RELEASE NOTES BEGIN

We have implemented a set of options `osh_options` that allow you to customize OpenScanHub scans via config.

RELEASE NOTES END
