### PR TITLE
chore(git): mark requre responses as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 # Needed for setuptools-scm
 .git_archival.txt  export-subst
+
+# Mark requre responses as generated
+/tests_recording/test_data/**/*.tar.xz linguist-generated
+/tests_recording/test_data/**/*.yaml linguist-generated


### PR DESCRIPTION
As I was working on https://codeberg.org/forgejo/forgejo/pulls/8935, I noticed that it's possible to utilize `.gitattributes` to mark certain files in a repository as _generated_ and affect the git diffs and stats.

As requre responses are generated by requre, it makes sense to mark them as such.

- git docs: https://git-scm.com/docs/gitattributes
- GitHub lingust docs: https://github.com/github-linguist/linguist/blob/main/docs/overrides.md
- Inspired by: https://codeberg.org/forgejo/forgejo/src/commit/f6bc8f7cd7c1e013b54088ed4165c4bbe47c6268/.gitattributes#L6