### PR TITLE
Improve error message when pagure API key is missing

### DIFF
--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -13,7 +13,8 @@ import requests
 import rpm
 from git import GitCommandError, PushInfo
 from ogr.abstract import AccessLevel, GitProject, PullRequest
-from ogr.services.pagure import PagureProject
+from ogr.exceptions import OgrNetworkError
+from ogr.services.pagure import PagureProject, PagureService
 from specfile import Specfile
 from specfile.exceptions import (
     DuplicateSourceException,
@@ -37,6 +38,21 @@ from packit.utils.lookaside import LookasideCache
 from packit.utils.repo import RepositoryCache, commit_message_file
 
 logger = getLogger(__name__)
+
+
+def _is_auth_failure(ex: BaseException) -> bool:
+    """Whether an exception (or its cause chain) looks like repeated 401s.
+
+    urllib3/requests report exhausted auth retries as "too many 401 error
+    responses" inside a RetryError/ConnectionError; ogr may wrap that into
+    an OgrNetworkError whose __cause__ still carries the message.
+    """
+    current: Optional[BaseException] = ex
+    while current is not None:
+        if "401" in str(current):
+            return True
+        current = current.__cause__
+    return False
 
 
 class PackitRepositoryBase:
@@ -671,7 +687,25 @@ class PackitRepositoryBase:
 
     def get_user(self) -> Optional[str]:
         if self.local_project.git_service:
-            return self.local_project.git_service.user.get_username()
+            try:
+                return self.local_project.git_service.user.get_username()
+            except (requests.exceptions.RequestException, OgrNetworkError) as ex:
+                # A missing or invalid pagure API key surfaces as repeated 401s
+                # from the whoami call ("too many 401 error responses"), which
+                # is not actionable for users. Translate it, but only for
+                # pagure and only when the failure really is an auth failure —
+                # everything else propagates unchanged.
+                if (
+                    isinstance(self.local_project.git_service, PagureService)
+                    and _is_auth_failure(ex)
+                ):
+                    raise PackitException(
+                        "You need to add an API key for pagure in your packit "
+                        "config file. See "
+                        "https://packit.dev/docs/configuration#user-configuration-file "
+                        "for details.",
+                    ) from ex
+                raise
         return None
 
     def existing_pr(

--- a/packit/base_git.py
+++ b/packit/base_git.py
@@ -695,10 +695,9 @@ class PackitRepositoryBase:
                 # is not actionable for users. Translate it, but only for
                 # pagure and only when the failure really is an auth failure —
                 # everything else propagates unchanged.
-                if (
-                    isinstance(self.local_project.git_service, PagureService)
-                    and _is_auth_failure(ex)
-                ):
+                if isinstance(
+                    self.local_project.git_service, PagureService,
+                ) and _is_auth_failure(ex):
                     raise PackitException(
                         "You need to add an API key for pagure in your packit "
                         "config file. See "

--- a/tests/unit/test_base_git.py
+++ b/tests/unit/test_base_git.py
@@ -8,6 +8,7 @@ from typing import Optional, Union
 import pytest
 from distro import linux_distribution
 from flexmock import flexmock
+from ogr.services.pagure import PagureService
 from specfile import Specfile
 from specfile.changelog import ChangelogEntry
 
@@ -23,8 +24,6 @@ from packit.upstream import GitUpstream
 from packit.utils import commands
 from packit.utils.repo import create_new_repo
 from tests.spellbook import can_a_module_be_imported, initiate_git_repo
-
-from ogr.services.pagure import PagureService
 
 
 @pytest.fixture()

--- a/tests/unit/test_base_git.py
+++ b/tests/unit/test_base_git.py
@@ -17,11 +17,14 @@ from packit.command_handler import LocalCommandHandler
 from packit.config import CommonPackageConfig, Config, PackageConfig, RunCommandType
 from packit.config.sources import SourcesItem
 from packit.distgit import DistGit
+from packit.exceptions import PackitException
 from packit.local_project import LocalProject, LocalProjectBuilder
 from packit.upstream import GitUpstream
 from packit.utils import commands
 from packit.utils.repo import create_new_repo
 from tests.spellbook import can_a_module_be_imported, initiate_git_repo
+
+from ogr.services.pagure import PagureService
 
 
 @pytest.fixture()
@@ -1162,3 +1165,49 @@ def test_default_macro_definitions(
     )
     dist_git._specfile_path = distgit_spec_path
     assert dist_git.specfile.macros == result
+
+
+def _base_with_service(service):
+    base = PackitRepositoryBase(config=flexmock(), package_config=flexmock())
+    base.local_project = flexmock(git_service=service)
+    return base
+
+
+def test_get_user_pagure_auth_failure_raises_clear_message():
+    service = PagureService(
+        token="invalid-token",
+        instance_url="https://src.fedoraproject.org",
+    )
+    flexmock(service).should_receive("user").and_raise(
+        requests.exceptions.ConnectionError(
+            "HTTPSConnectionPool(host='src.fedoraproject.org', port=443): "
+            "Max retries exceeded with url: /api/0/-/whoami "
+            "(Caused by ResponseError('too many 401 error responses'))",
+        ),
+    )
+
+    with pytest.raises(PackitException, match="API key for pagure"):
+        _base_with_service(service).get_user()
+
+
+def test_get_user_pagure_non_auth_network_error_propagates():
+    service = PagureService(
+        token="valid-looking-token",
+        instance_url="https://src.fedoraproject.org",
+    )
+    original = requests.exceptions.ConnectionError("Connection refused")
+    flexmock(service).should_receive("user").and_raise(original)
+
+    with pytest.raises(requests.exceptions.ConnectionError):
+        _base_with_service(service).get_user()
+
+
+def test_get_user_non_pagure_auth_failure_propagates():
+    service = flexmock()
+    original = requests.exceptions.ConnectionError(
+        "Max retries exceeded (Caused by ResponseError('too many 401 error responses'))",
+    )
+    flexmock(service).should_receive("user").and_raise(original)
+
+    with pytest.raises(requests.exceptions.ConnectionError):
+        _base_with_service(service).get_user()


### PR DESCRIPTION
Fixes #2737

`packit pull-from-upstream` 在缺少/无效 pagure API key 时,原来报晦涩的 `too many 401 error responses`(whoami 重试耗尽)。现在翻译成可操作的报错:
`You need to add an API key for pagure in your packit config file. See https://packit.dev/docs/configuration#user-configuration-file for details.`

- packit/base_git.py:get_user() 捕获 pagure 服务认证失败(requests 异常或 ogr 的 OgrNetworkError,异常链含 401 即判定为认证失败),抛 PackitException 清晰报错;仅限 PagureService,非认证网络错误与 GitHub 路径原样传播
- tests/unit/test_base_git.py:3 个新测试(pagure 401 → 清晰报错;pagure 非认证网络错误原样传播;非 pagure 认证错误原样传播)

验证:py_compile 通过;PagureService 构造函数经 ogr 源码确认无网络调用(测试前提)。注:本机 Windows 无法导入 packit.base_git(缺 rpm 模块),完整单测由上游 CI 跑。另:测试里的 token 为明显伪造的假值,本地 pre-commit 密钥扫描误报已按官方 bypass 处理。