### PR TITLE
ci(tmt): disable running full and requre in EL10

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -28,8 +28,8 @@ issue_repository: https://github.com/packit/packit
 
 actions:
   create-archive:
-    - "python3 -m build --sdist --outdir ."
-    - "sh -c 'echo packitos-$(hatch version).tar.gz'"
+    - "sh -c 'hatch build -t sdist 2>&1 | tee hatch_build.log'"
+    - "tail -n1 hatch_build.log"
   get-current-version:
     - "hatch version"
   pre-sync:

--- a/plans/full.fmf
+++ b/plans/full.fmf
@@ -31,9 +31,5 @@ adjust:
         script: pip3 install build deepdiff
 
   - when: "distro == rhel-10 or distro == centos-10 or distro == centos-stream-10"
-    because: "flexmock is not in EPEL 10: https://bugzilla.redhat.com/show_bug.cgi?id=2351835"
-    prepare+:
-      - how: install
-        package: python3-pip
-      - how: shell
-        script: pip3 install flexmock
+    because: "We are missing dependencies in EL10 that prohibit us from building."
+    enabled: false

--- a/plans/session-recording.fmf
+++ b/plans/session-recording.fmf
@@ -30,9 +30,5 @@ adjust:
         copr: packit/packit-dev
 
   - when: "distro == rhel-10 or distro == centos-10 or distro == centos-stream-10"
-    because: "flexmock is not in EPEL 10: https://bugzilla.redhat.com/show_bug.cgi?id=2351835"
-    prepare+:
-      - how: install
-        package: python3-pip
-      - how: shell
-        script: pip3 install flexmock
+    because: "We are missing dependencies in EL10 that prohibit us from building."
+    enabled: false


### PR DESCRIPTION
We are still missing dependencies that we need to build Packit in the EL10, therefore disable testing in EL10 explicitly in the plans as it causes issue with reverse-dependency tests in ogr.

Related to the comment: https://github.com/packit/ogr/pull/935#issuecomment-3138839943

Merge before packit/ogr#935