### PR TITLE
Set `allow_maintainer_edit` on PRs in Forgejo dist-git

### DIFF
--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -345,12 +345,17 @@ class DistGit(PackitRepositoryBase):
             project.fork_create()
             project_fork = project.get_fork()
 
+        # [XXX] once dist-git migration is complete, allow_maintainer_edit
+        # can be set to True directly without the check for PagureProject
         try:
             dist_git_pr = project_fork.create_pr(
                 title=pr_title,
                 body=pr_description,
                 source_branch=source_branch,
                 target_branch=target_branch,
+                allow_maintainer_edit=(
+                    None if isinstance(project, PagureProject) else True
+                ),
             )
         except Exception as ex:
             logger.error(f"There was an error while creating the PR: {ex!r}")


### PR DESCRIPTION
The Forgejo API makes it possible to grant write access to Packit's PRs to maintainers (done via `ogr`). When this is set, there should be no need for Packit to sync ACLs manually (like it had to be done for Pagure in the past).

`allow_maintainer_edit` is only set in case the user's project is a `ForgejoProject`. It shouldn't break Packit while dist-git is still hosted on Pagure.

It might be worth checking whether it is possible that a PR could be created in dist-git in a code path other than in packit/distgit.py, causing a PR to be created without `allow_maintainer_edit` being set to. I don't believe that should be possible. If if it were possible, `allow_maintainer_edit` should be set here when updating Forgejo dist-git PRs: https://github.com/packit/packit/blob/375470775f49b43ee47fdfd4cc109e9e92194447/packit/api.py#L1743-L1748

Note: the `PagureAPIException` doesn't cover `ForgejoAPIException` and `GitlabAPIException`. That fix is already covered in a separate PR: https://github.com/packit/packit/pull/2762

Merge after https://github.com/packit/ogr/pull/1012

Fixes https://github.com/packit/packit/issues/2748
