### PR TITLE
Add JSON Schema generation for package config using marshmallow-jsonschema

### DIFF
--- a/files/tasks/rpm-test-deps.yaml
+++ b/files/tasks/rpm-test-deps.yaml
@@ -21,6 +21,7 @@
       - python3-pytest-timeout
       - python3-deepdiff
       - python3-flexmock
+      - python3-jsonschema
     state: present
   when: ansible_facts['distribution'] == 'Fedora'
   become: true
@@ -42,6 +43,15 @@
       - pytest-timeout
       - deepdiff
       - flexmock
+      - jsonschema
     state: latest
   when: ansible_facts['distribution'] != 'Fedora'
+  become: true
+
+# not packaged for Fedora/EPEL, install from PyPI
+- name: Install dependencies from PyPI
+  ansible.builtin.pip:
+    name:
+      - marshmallow-jsonschema
+    state: latest
   become: true

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -66,6 +66,14 @@ class StringOrListOfStringsField(fields.Field):
             return [value]
         raise ValidationError(f"Expected 'list[str]' or 'str', got {type(value)!r}.")
 
+    def _jsonschema_type_mapping(self):
+        return {
+            "anyOf": [
+                {"type": "string"},
+                {"type": "array", "items": {"type": "string"}},
+            ],
+        }
+
 
 class SyncFilesItemSchema(Schema):
     """Schema for SyncFilesItem"""
@@ -101,6 +109,35 @@ class FilesToSyncField(fields.Field):
             return SyncFilesItem(src=[value], dest=value)
         raise ValidationError(f"Expected 'dict' or 'str', got {type(value)!r}.")
 
+    def _jsonschema_type_mapping(self):
+        return {
+            "anyOf": [
+                {"type": "string"},
+                {
+                    "type": "object",
+                    "properties": {
+                        "src": {
+                            "anyOf": [
+                                {"type": "string"},
+                                {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                            ],
+                        },
+                        "dest": {"type": "string"},
+                        "mkpath": {"type": "boolean"},
+                        "delete": {"type": "boolean"},
+                        "filters": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                    },
+                    "required": ["src", "dest"],
+                },
+            ],
+        }
+
 
 class ActionField(fields.Field):
     """
@@ -134,6 +171,17 @@ class ActionField(fields.Field):
         if invalid_actions:
             raise ValidationError(f"Unknown action(s) provided: {invalid_actions}")
 
+    def _jsonschema_type_mapping(self):
+        return {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    {"type": "string"},
+                    {"type": "array", "items": {"type": "string"}},
+                ],
+            },
+        }
+
 
 class NotProcessedField(fields.Field):
     """
@@ -157,6 +205,10 @@ class NotProcessedField(fields.Field):
         additional_message = self.metadata.get("additional_message")
         if additional_message:
             logger.warning(f"{additional_message}")
+
+    def _jsonschema_type_mapping(self):
+        # This field is deprecated and not processed — accept anything.
+        return {}
 
 
 class SourceSchema(Schema):
@@ -256,6 +308,14 @@ class ListOrDict(fields.Field):
             or not all(isinstance(k, str) for k in value)
             or not all(isinstance(v, dict) for v in value.values())
         )
+
+    def _jsonschema_type_mapping(self):
+        return {
+            "anyOf": [
+                {"type": "array", "items": {"type": "string"}},
+                {"type": "object"},
+            ],
+        }
 
 
 class DistGitBranches(ListOrDict):
@@ -467,6 +527,11 @@ class CommonConfigSchema(Schema):
     spec_source_id = fields.Method(
         deserialize="spec_source_id_fm",
         serialize="spec_source_id_serialize",
+        metadata={
+            "_jsonschema_type_mapping": {
+                "anyOf": [{"type": "string"}, {"type": "integer"}],
+            },
+        },
     )
     files_to_sync = fields.List(FilesToSyncField())
     actions = ActionField(dump_default={})
@@ -947,6 +1012,21 @@ class PackageConfigSchema(Schema):
     @post_load
     def make_instance(self, data: dict, **_) -> PackageConfig:
         return PackageConfig(**data)
+
+    @classmethod
+    def json_schema(cls) -> dict:
+        """Generate a JSON Schema (Draft-07) for the PackageConfig.
+
+        Uses ``marshmallow-jsonschema`` to introspect the marshmallow
+        schema and produce a JSON Schema dict suitable for submission to
+        the `Schema Store <https://www.schemastore.org/>`_.
+
+        Returns:
+            A dict representing the JSON Schema.
+        """
+        from marshmallow_jsonschema import JSONSchema
+
+        return JSONSchema().dump(cls())
 
 
 class UserConfigSchema(Schema):

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -26,7 +26,7 @@ from packit.config import (
     OshOptionsConfig,
     PackageConfig,
 )
-from packit.config.aliases import DEPRECATED_TARGET_MAP
+from packit.config.aliases import ARCHITECTURE_LIST, DEPRECATED_TARGET_MAP
 from packit.config.commands import TestCommandConfig
 from packit.config.common_package_config import MockBootstrapSetup
 from packit.config.job_config import (
@@ -365,7 +365,42 @@ class DistGitBranches(ListOrDict):
         return True
 
 
+# A Copr build target may be a stable release alias (resolved to concrete
+# chroots at runtime), a concrete Fedora/EPEL chroot, or a chroot of any other
+# Copr-supported distro.  The Fedora/EPEL namespaces are validated strictly so
+# a typo such as `fedora-unstable` is rejected, while every other distro is
+# matched loosely because that set is open-ended.
+_TARGET_ARCHES = "|".join(ARCHITECTURE_LIST)
+_TARGET_ARCH_SUFFIX = rf"(?:-(?:{_TARGET_ARCHES}))?"
+
+_TARGET_RELEASE_ALIASES = (
+    r"fedora-stable|fedora-development|fedora-latest-stable|fedora-latest"
+    r"|fedora-branched|fedora-all|fedora-rawhide|fedora-eln|epel-all"
+)
+
+_TARGET_PATTERN = (
+    rf"^(?:"
+    rf"(?:{_TARGET_RELEASE_ALIASES}){_TARGET_ARCH_SUFFIX}"  # release aliases
+    rf"|fedora-[0-9]+{_TARGET_ARCH_SUFFIX}"  # Fedora chroots
+    rf"|epel-[0-9]+(?:\.[0-9]+)?(?:-(?:branched|all))?{_TARGET_ARCH_SUFFIX}"  # EPEL chroots
+    rf"|(?!fedora-)(?!epel-).+"  # any other distro
+    rf")$"
+)
+
+
 class Targets(ListOrDict):
+    def _jsonschema_type_mapping(self):
+        return {
+            "anyOf": [
+                {"type": "string", "pattern": _TARGET_PATTERN},
+                {
+                    "type": "array",
+                    "items": {"type": "string", "pattern": _TARGET_PATTERN},
+                },
+                {"type": "object"},
+            ],
+        }
+
     def is_dict(self, value) -> bool:
         if not super().is_dict(value):
             return False

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -662,13 +662,47 @@ class JobConfigSchema(Schema):
     """
 
     job = fields.Enum(JobType, required=True, attribute="type")
-    trigger = fields.Enum(JobConfigTriggerType, required=True)
+    trigger = fields.Enum(
+        JobConfigTriggerType,
+        required=True,
+        metadata={
+            "_jsonschema_type_mapping": {
+                "anyOf": [
+                    {"enum": [t.value for t in JobConfigTriggerType]},
+                    {
+                        "type": "string",
+                        "pattern": r"\s*\|\s*",
+                        "description": (
+                            "pipe-separated triggers, e.g. 'commit | koji_build'"
+                        ),
+                    },
+                ],
+            },
+        },
+    )
     skip_build = fields.Boolean()
     manual_trigger = fields.Boolean()
     labels = fields.List(fields.String(), load_default=None)
     packages = fields.Dict(
         keys=fields.String(),
         values=fields.Nested(CommonConfigSchema()),
+        metadata={
+            "_jsonschema_type_mapping": {
+                "anyOf": [
+                    {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "names of the packages the job applies to",
+                    },
+                    {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/definitions/CommonConfigSchema",
+                        },
+                    },
+                ],
+            },
+        },
     )
     package = fields.String(load_default=None)
 
@@ -1026,7 +1060,29 @@ class PackageConfigSchema(Schema):
         """
         from marshmallow_jsonschema import JSONSchema
 
-        return JSONSchema().dump(cls())
+        dumped = JSONSchema().dump(cls())
+
+        # marshmallow-jsonschema emits a top-level ``$ref`` to
+        # ``#/definitions/PackageConfigSchema`` (because the schema participates
+        # in nested references) and keeps every schema in ``definitions``.
+        definitions = dumped["definitions"]
+        root = definitions["PackageConfigSchema"]
+
+        # The raw ``.packit.yaml`` format allows ``CommonConfigSchema`` keys at
+        # the top level and on individual jobs (they are rearranged into
+        # ``packages`` during pre-processing). The marshmallow
+        # ``PackageConfigSchema`` and ``JobConfigSchema`` only declare their own
+        # structural keys, so merge the common-config properties into both to
+        # validate the raw format rather than the processed one.
+        common_props = definitions["CommonConfigSchema"]["properties"]
+        root["properties"].update(common_props)
+        definitions["JobConfigSchema"]["properties"].update(common_props)
+
+        return {
+            "$schema": dumped["$schema"],
+            "definitions": definitions,
+            **root,
+        }
 
 
 class UserConfigSchema(Schema):

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -656,6 +656,15 @@ class CommonConfigSchema(Schema):
         return CommonPackageConfig(**data)
 
 
+# A job may react to multiple events, e.g. `commit | koji_build`, which is
+# expanded into separate jobs by ``PackageConfigSchema.process_job_triggers``.
+# The pattern matches one or more trigger names joined by `|` (with optional
+# whitespace), and is anchored so it does not accept arbitrary strings
+# containing a `|`.
+_TRIGGER_VALUES = "|".join(t.value for t in JobConfigTriggerType)
+_TRIGGER_PIPE_PATTERN = rf"^({_TRIGGER_VALUES})(\s*\|\s*({_TRIGGER_VALUES}))*$"
+
+
 class JobConfigSchema(Schema):
     """
     Schema for processing JobConfig config data.
@@ -671,7 +680,7 @@ class JobConfigSchema(Schema):
                     {"enum": [t.value for t in JobConfigTriggerType]},
                     {
                         "type": "string",
-                        "pattern": r"\s*\|\s*",
+                        "pattern": _TRIGGER_PIPE_PATTERN,
                         "description": (
                             "pipe-separated triggers, e.g. 'commit | koji_build'"
                         ),

--- a/packit/schema.py
+++ b/packit/schema.py
@@ -1087,6 +1087,23 @@ class PackageConfigSchema(Schema):
         root["properties"].update(common_props)
         definitions["JobConfigSchema"]["properties"].update(common_props)
 
+        # A few raw-format keys are consumed before (or during) pre-processing,
+        # so they are not part of any marshmallow schema and must be allowed
+        # explicitly here:
+        #   * ``_`` is a YAML-anchor placeholder dropped by ``load_packit_yaml``.
+        #   * ``metadata`` on a job is deprecated; its contents are merged into
+        #     the job during pre-processing.
+        root["properties"]["_"] = {
+            "description": "YAML anchor placeholders (ignored by packit).",
+        }
+        definitions["JobConfigSchema"]["properties"]["metadata"] = {
+            "type": "object",
+            "description": (
+                "Deprecated: nest these options directly under the job object "
+                "instead."
+            ),
+        }
+
         return {
             "$schema": dumped["$schema"],
             "definitions": definitions,

--- a/plans/full.fmf
+++ b/plans/full.fmf
@@ -3,6 +3,13 @@ summary: Unit, integration & functional tests.
 discover+:
   filter: tag:full
 
+# marshmallow-jsonschema has no Fedora/EPEL package, install it from PyPI
+prepare:
+  - how: install
+    package: python3-pip
+  - how: shell
+    script: pip3 install marshmallow-jsonschema
+
 adjust:
   - when: "initiator == packit"
     because: "have the latest builds of ogr and specfile available for upstream test jobs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,8 +77,12 @@ testing = [
     "setuptools", # Required for test_upstream.py/test_get_version_macro
     "setuptools-scm", # Required for tests using python-ogr.spec
 ]
+schema = [
+    "marshmallow-jsonschema",
+]
 dev = [
     "packitos[testing]",
+    "packitos[schema]",
     "pre-commit",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ testing = [
     "flexmock",
     "deepdiff",
     "distro",
+    "jsonschema",
     "setuptools", # Required for test_upstream.py/test_get_version_macro
     "setuptools-scm", # Required for tests using python-ogr.spec
 ]

--- a/scripts/generate_package_schema.py
+++ b/scripts/generate_package_schema.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+"""Generate a JSON Schema for the Packit package configuration.
+
+This script uses ``marshmallow-jsonschema`` to introspect the
+``PackageConfigSchema`` and output a JSON Schema file suitable for
+submission to the `Schema Store <https://www.schemastore.org/>`_.
+
+Usage::
+
+    python scripts/generate_package_schema.py
+    python scripts/generate_package_schema.py --output packit.schema.json
+
+Requirements:
+    marshmallow-jsonschema (install with ``pip install marshmallow-jsonschema``)
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate JSON Schema for Packit package config",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=Path("packit.schema.json"),
+        help="Path to write the JSON Schema file (default: packit.schema.json)",
+    )
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indentation level (default: 2)",
+    )
+    args = parser.parse_args()
+
+    try:
+        from packit.schema import PackageConfigSchema
+    except ImportError as e:
+        print(
+            f"Error: Could not import PackageConfigSchema from packit.schema.\n"
+            f"Make sure packit is installed or PYTHONPATH is set correctly.\n"
+            f"Details: {e}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print("Generating JSON Schema from PackageConfigSchema...")
+    try:
+        schema = PackageConfigSchema.json_schema()
+    except Exception as e:
+        print(
+            f"Error: Failed to generate JSON Schema.\n" f"Details: {e}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(schema, f, indent=args.indent, ensure_ascii=False)
+        f.write("\n")
+
+    print(f"JSON Schema written to: {args.output.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/data/schema/invalid/invalid_pipe_trigger.yaml
+++ b/tests/data/schema/invalid/invalid_pipe_trigger.yaml
@@ -1,0 +1,7 @@
+packages:
+  mypackage:
+    specfile_path: mypackage.spec
+
+jobs:
+  - job: koji_build
+    trigger: commit | bogus

--- a/tests/data/schema/invalid/invalid_target.yaml
+++ b/tests/data/schema/invalid/invalid_target.yaml
@@ -1,0 +1,11 @@
+packages:
+  mypackage:
+    specfile_path: mypackage.spec
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - fedora-unstable
+    packages:
+      - mypackage

--- a/tests/data/schema/invalid/invalid_trigger.yaml
+++ b/tests/data/schema/invalid/invalid_trigger.yaml
@@ -1,0 +1,7 @@
+packages:
+  mypackage:
+    specfile_path: mypackage.spec
+
+jobs:
+  - job: copr_build
+    trigger: bogus

--- a/tests/data/schema/invalid/missing_job.yaml
+++ b/tests/data/schema/invalid/missing_job.yaml
@@ -1,0 +1,6 @@
+packages:
+  mypackage:
+    specfile_path: mypackage.spec
+
+jobs:
+  - trigger: pull_request

--- a/tests/data/schema/invalid/wrong_type.yaml
+++ b/tests/data/schema/invalid/wrong_type.yaml
@@ -1,0 +1,5 @@
+packages:
+  mypackage:
+    specfile_path: mypackage.spec
+
+jobs: not-a-list

--- a/tests/data/schema/valid/common_config.yaml
+++ b/tests/data/schema/valid/common_config.yaml
@@ -1,0 +1,17 @@
+packages:
+  mypackage:
+    specfile_path: mypackage.spec
+
+packit_instances:
+  - prod
+
+targets:
+  - fedora-all
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - fedora-all
+    packages:
+      - mypackage

--- a/tests/data/schema/valid/metadata_in_job.yaml
+++ b/tests/data/schema/valid/metadata_in_job.yaml
@@ -1,0 +1,14 @@
+packages:
+  mypackage:
+    specfile_path: mypackage.spec
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    metadata:
+      owner: "@oamg"
+      project: leapp
+      targets:
+        - epel-8-x86_64
+    packages:
+      - mypackage

--- a/tests/data/schema/valid/minimal.yaml
+++ b/tests/data/schema/valid/minimal.yaml
@@ -1,0 +1,9 @@
+packages:
+  mypackage:
+    specfile_path: mypackage.spec
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    packages:
+      - mypackage

--- a/tests/data/schema/valid/multiple_triggers.yaml
+++ b/tests/data/schema/valid/multiple_triggers.yaml
@@ -1,0 +1,9 @@
+packages:
+  mypackage:
+    specfile_path: mypackage.spec
+
+jobs:
+  - job: koji_build
+    trigger: commit | koji_build
+    packages:
+      - mypackage

--- a/tests/data/schema/valid/valid_targets.yaml
+++ b/tests/data/schema/valid/valid_targets.yaml
@@ -1,0 +1,27 @@
+packages:
+  mypackage:
+    specfile_path: mypackage.spec
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      # stable release aliases
+      - fedora-stable
+      - fedora-latest-stable
+      - fedora-all
+      - epel-all
+      # alias with an explicit architecture
+      - fedora-rawhide-x86_64
+      # concrete Fedora / EPEL chroots
+      - fedora-42
+      - fedora-42-aarch64
+      - epel-9
+      - epel-10.1
+      - epel-9-branched
+      # other Copr-supported distros
+      - centos-stream-9
+      - rhel+epel-10-x86_64
+      - opensuse-tumbleweed
+    packages:
+      - mypackage

--- a/tests/data/schema/valid/yaml_anchor_placeholder.yaml
+++ b/tests/data/schema/valid/yaml_anchor_placeholder.yaml
@@ -1,0 +1,14 @@
+packages:
+  mypackage:
+    specfile_path: mypackage.spec
+
+# YAML anchor placeholder, ignored by packit
+_:
+  - job: copr_build
+    trigger: pull_request
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    packages:
+      - mypackage

--- a/tests/full.fmf
+++ b/tests/full.fmf
@@ -18,6 +18,7 @@ require:
   - packit
   - python3-packit
   - python3-pytest-cov
+  - python3-jsonschema
   - rpm-build
   - rpmdevtools
   - python3-bodhi-client

--- a/tests/unit/config/test_json_schema.py
+++ b/tests/unit/config/test_json_schema.py
@@ -1,0 +1,47 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+import pytest
+import yaml
+from jsonschema import Draft7Validator
+
+from packit.schema import PackageConfigSchema
+
+SCHEMA_DATA_DIR = Path(__file__).parents[2] / "data" / "schema"
+VALID_CONFIG_PATHS = sorted((SCHEMA_DATA_DIR / "valid").glob("*.yaml"))
+INVALID_CONFIG_PATHS = sorted((SCHEMA_DATA_DIR / "invalid").glob("*.yaml"))
+
+
+@pytest.fixture(scope="module")
+def validator():
+    """Return a Draft7 validator for the generated package-config schema."""
+    return Draft7Validator(PackageConfigSchema.json_schema())
+
+
+def _load_yaml(path: Path) -> dict:
+    with path.open() as f:
+        return yaml.safe_load(f)
+
+
+@pytest.mark.parametrize(
+    "config_path",
+    VALID_CONFIG_PATHS,
+    ids=lambda path: path.stem,
+)
+def test_valid_package_configs(validator, config_path):
+    """The generated JSON Schema must accept valid .packit.yaml files."""
+    errors = list(validator.iter_errors(_load_yaml(config_path)))
+    assert errors == []
+
+
+@pytest.mark.parametrize(
+    "config_path",
+    INVALID_CONFIG_PATHS,
+    ids=lambda path: path.stem,
+)
+def test_invalid_package_configs(validator, config_path):
+    """The generated JSON Schema must reject invalid .packit.yaml files."""
+    errors = list(validator.iter_errors(_load_yaml(config_path)))
+    assert errors, f"expected validation errors in {config_path.name}"


### PR DESCRIPTION
## Summary

Packit package config files (`.packit.yaml`) lack a JSON Schema for inclusion in the JSON Schema Store, preventing editor validation and autocompletion. This PR automates schema generation from the existing marshmallow schema (`PackageConfigSchema`) using `marshmallow-jsonschema` and provides a helper script to output the schema as a JSON file.

Fixes #2759

## Changes

- Add `_jsonschema_type_mapping` methods to all custom marshmallow field types (`StringOrListOfStringsField`, `FilesToSyncField`, `ActionField`, `NotProcessedField`, `ListOrDict`) so that `marshmallow-jsonschema` can introspect them and produce accurate JSON Schema definitions.
- Add `PackageConfigSchema.json_schema()` classmethod that generates a Draft-07 JSON Schema dict using `marshmallow-jsonschema`.
- Create `scripts/generate_package_schema.py` helper script to import the schema, call `json_schema()`, and write the formatted JSON to a file (default: `packit.schema.json`).
- Add `marshmallow-jsonschema` as an optional `schema` extra dependency.

## Validation

- Run `python scripts/generate_package_schema.py` and verify the output is valid JSON Schema using a standard validator (e.g., `check-jsonschema`).
- Test the generated schema against a representative `.packit.yaml` file to confirm constraint coverage.
- Custom field types produce correct `anyOf`, `additionalProperties`, and nested schema definitions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)