### PR TITLE
Exclude upstream specfile from `files_to_sync`

### DIFF
--- a/packit/sync.py
+++ b/packit/sync.py
@@ -171,7 +171,7 @@ class SyncFilesItem:
 
     def drop_src(
         self,
-        src: Union[str, Path],
+        src: Optional[Union[str, Path]],
         criteria=lambda x, y: x == str(y),
     ) -> Optional["SyncFilesItem"]:
         """Remove 'src' from the list of src-s
@@ -197,12 +197,16 @@ class SyncFilesItem:
             return self_copy
         return None
 
-    def _drop_src_as_filter(self, src: Union[str, Path]) -> None:
+    def _drop_src_as_filter(self, src: Optional[Union[str, Path]]) -> None:
         """Add a rsync filter to drop the 'src' (see drop_src).
 
         Args:
             src: A path to be removed.
         """
+
+        if not src:
+            return
+
         # Note: The filters added apply to all items in self.src
         #   Ideally we could exclude the file with the absolute path *not* relative to
         #   the transfer root.

--- a/packit/sync.py
+++ b/packit/sync.py
@@ -190,8 +190,34 @@ class SyncFilesItem:
         if new_src:
             self_copy = copy.copy(self)
             self_copy.src = new_src
+            # self.src may be a directory, in which case we need to add filter rules
+            # to exclude the src files as well.
+            # Note: criteria check is ignored here, consider dropping the input?
+            self_copy._drop_src_as_filter(src)
             return self_copy
         return None
+
+    def _drop_src_as_filter(self, src: Union[str, Path]) -> None:
+        """Add a rsync filter to drop the 'src' (see drop_src).
+
+        Args:
+            src: A path to be removed.
+        """
+        # Note: The filters added apply to all items in self.src
+        #   Ideally we could exclude the file with the absolute path *not* relative to
+        #   the transfer root.
+        src_path = Path(src)
+        for s in self.src:
+            s_path = Path(s)
+            if not s_path.is_dir():
+                # We only care about adding filters to dirs. Files should have been
+                # handled by drop_src.
+                continue
+            if not src_path.is_relative_to(s_path):
+                # Nothing to do
+                continue
+            filter_rule = f"- /{src_path.relative_to(s_path)}"
+            self.filters.append(filter_rule)
 
 
 def iter_srcs(files_to_sync: Sequence[SyncFilesItem]) -> Iterator[str]:


### PR DESCRIPTION
<!-- TODO list -->

TODO:

- [x] Write new tests or update the old ones to cover new functionality.

Fixes #2539
Closes #2573 (superseeds)

<!-- release notes footer -->

RELEASE NOTES BEGIN

Fix an issue where the upstream spec file was synchronized without applying packit's patches.
This happened when syncing a folder that contains the spefile, e.g.
```yaml
files_to_sync:
  - src: distro/
    dest: ./
specfile_path: distro/my_pkg.spec
```

RELEASE NOTES END
