### PR TITLE
Make osc an optional dependency

### DIFF
--- a/packit/utils/obs_helper.py
+++ b/packit/utils/obs_helper.py
@@ -11,6 +11,7 @@ from typing import Optional
 
 try:
     from osc import conf, core
+
     _OSC_AVAILABLE = True
 except ImportError:
     _OSC_AVAILABLE = False

--- a/packit/utils/obs_helper.py
+++ b/packit/utils/obs_helper.py
@@ -9,7 +9,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from osc import conf, core
+try:
+    from osc import conf, core
+    _OSC_AVAILABLE = True
+except ImportError:
+    _OSC_AVAILABLE = False
 
 from packit.config import PackageConfig
 from packit.config.aliases import DEPRECATED_TARGET_MAP
@@ -17,6 +21,14 @@ from packit.config.aliases import DEPRECATED_TARGET_MAP
 logger = logging.getLogger(__name__)
 
 _API_URL = "https://api.opensuse.org"
+
+
+def _require_osc() -> None:
+    if not _OSC_AVAILABLE:
+        raise RuntimeError(
+            "The osc library is not installed. Install it with "
+            "'pip install packit[osc]' to use the OBS functionality.",
+        )
 
 
 @dataclass(frozen=True)
@@ -283,6 +295,7 @@ def create_package(project_name: str, package_name: str) -> None:
     root.append(title)
     root.append(descr)
 
+    _require_osc()
     package_url = core.makeurl(
         _API_URL,
         ["source", project_name, package_name, "_meta"],
@@ -315,6 +328,7 @@ def create_obs_project(
     Raises:
         ValueError: If the provided package_config contains multiple packages.
     """
+    _require_osc()
     conf.get_config()
     owner = owner or conf.config["api_host_options"][_API_URL]["user"]
     project_name = project or f"home:{owner}:packit"
@@ -369,6 +383,7 @@ def init_obs_project(
     Returns:
         Path: Path to the empty package directory within the OBS project.
     """
+    _require_osc()
     core.Project.init_project(
         _API_URL,
         (prj_dir := Path(build_dir)),
@@ -420,6 +435,7 @@ def commit_srpm_and_get_build_results(
     """
     # don't use the files argument of unpack_srcrpm, it allows for shell
     # injection unless sanitized carefully
+    _require_osc()
     core.unpack_srcrpm(str(srpm), package_dir)
 
     create_changes_file(package_dir=package_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,6 @@ dependencies = [
     "python-bugzilla",
     "backoff",
     "tomli; python_version < '3.11'",
-    # osc 1.8.2 introduced a regression that was fixed via https://github.com/openSUSE/osc/pull/1595 in 1.8.3
-    "osc >= 1.6.2, != 1.8.2",
     "opensuse-distro-aliases",
 ]
 
@@ -80,6 +78,10 @@ testing = [
 dev = [
     "packitos[testing]",
     "pre-commit",
+]
+osc = [
+    # osc 1.8.2 introduced a regression that was fixed via https://github.com/openSUSE/osc/pull/1595 in 1.8.3
+    "osc >= 1.6.2, != 1.8.2",
 ]
 
 [project.scripts]

--- a/tests/unit/test_obs_build.py
+++ b/tests/unit/test_obs_build.py
@@ -5,6 +5,8 @@ import xml.etree.ElementTree as ET
 
 import pytest
 
+pytest.importorskip("osc")
+
 from packit.utils import obs_helper
 
 _NAME = "home:me:packit"


### PR DESCRIPTION
Fixes #2687

把 osc 从主依赖移到 optional extra,packit 可以在不装 osc 的情况下使用(缓解 #2537——packit/api.py 顶层导入 obs_helper,之前缺 osc 时 `import packit` 直接 ImportError):
- pyproject.toml:`osc >= 1.6.2, != 1.8.2` 从 [project.dependencies] 移到新的 [project.optional-dependencies] `osc` extra
- packit/utils/obs_helper.py:`from osc import conf, core` 改为 try/except ImportError + `_OSC_AVAILABLE` 标志;4 个使用 conf/core 的函数(create_package / create_obs_project / init_obs_project / commit_srpm_and_get_build_results)入口调用 `_require_osc()`,缺 osc 时给出清晰报错 `pip install packit[osc]`
- tests/unit/test_obs_build.py:加 `pytest.importorskip("osc")`,无 osc 环境跳过而非收集失败

验证:py_compile 通过;pyproject 确认 osc 仅在 extras;全部 13 处 conf/core 调用均在 4 个已守卫函数内。注:本机 Windows 无法完整安装 packit 依赖(cccolutils 等 C 扩展不构建),完整 CI 由上游验证。