### PR TITLE
feat: pass upstream package name to tag template

### DIFF
--- a/packit/upstream.py
+++ b/packit/upstream.py
@@ -205,7 +205,10 @@ class Upstream:
              tag
         """
         try:
-            tag = self.package_config.upstream_tag_template.format(version=version_)
+            tag = self.package_config.upstream_tag_template.format(
+                version=version_,
+                upstream_package_name=self.package_config.upstream_package_name,
+            )
         except KeyError as e:
             msg = (
                 f"Invalid upstream_tag_template: {self.package_config.upstream_tag_template} - "

--- a/tests/unit/test_upstream.py
+++ b/tests/unit/test_upstream.py
@@ -160,6 +160,13 @@ def test_get_current_version(action_output, version, expected_result, upstream_m
             pytest.raises(PackitException),
             id="no_match_found",
         ),
+        pytest.param(
+            "test_package_name-1.0.0",
+            "{upstream_package_name}-{version}",
+            "1.0.0",
+            does_not_raise(),
+            id="test with upstream_package_name in template",
+        ),
     ],
 )
 def test_get_version_from_tag(
@@ -279,6 +286,13 @@ def test_get_archive_root_dir_from_template(
             "1.0.0",
             pytest.raises(PackitException),
             id="invalid_template",
+        ),
+        pytest.param(
+            "1.0.0",
+            "{upstream_package_name}-{version}",
+            "test_package_name-1.0.0",
+            does_not_raise(),
+            id="upstream package name in the template",
         ),
     ],
 )


### PR DESCRIPTION
Fixes #2603

<!-- release notes footer -->

RELEASE NOTES BEGIN

We have added a support for passing `upstream_package_name` to the `upstream_tag_template` option.

RELEASE NOTES END
