### PR TITLE
ci(tmt): fix upgrading/installing of deps

### DIFF
--- a/plans/full.fmf
+++ b/plans/full.fmf
@@ -13,9 +13,14 @@ adjust:
       # make sure the Copr repo has higher priority than TF Tag Repository
       - how: shell
         script: sed -i -n '/^priority=/!p;$apriority=5' /etc/yum.repos.d/*:packit:packit-dev.repo
-      # upgrade ogr and specfile in case they are already installed
+
+      # upgrade or install ‹ogr›, if needed
       - how: shell
-        script: dnf -y upgrade python3-ogr python3-specfile
+        script: dnf -y upgrade python3-ogr || dnf -y install python3-ogr
+
+      # upgrade or install ‹specfile›, if needed
+      - how: shell
+        script: dnf -y upgrade python3-specfile || dnf -y install python3-specfile
 
   - when: "distro == rhel-9 or distro == centos-9 or distro == centos-stream-9"
     because: "build and deepdiff are not in EPEL 9"

--- a/plans/session-recording.fmf
+++ b/plans/session-recording.fmf
@@ -15,9 +15,13 @@ adjust:
       - how: shell
         script: sed -i -n '/^priority=/!p;$apriority=5' /etc/yum.repos.d/*:packit:packit-dev.repo
 
-      # upgrade ogr and specfile in case they are already installed
+      # upgrade or install ‹ogr›, if needed
       - how: shell
-        script: dnf -y upgrade python3-ogr python3-specfile
+        script: dnf -y upgrade python3-ogr || dnf -y install python3-ogr
+
+      # upgrade or install ‹specfile›, if needed
+      - how: shell
+        script: dnf -y upgrade python3-specfile || dnf -y install python3-specfile
 
   - when: "distro <= rhel-9 or distro <= centos-9 or distro == centos-stream-8 or distro == centos-stream-9"
     prepare+:


### PR DESCRIPTION
When trying to import the plans from ‹ogr›, we found out that at the time of running the ‹prepare› phase not all dependencies might be installed, this, of course, breaks the upgrade of the non-existing dependencies.

Therefore handle deps one-by-one and try to upgrade, if fails, then install.