### PR TITLE
Remove unnecessary shlex.quote() when building osh-cli command

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -2402,7 +2402,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         if csmock_args:
             cmd.append("--csmock-args=" + csmock_args)
 
-        osh_config = str(chroot)
+        osh_config = chroot
 
         if osh_options := self.package_config.osh_options:
             if analyzer := osh_options.analyzer:

--- a/packit/api.py
+++ b/packit/api.py
@@ -12,7 +12,6 @@ import copy
 import logging
 import os
 import re
-import shlex
 import tempfile
 from collections.abc import Iterable, Sequence
 from datetime import datetime
@@ -2401,17 +2400,17 @@ The first dist-git commit to be synced is '{short_hash}'.
             csmock_args = self.package_config.csmock_args
 
         if csmock_args:
-            cmd.append("--csmock-args=" + shlex.quote(csmock_args))
+            cmd.append("--csmock-args=" + csmock_args)
 
         osh_config = str(chroot)
 
         if osh_options := self.package_config.osh_options:
             if analyzer := osh_options.analyzer:
-                cmd.append("--analyzer=" + shlex.quote(analyzer))
+                cmd.append("--analyzer=" + analyzer)
             if profile := osh_options.profile:
-                cmd.append("--profile=" + shlex.quote(profile))
+                cmd.append("--profile=" + profile)
             if config := osh_options.config:
-                osh_config = shlex.quote(config)
+                osh_config = config
 
         cmd.append("--config=" + osh_config)
         cmd.append("--nowait")


### PR DESCRIPTION
Context: https://redhat-internal.slack.com/archives/C07NHHR1W5T/p1747661088924529

Using shlex.quote() on arguments like --csmock-args caused incorrect command construction, e.g. "--gcc-analyze --timeout=180" resulted in the argument being quoted as a single string: '--gcc-analyze --timeout=180', which didn't work with argument parsing in osh-cli.

As suggested by @kdudka, the code should be still safe as the command
is passed to subprocess called with shell=False.
