### PR TITLE
feature: notify user of automatic steps when creating PR

### DIFF
--- a/packit/api.py
+++ b/packit/api.py
@@ -1459,20 +1459,20 @@ The first dist-git commit to be synced is '{short_hash}'.
 
         if JobType.koji_build in job_types:
             automatic_steps.append(
-                "- Packit will **automatically** build the package in Koji"
+                "- Packit will **automatically** build the package in Koji",
             )
         else:
             automatic_steps.append(
-                "- Packit will **NOT** automatically build the package in Koji"
+                "- Packit will **NOT** automatically build the package in Koji",
             )
 
         if JobType.bodhi_update in job_types:
             automatic_steps.append(
-                "- Packit will **automatically** create a Bodhi update"
+                "- Packit will **automatically** create a Bodhi update",
             )
         else:
             automatic_steps.append(
-                "- Packit will **NOT** automatically create a Bodhi update"
+                "- Packit will **NOT** automatically create a Bodhi update",
             )
 
         automatic_steps_info = (

--- a/packit/api.py
+++ b/packit/api.py
@@ -45,6 +45,7 @@ from packit.base_git import PackitRepositoryBase
 from packit.config import Config, PackageConfig, RunCommandType
 from packit.config.aliases import get_branches
 from packit.config.common_package_config import MockBootstrapSetup, MultiplePackages
+from packit.config.job_config import JobType
 from packit.config.package_config import find_packit_yaml, load_packit_yaml
 from packit.config.package_config_validator import PackageConfigValidator
 from packit.constants import (
@@ -1453,11 +1454,37 @@ The first dist-git commit to be synced is '{short_hash}'.
             else ""
         )
 
+        job_types = {job.type for job in self.package_config.jobs}
+        automatic_steps = []
+
+        if JobType.koji_build in job_types:
+            automatic_steps.append(
+                "- Packit will **automatically** build the package in Koji"
+            )
+        else:
+            automatic_steps.append(
+                "- Packit will **NOT** automatically build the package in Koji"
+            )
+
+        if JobType.bodhi_update in job_types:
+            automatic_steps.append(
+                "- Packit will **automatically** create a Bodhi update"
+            )
+        else:
+            automatic_steps.append(
+                "- Packit will **NOT** automatically create a Bodhi update"
+            )
+
+        automatic_steps_info = (
+            "\nWhen this PR is merged:\n" + "\n".join(automatic_steps) + "\n"
+        )
+
         return SYNC_RELEASE_PR_DESCRIPTION.format(
             upstream_tag_info=tag_info,
             upstream_commit_info=commit_info,
             release_monitoring_info=release_monitoring_info,
             resolved_bugzillas_info=resolved_bugzillas_info,
+            automatic_steps_info=automatic_steps_info,
         )
 
     def get_pr_default_title_and_description(self):

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -218,6 +218,7 @@ SYNC_RELEASE_PR_DESCRIPTION = (
     "{upstream_commit_info}\n"
     "{release_monitoring_info}"
     "{resolved_bugzillas_info}"
+    "{automatic_steps_info}"
 )
 
 SYNC_RELEASE_PR_GITLAB_CLONE_INSTRUCTIONS = (

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -41,6 +41,7 @@ def package_config_mock():
         parse_time_macros={},
         version_suffix=None,
         release_suffix=None,
+        jobs=[],
     )
     mock.should_receive("get_base_env").and_return({})
     mock.should_receive("get_all_files_to_sync").and_return(files_to_sync)

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -464,9 +464,9 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
             None,
             None,
             "Upstream tag: 1.0.0\nUpstream commit: _\n"
-                "\nWhen this PR is merged:\n"
-                "- Packit will **NOT** automatically build the package in Koji\n"
-                "- Packit will **NOT** automatically create a Bodhi update\n",
+            "\nWhen this PR is merged:\n"
+            "- Packit will **NOT** automatically build the package in Koji\n"
+            "- Packit will **NOT** automatically create a Bodhi update\n",
         ),
         pytest.param(
             "tag-link",
@@ -474,9 +474,9 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
             None,
             None,
             "Upstream tag: [1.0.0](tag-link)\nUpstream commit: _\n"
-                "\nWhen this PR is merged:\n"
-                "- Packit will **NOT** automatically build the package in Koji\n"
-                "- Packit will **NOT** automatically create a Bodhi update\n",
+            "\nWhen this PR is merged:\n"
+            "- Packit will **NOT** automatically build the package in Koji\n"
+            "- Packit will **NOT** automatically create a Bodhi update\n",
         ),
         pytest.param(
             "tag-link",
@@ -484,29 +484,31 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
             None,
             None,
             "Upstream tag: [1.0.0](tag-link)\nUpstream commit: [_](commit-link)\n"
-                "\nWhen this PR is merged:\n"
-                "- Packit will **NOT** automatically build the package in Koji\n"
-                "- Packit will **NOT** automatically create a Bodhi update\n",
+            "\nWhen this PR is merged:\n"
+            "- Packit will **NOT** automatically build the package in Koji\n"
+            "- Packit will **NOT** automatically create a Bodhi update\n",
         ),
         pytest.param(
             "tag-link",
             "",
             None,
             None,
-            "Upstream tag: [1.0.0](tag-link)\n" "Upstream commit: _\n"
-                "\nWhen this PR is merged:\n"
-                "- Packit will **NOT** automatically build the package in Koji\n"
-                "- Packit will **NOT** automatically create a Bodhi update\n",
+            "Upstream tag: [1.0.0](tag-link)\n"
+            "Upstream commit: _\n"
+            "\nWhen this PR is merged:\n"
+            "- Packit will **NOT** automatically build the package in Koji\n"
+            "- Packit will **NOT** automatically create a Bodhi update\n",
         ),
         pytest.param(
             "tag-link",
             "commit-link",
             None,
             None,
-            "Upstream tag: [1.0.0](tag-link)\n" "Upstream commit: [_](commit-link)\n"
-                "\nWhen this PR is merged:\n"
-                "- Packit will **NOT** automatically build the package in Koji\n"
-                "- Packit will **NOT** automatically create a Bodhi update\n",
+            "Upstream tag: [1.0.0](tag-link)\n"
+            "Upstream commit: [_](commit-link)\n"
+            "\nWhen this PR is merged:\n"
+            "- Packit will **NOT** automatically build the package in Koji\n"
+            "- Packit will **NOT** automatically create a Bodhi update\n",
         ),
         pytest.param(
             "tag-link",
@@ -516,9 +518,9 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
             "Upstream tag: [1.0.0](tag-link)\n"
             "Upstream commit: [_](commit-link)\n"
             "Release monitoring project: [12345](https://release-monitoring.org/project/12345)\n"
-                "\nWhen this PR is merged:\n"
-                "- Packit will **NOT** automatically build the package in Koji\n"
-                "- Packit will **NOT** automatically create a Bodhi update\n",
+            "\nWhen this PR is merged:\n"
+            "- Packit will **NOT** automatically build the package in Koji\n"
+            "- Packit will **NOT** automatically create a Bodhi update\n",
         ),
         pytest.param(
             "tag-link",
@@ -529,9 +531,9 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
             "Upstream commit: [_](commit-link)\n"
             "Release monitoring project: [12345](https://release-monitoring.org/project/12345)\n"
             "Resolves: [rhbz#1234](https://bugzilla.redhat.com/show_bug.cgi?id=1234)\n"
-                "\nWhen this PR is merged:\n"
-                "- Packit will **NOT** automatically build the package in Koji\n"
-                "- Packit will **NOT** automatically create a Bodhi update\n",
+            "\nWhen this PR is merged:\n"
+            "- Packit will **NOT** automatically build the package in Koji\n"
+            "- Packit will **NOT** automatically create a Bodhi update\n",
         ),
         pytest.param(
             "tag-link",
@@ -542,9 +544,9 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
             "Upstream commit: [_](commit-link)\n"
             "Release monitoring project: [12345](https://release-monitoring.org/project/12345)\n"
             "Resolves: rhbz#not-a-number\n"
-                "\nWhen this PR is merged:\n"
-                "- Packit will **NOT** automatically build the package in Koji\n"
-                "- Packit will **NOT** automatically create a Bodhi update\n",
+            "\nWhen this PR is merged:\n"
+            "- Packit will **NOT** automatically build the package in Koji\n"
+            "- Packit will **NOT** automatically create a Bodhi update\n",
         ),
     ],
 )

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -315,7 +315,11 @@ def test_sync_release_sync_files_call(config_mock, upstream_mock, distgit_mock):
     [
         pytest.param(
             (
-                "Upstream tag: _\nUpstream commit: _\n\n---\n\n"
+                "Upstream tag: _\nUpstream commit: _\n"
+                "\nWhen this PR is merged:\n"
+                "- Packit will **NOT** automatically build the package in Koji\n"
+                "- Packit will **NOT** automatically create a Bodhi update\n"
+                "\n---\n\n"
                 "If you need to do any change in this pull request, you can clone Packit's fork "
                 "and push directly to the source branch of this PR (provided you have "
                 "commit access "
@@ -356,7 +360,11 @@ def test_sync_release_sync_files_call(config_mock, upstream_mock, distgit_mock):
         ),
         pytest.param(
             (
-                "Upstream tag: _\nUpstream commit: _\n\n---\n\n"
+                "Upstream tag: _\nUpstream commit: _\n"
+                "\nWhen this PR is merged:\n"
+                "- Packit will **NOT** automatically build the package in Koji\n"
+                "- Packit will **NOT** automatically create a Bodhi update\n"
+                "\n---\n\n"
                 "If you need to do any change in this pull request, follow "
                 "the instructions under `Code -> Check out branch` in the right sidebar.\n"
                 "\n---\n\n"
@@ -455,35 +463,50 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
             "",
             None,
             None,
-            "Upstream tag: 1.0.0\nUpstream commit: _\n",
+            "Upstream tag: 1.0.0\nUpstream commit: _\n"
+                "\nWhen this PR is merged:\n"
+                "- Packit will **NOT** automatically build the package in Koji\n"
+                "- Packit will **NOT** automatically create a Bodhi update\n",
         ),
         pytest.param(
             "tag-link",
             "",
             None,
             None,
-            "Upstream tag: [1.0.0](tag-link)\nUpstream commit: _\n",
+            "Upstream tag: [1.0.0](tag-link)\nUpstream commit: _\n"
+                "\nWhen this PR is merged:\n"
+                "- Packit will **NOT** automatically build the package in Koji\n"
+                "- Packit will **NOT** automatically create a Bodhi update\n",
         ),
         pytest.param(
             "tag-link",
             "commit-link",
             None,
             None,
-            "Upstream tag: [1.0.0](tag-link)\nUpstream commit: [_](commit-link)\n",
+            "Upstream tag: [1.0.0](tag-link)\nUpstream commit: [_](commit-link)\n"
+                "\nWhen this PR is merged:\n"
+                "- Packit will **NOT** automatically build the package in Koji\n"
+                "- Packit will **NOT** automatically create a Bodhi update\n",
         ),
         pytest.param(
             "tag-link",
             "",
             None,
             None,
-            "Upstream tag: [1.0.0](tag-link)\n" "Upstream commit: _\n",
+            "Upstream tag: [1.0.0](tag-link)\n" "Upstream commit: _\n"
+                "\nWhen this PR is merged:\n"
+                "- Packit will **NOT** automatically build the package in Koji\n"
+                "- Packit will **NOT** automatically create a Bodhi update\n",
         ),
         pytest.param(
             "tag-link",
             "commit-link",
             None,
             None,
-            "Upstream tag: [1.0.0](tag-link)\n" "Upstream commit: [_](commit-link)\n",
+            "Upstream tag: [1.0.0](tag-link)\n" "Upstream commit: [_](commit-link)\n"
+                "\nWhen this PR is merged:\n"
+                "- Packit will **NOT** automatically build the package in Koji\n"
+                "- Packit will **NOT** automatically create a Bodhi update\n",
         ),
         pytest.param(
             "tag-link",
@@ -492,7 +515,10 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
             None,
             "Upstream tag: [1.0.0](tag-link)\n"
             "Upstream commit: [_](commit-link)\n"
-            "Release monitoring project: [12345](https://release-monitoring.org/project/12345)\n",
+            "Release monitoring project: [12345](https://release-monitoring.org/project/12345)\n"
+                "\nWhen this PR is merged:\n"
+                "- Packit will **NOT** automatically build the package in Koji\n"
+                "- Packit will **NOT** automatically create a Bodhi update\n",
         ),
         pytest.param(
             "tag-link",
@@ -502,7 +528,10 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
             "Upstream tag: [1.0.0](tag-link)\n"
             "Upstream commit: [_](commit-link)\n"
             "Release monitoring project: [12345](https://release-monitoring.org/project/12345)\n"
-            "Resolves: [rhbz#1234](https://bugzilla.redhat.com/show_bug.cgi?id=1234)\n",
+            "Resolves: [rhbz#1234](https://bugzilla.redhat.com/show_bug.cgi?id=1234)\n"
+                "\nWhen this PR is merged:\n"
+                "- Packit will **NOT** automatically build the package in Koji\n"
+                "- Packit will **NOT** automatically create a Bodhi update\n",
         ),
         pytest.param(
             "tag-link",
@@ -512,7 +541,10 @@ def test_get_default_commit_description(api_mock, resolved_bugs, result):
             "Upstream tag: [1.0.0](tag-link)\n"
             "Upstream commit: [_](commit-link)\n"
             "Release monitoring project: [12345](https://release-monitoring.org/project/12345)\n"
-            "Resolves: rhbz#not-a-number\n",
+            "Resolves: rhbz#not-a-number\n"
+                "\nWhen this PR is merged:\n"
+                "- Packit will **NOT** automatically build the package in Koji\n"
+                "- Packit will **NOT** automatically create a Bodhi update\n",
         ),
     ],
 )
@@ -534,6 +566,30 @@ def test_get_pr_description(
         )
         == result
     )
+
+
+def test_get_pr_description_with_jobs(config_mock, upstream_mock, distgit_mock):
+    """Test that automatic steps info reflects configured jobs correctly."""
+    from packit.config.job_config import JobType
+
+    jobs = [
+        flexmock(type=JobType.koji_build),
+        flexmock(type=JobType.bodhi_update),
+    ]
+    package_config_mock = flexmock(jobs=jobs)
+    api = PackitAPI(config=config_mock, package_config=package_config_mock)
+    flexmock(api)
+    api._up = upstream_mock
+    api._dg = distgit_mock
+
+    flexmock(packit_api).should_receive("get_tag_link").and_return("tag-link")
+    flexmock(packit_api).should_receive("get_commit_link").and_return("commit-link")
+
+    result = api.get_pr_description("1.0.0")
+    assert "When this PR is merged:" in result
+    assert "- Packit will **automatically** build the package in Koji" in result
+    assert "- Packit will **automatically** create a Bodhi update" in result
+    assert "NOT" not in result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When sync_release creates a PR, append a summary to the PR description indicating which jobs (koji_build, bodhi_update) will run automatically after merge, based on the packit.yaml config.

Example output in PR description:
  When this PR is merged:
  - Packit will automatically build the package in Koji
  - Packit will NOT automatically create a Bodhi update

Closes #2729

cc @lbarcziova