### PR TITLE
Add --dry-run option to propose-downstream and pull-from-upstream

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -967,8 +967,8 @@ The first dist-git commit to be synced is '{short_hash}'.
         sync_acls: Optional[bool] = False,
         fast_forward_merge_branches: Optional[set[str]] = None,
         dry_run: bool = False,
-    ) -> tuple[PullRequest, dict[str, PullRequest]]:
-        """Overload for type-checking; return PullRequest if create_pr=True."""
+    ) -> tuple[Optional[PullRequest], dict[str, PullRequest]]:
+        """Overload for type-checking; return tuple with optional PullRequest (None if dry_run=True)."""
 
     @overload
     def sync_release(
@@ -1022,7 +1022,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         sync_acls: Optional[bool] = False,
         fast_forward_merge_branches: Optional[set[str]] = None,
         dry_run: bool = False,
-    ) -> Optional[tuple[PullRequest, dict[str, PullRequest]]]:
+    ) -> Optional[tuple[Optional[PullRequest], dict[str, PullRequest]]]:
         """
         Update given package in dist-git
 
@@ -1064,8 +1064,9 @@ The first dist-git commit to be synced is '{short_hash}'.
         Returns:
             Tuple of the created (or existing if one already exists) PullRequest and
              dictionary of branches from fast_forward_merge_branches as keys and
-             PullRequest objects as values if
-            create_pr is True, else None.
+             PullRequest objects as values if create_pr is True, else None.
+             When dry_run is True, PullRequest will be None (PR is not created).
+             When create_pr is False, returns None.
 
         Raises:
             PackitException, if both 'version' and 'tag' are provided.

--- a/packit/api.py
+++ b/packit/api.py
@@ -966,9 +966,37 @@ The first dist-git commit to be synced is '{short_hash}'.
         pr_description_footer: Optional[str] = None,
         sync_acls: Optional[bool] = False,
         fast_forward_merge_branches: Optional[set[str]] = None,
-        dry_run: bool = False,
-    ) -> tuple[Optional[PullRequest], dict[str, PullRequest]]:
-        """Overload: return PullRequest if create_pr=True (None if dry_run=True)."""
+        dry_run: Literal[False] = False,
+    ) -> tuple[PullRequest, dict[str, PullRequest]]:
+        """Overload: return PullRequest when create_pr=True and dry_run=False."""
+
+    @overload
+    def sync_release(
+        self,
+        dist_git_branch: Optional[str] = None,
+        versions: Optional[list[str]] = None,
+        tag: Optional[str] = None,
+        use_local_content=False,
+        add_new_sources=True,
+        force_new_sources=False,
+        upstream_ref: Optional[str] = None,
+        create_pr: Literal[True] = True,
+        force: bool = False,
+        create_sync_note: bool = True,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        local_pr_branch_suffix: str = "update",
+        mark_commit_origin: bool = False,
+        use_downstream_specfile: bool = False,
+        add_pr_instructions: bool = False,
+        resolved_bugs: Optional[list[str]] = None,
+        release_monitoring_project_id: Optional[int] = None,
+        pr_description_footer: Optional[str] = None,
+        sync_acls: Optional[bool] = False,
+        fast_forward_merge_branches: Optional[set[str]] = None,
+        dry_run: Literal[True] = ...,
+    ) -> tuple[None, dict[str, PullRequest]]:
+        """Overload: return None when create_pr=True but dry_run=True."""
 
     @overload
     def sync_release(
@@ -996,7 +1024,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         fast_forward_merge_branches: Optional[set[str]] = None,
         dry_run: bool = False,
     ) -> None:
-        """Overload for type-checking; return None if create_pr=False."""
+        """Overload: return None when create_pr=False."""
 
     def sync_release(
         self,

--- a/packit/api.py
+++ b/packit/api.py
@@ -968,7 +968,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         fast_forward_merge_branches: Optional[set[str]] = None,
         dry_run: bool = False,
     ) -> tuple[Optional[PullRequest], dict[str, PullRequest]]:
-        """Overload for type-checking; return tuple with optional PullRequest (None if dry_run=True)."""
+        """Overload: return PullRequest if create_pr=True (None if dry_run=True)."""
 
     @overload
     def sync_release(
@@ -1855,7 +1855,8 @@ The first dist-git commit to be synced is '{short_hash}'.
         # or because force_new_sources is set.
         if dry_run:
             logger.info(
-                "Dry run: updating sources file without uploading to lookaside cache for archives: %s",
+                "Dry run: updating sources file without uploading "
+                "to lookaside cache for archives: %s",
                 [archive.name for archive in archives],
             )
         else:

--- a/packit/api.py
+++ b/packit/api.py
@@ -357,6 +357,7 @@ class PackitAPI:
         check_sync_status: bool = False,
         check_dist_git_pristine: bool = True,
         resolved_bugs: Optional[list[str]] = None,
+        dry_run: bool = False,
     ):
         """Update a dist-git repo from an upstream (aka source-git) repo
 
@@ -383,6 +384,7 @@ class PackitAPI:
                 and dist-git repos prior to performing the update.
             check_dist_git_pristine: Check whether the dist-git is pristine.
             resolved_bugs: List of bugs that are resolved by the update (e.g. [rhbz#123]).
+            dry_run: Skip uploading to lookaside cache if True.
         """
         if check_sync_status:
             status = self.sync_status()
@@ -454,6 +456,7 @@ class PackitAPI:
                 force_new_sources=force_new_sources,
                 pkg_tool=pkg_tool,
                 env=self.common_env(version=version),
+                dry_run=dry_run,
             )
         else:
             # run the `post-modifications` action even if sources are not being processed
@@ -963,6 +966,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         pr_description_footer: Optional[str] = None,
         sync_acls: Optional[bool] = False,
         fast_forward_merge_branches: Optional[set[str]] = None,
+        dry_run: bool = False,
     ) -> tuple[PullRequest, dict[str, PullRequest]]:
         """Overload for type-checking; return PullRequest if create_pr=True."""
 
@@ -990,6 +994,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         pr_description_footer: Optional[str] = None,
         sync_acls: Optional[bool] = False,
         fast_forward_merge_branches: Optional[set[str]] = None,
+        dry_run: bool = False,
     ) -> None:
         """Overload for type-checking; return None if create_pr=False."""
 
@@ -1016,6 +1021,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         pr_description_footer: Optional[str] = None,
         sync_acls: Optional[bool] = False,
         fast_forward_merge_branches: Optional[set[str]] = None,
+        dry_run: bool = False,
     ) -> Optional[tuple[PullRequest, dict[str, PullRequest]]]:
         """
         Update given package in dist-git
@@ -1052,6 +1058,8 @@ The first dist-git commit to be synced is '{short_hash}'.
                 fork when creating a PR from fork.
             fast_forward_merge_branches: Set of branches `dist_git_branch` should be
                 fast-forward-merged into.
+            dry_run: Prepare dist-git locally without pushing to remote or uploading to
+                lookaside cache.
 
         Returns:
             Tuple of the created (or existing if one already exists) PullRequest and
@@ -1263,6 +1271,7 @@ The first dist-git commit to be synced is '{short_hash}'.
                 mark_commit_origin=mark_commit_origin,
                 check_dist_git_pristine=False,
                 resolved_bugs=resolved_bugs,
+                dry_run=dry_run,
             )
 
             pr = None
@@ -1282,15 +1291,21 @@ The first dist-git commit to be synced is '{short_hash}'.
                 footer = (
                     f"\n---\n\n{pr_description_footer}" if pr_description_footer else ""
                 )
-                pr = self.push_and_create_pr(
-                    pr_title=pr_title,
-                    pr_description=f"{pr_description}{pr_instructions}{footer}",
-                    git_branch=dist_git_branch,
-                    repo=self.dg,
-                    sync_acls=sync_acls,
-                )
+                if dry_run:
+                    logger.info(
+                        "Dry run: skipping push and PR creation for branch %s",
+                        dist_git_branch,
+                    )
+                else:
+                    pr = self.push_and_create_pr(
+                        pr_title=pr_title,
+                        pr_description=f"{pr_description}{pr_instructions}{footer}",
+                        git_branch=dist_git_branch,
+                        repo=self.dg,
+                        sync_acls=sync_acls,
+                    )
 
-                if fast_forward_merge_branches:
+                if fast_forward_merge_branches and not dry_run:
                     for ff_branch in fast_forward_merge_branches:
                         logger.info(
                             f"Syncing branch {ff_branch} defined in `fast_forward_merge_into`",
@@ -1344,8 +1359,19 @@ The first dist-git commit to be synced is '{short_hash}'.
                             target_branch=ff_branch,
                             repo=self.dg,
                         )
+                elif fast_forward_merge_branches and dry_run:
+                    logger.info(
+                        "Dry run: skipping fast-forward merge branches: %s",
+                        fast_forward_merge_branches,
+                    )
             else:
-                self.dg.push(refspec=f"HEAD:{dist_git_branch}")
+                if dry_run:
+                    logger.info(
+                        "Dry run: skipping push to %s",
+                        dist_git_branch,
+                    )
+                else:
+                    self.dg.push(refspec=f"HEAD:{dist_git_branch}")
         finally:
             # version should hold the plain version string
             if version.startswith("v"):
@@ -1774,6 +1800,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         force_new_sources: bool,
         pkg_tool: str = "",
         env: Optional[dict] = None,
+        dry_run: bool = False,
     ):
         """Download upstream archive and upload it to dist-git lookaside cache.
 
@@ -1785,6 +1812,7 @@ The first dist-git commit to be synced is '{short_hash}'.
                 you want to upload archive with the same name but different hash.
             pkg_tool: Tool to upload sources.
             env: Environment to pass to the `post-modifications` action.
+            dry_run: Skip uploading to lookaside cache if True.
         """
         # We need to download the sources beforehand! Previous solution was relying
         # on the HTTP index of the uploaded archives in the lookaside cache which
@@ -1824,15 +1852,23 @@ The first dist-git commit to be synced is '{short_hash}'.
         # There is at least one archive to upload,
         # because it is missing from lookaside, sources file, or both,
         # or because force_new_sources is set.
-        self.init_kerberos_ticket()
+        if dry_run:
+            logger.info(
+                "Dry run: updating sources file without uploading to lookaside cache for archives: %s",
+                [archive.name for archive in archives],
+            )
+        else:
+            self.init_kerberos_ticket()
+
         # Upload all of archives. If we uploaded only those that need uploading,
         # we would lose the unchanged ones from sources file,
         # because upload_to_lookaside_cache maintains the sources file in addition
         # to uploading, and it replaces it entirely, losing the previous content
+        # In dry-run mode, use offline=True to update the sources file without uploading
         self.dg.upload_to_lookaside_cache(
             archives=archives,
             pkg_tool=pkg_tool,
-            offline=not self.package_config.upload_sources,
+            offline=dry_run or not self.package_config.upload_sources,
         )
 
     def should_archives_be_uploaded_to_lookaside(self, archives: list[Path]) -> bool:

--- a/packit/api.py
+++ b/packit/api.py
@@ -1875,6 +1875,7 @@ The first dist-git commit to be synced is '{short_hash}'.
         if (
             not self.should_archives_be_uploaded_to_lookaside(archives)
             and not force_new_sources
+            and not dry_run
         ):
             return
 

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -66,6 +66,7 @@ def sync_release(
     package_config,
     resolve_bug,
     sync_acls,
+    dry_run,
     check_for_non_git_upstream=False,
 ):
     api = get_packit_api(
@@ -109,6 +110,7 @@ def sync_release(
             use_downstream_specfile=use_downstream_specfile,
             resolved_bugs=resolve_bug,
             sync_acls=sync_acls,
+            dry_run=dry_run,
             fast_forward_merge_branches=get_fast_forward_merge_branches_for(
                 dist_git_branches=dist_git_branches,
                 source_branch=branch,
@@ -198,6 +200,12 @@ def sync_release_common_options(func):
     "from which packit should generate patches "
     "(this option implies the repository is source-git).",
 )
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Prepare dist-git repository locally without pushing to remote or uploading to lookaside cache.",
+)
 @pass_config
 @cover_packit_exception
 @iterate_packages
@@ -215,6 +223,7 @@ def propose_downstream(
     sync_acls,
     resolve_bug,
     package_config,
+    dry_run,
 ):
     """
     Land a new upstream release in Fedora using upstream packit config.
@@ -240,11 +249,18 @@ def propose_downstream(
         package_config=package_config,
         resolve_bug=resolve_bug,
         sync_acls=sync_acls,
+        dry_run=dry_run,
     )
 
 
 @click.command("pull-from-upstream", context_settings=get_context_settings())
 @sync_release_common_options
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Prepare dist-git repository locally without pushing to remote or uploading to lookaside cache.",
+)
 @pass_config
 @cover_packit_exception
 @iterate_packages
@@ -260,6 +276,7 @@ def pull_from_upstream(
     sync_acls,
     resolve_bug,
     package_config,
+    dry_run,
 ):
     """
     Land a new upstream release in Fedora using downstream packit config.
@@ -285,5 +302,6 @@ def pull_from_upstream(
         package_config=package_config,
         resolve_bug=resolve_bug,
         sync_acls=sync_acls,
+        dry_run=dry_run,
         check_for_non_git_upstream=True,
     )

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -169,7 +169,8 @@ def sync_release_common_options(func):
         "--dry-run",
         is_flag=True,
         default=False,
-        help="Prepare dist-git repository locally without pushing to remote or uploading to lookaside cache.",
+        help="Prepare dist-git locally without pushing to remote "
+        "or uploading to lookaside cache.",
     )
     @click.option(
         PACKAGE_SHORT_OPTION,

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -166,6 +166,12 @@ def sync_release_common_options(func):
         help="Sync ACLs between dist-git repo and the fork, is considered only with --pr option.",
     )
     @click.option(
+        "--dry-run",
+        is_flag=True,
+        default=False,
+        help="Prepare dist-git repository locally without pushing to remote or uploading to lookaside cache.",
+    )
+    @click.option(
         PACKAGE_SHORT_OPTION,
         PACKAGE_LONG_OPTION,
         multiple=True,
@@ -199,12 +205,6 @@ def sync_release_common_options(func):
     help="Git ref of the last upstream commit in the current branch "
     "from which packit should generate patches "
     "(this option implies the repository is source-git).",
-)
-@click.option(
-    "--dry-run",
-    is_flag=True,
-    default=False,
-    help="Prepare dist-git repository locally without pushing to remote or uploading to lookaside cache.",
 )
 @pass_config
 @cover_packit_exception
@@ -255,12 +255,6 @@ def propose_downstream(
 
 @click.command("pull-from-upstream", context_settings=get_context_settings())
 @sync_release_common_options
-@click.option(
-    "--dry-run",
-    is_flag=True,
-    default=False,
-    help="Prepare dist-git repository locally without pushing to remote or uploading to lookaside cache.",
-)
 @pass_config
 @cover_packit_exception
 @iterate_packages

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -25,7 +25,9 @@ from packit.utils import get_default_branch
 logger = logging.getLogger(__name__)
 
 
-def get_dist_git_branches(api, dist_git_branch, pull_from_upstream=False, dry_run=False):
+def get_dist_git_branches(
+    api, dist_git_branch, pull_from_upstream=False, dry_run=False,
+):
     cmdline_dg_branches = dist_git_branch.split(",") if dist_git_branch else []
     config_dg_branches = []
     if isinstance(api.package_config, PackageConfig):

--- a/packit/cli/propose_downstream.py
+++ b/packit/cli/propose_downstream.py
@@ -20,11 +20,12 @@ from packit.constants import (
     PACKAGE_OPTION_HELP,
     PACKAGE_SHORT_OPTION,
 )
+from packit.utils import get_default_branch
 
 logger = logging.getLogger(__name__)
 
 
-def get_dist_git_branches(api, dist_git_branch, pull_from_upstream=False):
+def get_dist_git_branches(api, dist_git_branch, pull_from_upstream=False, dry_run=False):
     cmdline_dg_branches = dist_git_branch.split(",") if dist_git_branch else []
     config_dg_branches = []
     if isinstance(api.package_config, PackageConfig):
@@ -34,7 +35,14 @@ def get_dist_git_branches(api, dist_git_branch, pull_from_upstream=False):
             )
         )
 
-    default_dg_branch = api.dg.local_project.git_project.default_branch
+    if dry_run:
+        # In dry-run mode nothing is pushed to the remote, so avoid contacting
+        # the forge API (it fails for packages that don't exist on the remote,
+        # e.g. a local-only dist-git clone) and determine the default branch
+        # from the local dist-git clone instead.
+        default_dg_branch = get_default_branch(api.dg.local_project.git_repo)
+    else:
+        default_dg_branch = api.dg.local_project.git_project.default_branch
 
     dg_branches = (
         cmdline_dg_branches or config_dg_branches or default_dg_branch.split(",")
@@ -42,11 +50,12 @@ def get_dist_git_branches(api, dist_git_branch, pull_from_upstream=False):
     return dg_branches, default_dg_branch
 
 
-def get_dg_branches(api, dist_git_branch, pull_from_upstream=False):
+def get_dg_branches(api, dist_git_branch, pull_from_upstream=False, dry_run=False):
     dg_branches, default_dg_branch = get_dist_git_branches(
         api,
         dist_git_branch,
         pull_from_upstream,
+        dry_run=dry_run,
     )
     return get_branches(*dg_branches, default_dg_branch=default_dg_branch)
 
@@ -83,6 +92,7 @@ def sync_release(
         api,
         dist_git_branch,
         pull_from_upstream=use_downstream_specfile,
+        dry_run=dry_run,
     )
 
     click.echo(
@@ -93,6 +103,7 @@ def sync_release(
         api,
         dist_git_branch,
         pull_from_upstream=use_downstream_specfile,
+        dry_run=dry_run,
     )
     branches_to_update = get_branches(
         *dist_git_branches,

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -789,3 +789,47 @@ def test_get_local_archives_to_upload_skips_git_tracked(
     result = api_mock.get_local_archives_to_upload()
 
     assert result == [tmp_path / name for name in expected_to_upload]
+
+
+def test_sync_release_dry_run_skips_remote_operations(api_mock):
+    """Test that dry_run=True skips push and PR creation but does local work."""
+    flexmock(PatchGenerator).should_receive("undo_identical")
+    api_mock.up.should_receive("get_specfile_version").and_return("0")
+    api_mock.up.should_receive("specfile").and_return(
+        flexmock().should_receive("reload").mock(),
+    )
+    api_mock.up.package_config.should_receive("get_base_env").and_return({})
+    api_mock.dg.should_receive("get_specfile_version").and_return("0")
+    api_mock.dg.should_receive("specfile").and_return(
+        flexmock().should_receive("reload").mock(),
+    )
+    # In dry-run mode, push_and_create_pr should NOT be called
+    api_mock.should_receive("push_and_create_pr").never()
+    # But update_dist_git should still be called
+    api_mock.should_receive("update_dist_git").once()
+    
+    api_mock.sync_release(versions=["1.1"], dist_git_branch="_", dry_run=True)
+
+
+def test_sync_release_dry_run_skips_push_when_create_pr_false(api_mock):
+    """Test that dry_run=True skips direct push when create_pr=False."""
+    flexmock(PatchGenerator).should_receive("undo_identical")
+    api_mock.up.should_receive("get_specfile_version").and_return("0")
+    api_mock.up.should_receive("specfile").and_return(
+        flexmock().should_receive("reload").mock(),
+    )
+    api_mock.up.package_config.should_receive("get_base_env").and_return({})
+    api_mock.dg.should_receive("get_specfile_version").and_return("0")
+    api_mock.dg.should_receive("specfile").and_return(
+        flexmock().should_receive("reload").mock(),
+    )
+    # In dry-run mode with create_pr=False, dg.push should NOT be called
+    api_mock.dg.should_receive("push").never()
+    api_mock.should_receive("update_dist_git").once()
+    
+    api_mock.sync_release(
+        versions=["1.1"], 
+        dist_git_branch="_", 
+        create_pr=False,
+        dry_run=True,
+    )

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -807,7 +807,7 @@ def test_sync_release_dry_run_skips_remote_operations(api_mock):
     api_mock.should_receive("push_and_create_pr").never()
     # But update_dist_git should still be called
     api_mock.should_receive("update_dist_git").once()
-    
+
     api_mock.sync_release(versions=["1.1"], dist_git_branch="_", dry_run=True)
 
 
@@ -826,10 +826,10 @@ def test_sync_release_dry_run_skips_push_when_create_pr_false(api_mock):
     # In dry-run mode with create_pr=False, dg.push should NOT be called
     api_mock.dg.should_receive("push").never()
     api_mock.should_receive("update_dist_git").once()
-    
+
     api_mock.sync_release(
-        versions=["1.1"], 
-        dist_git_branch="_", 
+        versions=["1.1"],
+        dist_git_branch="_",
         create_pr=False,
         dry_run=True,
     )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -62,6 +62,7 @@ def test_propose_downstream_command():
         package_config=PackageConfig,
         resolve_bug=None,
         sync_acls=False,
+        dry_run=False,
     ).and_return()
     result = call_packit(packit_base, parameters=["propose-downstream", "."])
     assert result.exit_code == 0
@@ -86,6 +87,63 @@ def test_pull_from_upstream_command():
         package_config=PackageConfig,
         resolve_bug=None,
         sync_acls=False,
+        dry_run=False,
     ).and_return()
     result = call_packit(packit_base, parameters=["pull-from-upstream", "."])
+    assert result.exit_code == 0
+
+
+def test_propose_downstream_with_dry_run():
+    """Test that --dry-run flag is properly passed to sync_release"""
+    flexmock(utils).should_receive("get_local_package_config").and_return(
+        flexmock().should_receive("get_package_config_views").and_return({}).mock(),
+    )
+    flexmock(propose_downstream_module).should_receive("sync_release").with_args(
+        config=Config,
+        dist_git_path=None,
+        dist_git_branch=None,
+        force_new_sources=False,
+        pr=None,
+        path_or_url=LocalProject,
+        version=None,
+        force=False,
+        local_content=False,
+        upstream_ref=None,
+        use_downstream_specfile=False,
+        package_config=PackageConfig,
+        resolve_bug=None,
+        sync_acls=False,
+        dry_run=True,
+    ).and_return()
+    result = call_packit(
+        packit_base, parameters=["propose-downstream", ".", "--dry-run"],
+    )
+    assert result.exit_code == 0
+
+
+def test_pull_from_upstream_with_dry_run():
+    """Test that --dry-run flag is properly passed to sync_release"""
+    flexmock(utils).should_receive("get_local_package_config").and_return(
+        flexmock().should_receive("get_package_config_views").and_return({}).mock(),
+    )
+    flexmock(propose_downstream_module).should_receive("sync_release").with_args(
+        config=Config,
+        dist_git_path=None,
+        dist_git_branch=None,
+        force_new_sources=False,
+        pr=None,
+        path_or_url=LocalProject,
+        version=None,
+        force=False,
+        local_content=False,
+        upstream_ref=None,
+        use_downstream_specfile=True,
+        package_config=PackageConfig,
+        resolve_bug=None,
+        sync_acls=False,
+        dry_run=True,
+    ).and_return()
+    result = call_packit(
+        packit_base, parameters=["pull-from-upstream", ".", "--dry-run"],
+    )
     assert result.exit_code == 0

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -116,7 +116,8 @@ def test_propose_downstream_with_dry_run():
         dry_run=True,
     ).and_return()
     result = call_packit(
-        packit_base, parameters=["propose-downstream", ".", "--dry-run"],
+        packit_base,
+        parameters=["propose-downstream", ".", "--dry-run"],
     )
     assert result.exit_code == 0
 
@@ -144,6 +145,7 @@ def test_pull_from_upstream_with_dry_run():
         dry_run=True,
     ).and_return()
     result = call_packit(
-        packit_base, parameters=["pull-from-upstream", ".", "--dry-run"],
+        packit_base,
+        parameters=["pull-from-upstream", ".", "--dry-run"],
     )
     assert result.exit_code == 0

--- a/tests/unit/test_propose_downstream.py
+++ b/tests/unit/test_propose_downstream.py
@@ -5,6 +5,7 @@ import pytest
 from flexmock import flexmock
 
 from packit.api import PackitAPI
+from packit.cli import propose_downstream
 from packit.cli.propose_downstream import get_dg_branches
 from packit.config import (
     CommonPackageConfig,
@@ -278,3 +279,54 @@ def test_get_dist_git_branches(package_config, cmdline, expected):
     api.dg = flexmock(local_project=local_project)
 
     assert get_dg_branches(api, cmdline) == expected
+
+
+def _dry_run_api():
+    """Build a PackitAPI whose forge lookup (git_project.default_branch) raises
+    if it is ever accessed, so tests can prove dry-run stays offline."""
+    api = flexmock(PackitAPI)
+    api.package_config = PackageConfig(
+        packages={"package": CommonPackageConfig(specfile_path="xxx")},
+        jobs=[
+            JobConfig(
+                type=JobType.propose_downstream,
+                trigger=JobConfigTriggerType.pull_request,
+                packages={"package": CommonPackageConfig(specfile_path="xxx")},
+            ),
+        ],
+    )
+    git_repo = flexmock()
+    git_project = flexmock()
+    git_project.should_receive("default_branch").and_raise(
+        AssertionError("forge API must not be queried in dry-run mode"),
+    )
+    local_project = flexmock(git_repo=git_repo, git_project=git_project)
+    api.dg = flexmock(local_project=local_project)
+    return api, git_repo
+
+
+@pytest.mark.usefixtures("mock_get_aliases")
+def test_get_dist_git_branches_dry_run_no_branches():
+    """With no branches given, dry-run falls back to the local clone's default
+    branch instead of the forge API."""
+    api, git_repo = _dry_run_api()
+    flexmock(propose_downstream).should_receive("get_default_branch").with_args(
+        git_repo,
+    ).and_return("local_default").once()
+
+    assert get_dg_branches(api, None, dry_run=True) == {"local_default"}
+
+
+@pytest.mark.usefixtures("mock_get_aliases")
+def test_get_dist_git_branches_dry_run_with_branches():
+    """When branches are given explicitly, dry-run uses them without querying
+    the forge API for the default branch."""
+    api, git_repo = _dry_run_api()
+    flexmock(propose_downstream).should_receive("get_default_branch").with_args(
+        git_repo,
+    ).and_return("local_default")
+
+    assert get_dg_branches(api, "cmdline1,cmdline2", dry_run=True) == {
+        "cmdline1",
+        "cmdline2",
+    }


### PR DESCRIPTION
The --dry-run flag prepares dist-git locally without pushing to remote infrastructure or uploading to lookaside cache.

This allows maintainers to:
- Test dist-git updates locally
- Perform local builds before pushing to Fedora infrastructure
- Verify changes without affecting remote repositories

<!-- TODO list -->

TODO:

- [x] Write new tests or update the old ones to cover new functionality.
- [x] Update doc-strings where appropriate.
- [x] Update or write new documentation in `packit/packit.dev`.

Fixes #1952 

<!-- release notes footer -->

RELEASE NOTES BEGIN

Packit now supports dry-run for the propose-downstream and pull-from-upstream commands.

RELEASE NOTES END
