### PR TITLE
fix(copr): do not log failed cancel of Copr build as error

### DIFF
--- a/packit/copr_helper.py
+++ b/packit/copr_helper.py
@@ -560,7 +560,7 @@ class CoprHelper:
             self.copr_client.build_proxy.cancel(build_id)
             return True
         except CoprRequestException as ex:
-            logger.error(f"Failed to cancel build {build_id}: {ex}")
+            logger.warning(f"Failed to cancel build {build_id}: {ex}")
             return False
 
     def get_repo_download_url(self, owner: str, project: str, chroot: str) -> str:


### PR DESCRIPTION
It appears that logging failed cancellation of a Copr build results in spamming our Sentry, therefore turn it just into a warning.

Fixes #2600
