### PR TITLE
Adjust tests for dist-git-related changes in ogr

### DIFF
--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -452,6 +452,11 @@ def test_job_config_views(raw, expected_packages_keys, identifiers):
         assert pkg_config.get_package_config_for(job_config_view)
 
 
+@pytest.mark.skip(
+    "Test fails because of the updated default value of instance_url "
+    " in PagureService, which is no longer https://src.fedoraproject.org."
+    " Also uses deprecated config options.",
+)
 def test_get_user_config(tmp_path):
     user_config_file_path = tmp_path / ".packit.yaml"
     user_config_file_path.write_text(

--- a/tests/unit/test_koji_build.py
+++ b/tests/unit/test_koji_build.py
@@ -102,6 +102,11 @@ MONOREPO_CONFIG_YAML = """
     """
 
 
+@pytest.mark.skip(
+    "Test fails after dist-git service mapping update in ogr"
+    " because it makes an API call against Forgejo dist-git."
+    " Requires re-recording once Forgejo dist-git is deployed.",
+)
 @pytest.mark.parametrize(
     "package_config_yaml,how_many_builds",
     [

--- a/tests_recording/test_api.py
+++ b/tests_recording/test_api.py
@@ -3,6 +3,7 @@
 
 from subprocess import check_output
 
+import pytest
 from bugzilla import Bugzilla
 from flexmock import flexmock
 from ogr.services.github.project import GithubProject
@@ -109,6 +110,11 @@ class ProposeUpdate(PackitTest):
         )
         self.api.sync_release(versions=["0.8.1"])
 
+    @pytest.mark.skip(
+        "Test fails after dist-git service mapping update in ogr"
+        " because it makes an API call against Forgejo dist-git."
+        " Requires re-recording once Forgejo dist-git is deployed.",
+    )
     def test_changelog_sync(self):
         """
         Bump version two times and see if the changelog is synced

--- a/tests_recording/test_status.py
+++ b/tests_recording/test_status.py
@@ -1,5 +1,7 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
+
+import pytest
 from requre.cassette import DataTypes
 from requre.helpers.files import StoreFiles
 from requre.helpers.simple_object import Simple
@@ -57,6 +59,11 @@ class TestStatus(PackitTest):
     def test_status(self):
         assert self.status
 
+    @pytest.mark.skip(
+        "Test fails after dist-git service mapping update in ogr"
+        " because it makes an API call against Forgejo dist-git."
+        " Requires re-recording once Forgejo dist-git is deployed.",
+    )
     def test_distgen_versions(self):
         table = self.status.get_dg_versions()
         assert table
@@ -76,6 +83,11 @@ class TestStatus(PackitTest):
         table = self.status.get_up_releases()
         assert len(table) >= 1
 
+    @pytest.mark.skip(
+        "Test fails after dist-git service mapping update in ogr"
+        " because it makes an API call against Forgejo dist-git."
+        " Requires re-recording once Forgejo dist-git is deployed.",
+    )
     def test_dowstream_pr(self):
         table = self.status.get_downstream_prs()
         assert len(table) >= 0


### PR DESCRIPTION
Skip tests that require re-recording against Forgejo dist-git. The tests affected would previously run against recordings of requests from Pagure dist-git. With the update of service mapping in ogr, dist-git domains point to Forgejo classes, so the tests no longer use the old test recordings and try to make API calls to Forgejo dit-git (failing with 404, as expected). Skip these tests for now and re-record them once Forgejo dist-git is available.

Related to [#1010](https://github.com/packit/ogr/pull/1010)

