### PR TITLE
Upper-bound marshmallow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "copr",
     "fedora-distro-aliases",
     "lazy_object_proxy",
-    "marshmallow",
+    "marshmallow < 4.0",
     "marshmallow-enum",
     "munch",
     "ogr",


### PR DESCRIPTION
Marshmallow 4.0 was released 2 weeks ago and it seems that that is causing the failures in #2589