### PR TITLE
Provide user-friendly error when missing Pagure API key

### DIFF
--- a/packit/cli/utils.py
+++ b/packit/cli/utils.py
@@ -12,6 +12,7 @@ from typing import Optional, Union
 
 import click
 from github import GithubException
+from ogr.exceptions import OgrException
 from ogr.parsing import parse_git_repo
 from ogr.services.github import GithubService
 
@@ -23,8 +24,10 @@ from packit.constants import (
     CONFIG_FILE_NAMES,
     DISTRO_DIR,
     PACKIT_NAMESPACE,
+    PAGURE_API_KEY_ERROR_MSG,
     PRECOMMIT_HOOK_REPO,
     SRC_GIT_CONFIG,
+    USER_CONFIG_FILE_DOCS_URL,
 )
 from packit.exceptions import PackitException, PackitNotAGitRepoException
 from packit.local_project import LocalProject
@@ -75,10 +78,42 @@ def cover_packit_exception(_func=None, *, exit_code=None):
                         "https://github.com/packit/packit/tree/master/docs\n",
                     )
                 sys.exit(exit_code or 3)
-            except Exception as exc:
+            except OgrException as exc:
                 if config and config.debug:
                     logger.exception(exc)
                 else:
+                    msg = str(exc)
+                    cause = str(getattr(exc, "__cause__", "") or "")
+                    if (
+                        "whoami" in msg
+                        or "whoami" in cause
+                        or "401" in msg
+                        or "401" in cause
+                    ):
+                        logger.error(PAGURE_API_KEY_ERROR_MSG)
+                    else:
+                        logger.error(
+                            f"We've encountered an error while talking to Git service API: {exc}\n"
+                            "Please check that your API token is set and has correct permissions.\n"
+                            f"See {USER_CONFIG_FILE_DOCS_URL} for details.",
+                        )
+                sys.exit(exit_code or 2)
+            except Exception as exc:
+                if config and config.debug:
+                    logger.exception(exc)
+                    sys.exit(exit_code or 4)
+                else:
+                    msg = str(exc)
+                    cause = str(getattr(exc, "__cause__", "") or "")
+                    if ("whoami" in msg or "whoami" in cause) and (
+                        "401" in msg
+                        or "401" in cause
+                        or "src.fedoraproject.org" in msg
+                        or "src.fedoraproject.org" in cause
+                    ):
+                        logger.error(PAGURE_API_KEY_ERROR_MSG)
+                        sys.exit(exit_code or 2)
+                        return
                     logger.error(exc)
                     click.echo(
                         "Unexpected exception occurred,\n"
@@ -86,7 +121,7 @@ def cover_packit_exception(_func=None, *, exit_code=None):
                         "https://github.com/packit/packit/issues",
                         err=True,
                     )
-                sys.exit(exit_code or 4)
+                    sys.exit(exit_code or 4)
 
         return covered_func
 

--- a/packit/constants.py
+++ b/packit/constants.py
@@ -283,3 +283,11 @@ HTTP_REQUEST_TIMEOUT = (10, 30)
 FAST_FORWARD_MERGE_INTO_KEY = "fast_forward_merge_into"
 
 PACKAGE_CONFIG_HEADERS = {"Accept": "application/yaml"}
+
+USER_CONFIG_FILE_DOCS_URL = (
+    "https://packit.dev/docs/configuration#user-configuration-file"
+)
+PAGURE_API_KEY_ERROR_MSG = (
+    "You need to add an API key for Pagure in your packit config file. "
+    f"See {USER_CONFIG_FILE_DOCS_URL} for details."
+)

--- a/packit/distgit.py
+++ b/packit/distgit.py
@@ -11,10 +11,12 @@ from typing import Optional, Union
 
 import cccolutils
 import git
+import requests
 from bodhi.client.bindings import BodhiClientException
 from bodhi.client.oidcclient import OIDCClientError
 from lazy_object_proxy import Proxy
 from ogr.abstract import PullRequest
+from ogr.exceptions import OgrException
 from ogr.services.pagure import PagureProject
 from specfile.utils import NEVR
 
@@ -26,7 +28,11 @@ from packit.config import (
     PackageConfig,
     get_local_package_config,
 )
-from packit.constants import DEFAULT_BODHI_UPDATE_TYPE, EXISTING_BODHI_UPDATE_REGEX
+from packit.constants import (
+    DEFAULT_BODHI_UPDATE_TYPE,
+    EXISTING_BODHI_UPDATE_REGEX,
+    PAGURE_API_KEY_ERROR_MSG,
+)
 from packit.exceptions import (
     PackitBodhiException,
     PackitConfigException,
@@ -297,10 +303,25 @@ class DistGit(PackitRepositoryBase):
         if fork_remote_name not in [
             remote.name for remote in self.local_project.git_repo.remotes
         ]:
-            fork = self.local_project.git_project.get_fork()
-            if not fork:
-                self.local_project.git_project.fork_create()
+            try:
                 fork = self.local_project.git_project.get_fork()
+                if not fork:
+                    self.local_project.git_project.fork_create()
+                    fork = self.local_project.git_project.get_fork()
+            except (OgrException, requests.exceptions.RequestException) as ex:
+                cause = str(getattr(ex, "__cause__", "") or "")
+                if (
+                    "whoami" in str(ex)
+                    or "whoami" in cause
+                    or "401" in str(ex)
+                    or "401" in cause
+                ):
+                    raise PackitException(PAGURE_API_KEY_ERROR_MSG) from ex
+                raise PackitException(
+                    f"Failed to create/get a fork for "
+                    f"{self.local_project.git_project.full_repo_name}: {ex}",
+                ) from ex
+
             if not fork:
                 raise PackitException(
                     "Unable to create a fork of repository "
@@ -340,10 +361,21 @@ class DistGit(PackitRepositoryBase):
         )
         project = self.local_project.git_project
 
-        project_fork = project.get_fork()
-        if not project_fork:
-            project.fork_create()
+        try:
             project_fork = project.get_fork()
+            if not project_fork:
+                project.fork_create()
+                project_fork = project.get_fork()
+        except (OgrException, requests.exceptions.RequestException) as ex:
+            cause = str(getattr(ex, "__cause__", "") or "")
+            if (
+                "whoami" in str(ex)
+                or "whoami" in cause
+                or "401" in str(ex)
+                or "401" in cause
+            ):
+                raise PackitException(PAGURE_API_KEY_ERROR_MSG) from ex
+            raise
 
         try:
             dist_git_pr = project_fork.create_pr(

--- a/tests/unit/test_cli_utils.py
+++ b/tests/unit/test_cli_utils.py
@@ -1,9 +1,11 @@
 # Copyright Contributors to the Packit project.
 # SPDX-License-Identifier: MIT
 
+import logging
 import sys
 
 from flexmock import flexmock
+from ogr.exceptions import OgrException
 
 from packit.cli.utils import cover_packit_exception
 from packit.exceptions import PackitException
@@ -130,3 +132,52 @@ def test_cover_packit_exception_decorator_other_exception_config_debug():
         raise CustomException("Other test exception")
 
     covered_func(config=flexmock(debug=True))
+
+
+def test_cover_packit_exception_decorator_ogr_pagure_auth_error(caplog):
+    flexmock(sys).should_receive("exit").with_args(2)
+
+    @cover_packit_exception
+    def covered_func():
+        raise OgrException(
+            "Max retries exceeded with url: /api/0/-/whoami "
+            "(Caused by ResponseError('too many 401 error responses'))",
+        )
+
+    with caplog.at_level(logging.ERROR, logger="packit"):
+        covered_func()
+    assert (
+        "You need to add an API key for Pagure in your packit config file"
+        in caplog.text
+    )
+
+
+def test_cover_packit_exception_decorator_generic_ogr_exception(caplog):
+    flexmock(sys).should_receive("exit").with_args(2)
+
+    @cover_packit_exception
+    def covered_func():
+        raise OgrException("Generic git service failure")
+
+    with caplog.at_level(logging.ERROR, logger="packit"):
+        covered_func()
+    assert "We've encountered an error while talking to Git service API" in caplog.text
+
+
+def test_cover_packit_exception_decorator_other_exception_whoami(caplog):
+    flexmock(sys).should_receive("exit").with_args(2)
+
+    @cover_packit_exception
+    def covered_func():
+        raise Exception(
+            "HTTPSConnectionPool(host='src.fedoraproject.org', port=443): "
+            "Max retries exceeded with url: /api/0/-/whoami "
+            "(Caused by ResponseError('too many 401 error responses'))",
+        )
+
+    with caplog.at_level(logging.ERROR, logger="packit"):
+        covered_func()
+    assert (
+        "You need to add an API key for Pagure in your packit config file"
+        in caplog.text
+    )

--- a/tests/unit/test_dg.py
+++ b/tests/unit/test_dg.py
@@ -6,12 +6,14 @@ import re
 
 import pytest
 from flexmock import flexmock
+from ogr.exceptions import OgrException
 from specfile import Specfile
 
 from packit.cli.utils import get_packit_api
 from packit.config import CommonPackageConfig, Config, PackageConfig
 from packit.constants import DISTGIT_HOSTNAME_CANDIDATES, EXISTING_BODHI_UPDATE_REGEX
 from packit.distgit import DistGit
+from packit.exceptions import PackitException
 from packit.local_project import LocalProjectBuilder
 from packit.pkgtool import PkgTool
 
@@ -301,3 +303,39 @@ def test_pkg_tool_details():
             flexmock(PkgTool).should_receive("clone").and_return()
 
         api.dg.clone_package("/tmp")
+
+
+def test_push_to_fork_pagure_auth_error(distgit_mock):
+    distgit_mock.local_project.git_repo.remotes = []
+    distgit_mock.local_project.git_project.should_receive("get_fork").and_raise(
+        OgrException(
+            "HTTPSConnectionPool(host='src.fedoraproject.org', port=443): "
+            "Max retries exceeded with url: /api/0/-/whoami "
+            "(Caused by ResponseError('too many 401 error responses'))",
+        ),
+    )
+    with pytest.raises(PackitException) as excinfo:
+        distgit_mock.push_to_fork(branch_name="f36", fork_remote_name="fork-remote")
+    assert "You need to add an API key for Pagure in your packit config file" in str(
+        excinfo.value,
+    )
+
+
+def test_create_pull_pagure_auth_error(distgit_mock):
+    distgit_mock.local_project.git_project.should_receive("get_fork").and_raise(
+        OgrException(
+            "HTTPSConnectionPool(host='src.fedoraproject.org', port=443): "
+            "Max retries exceeded with url: /api/0/-/whoami "
+            "(Caused by ResponseError('too many 401 error responses'))",
+        ),
+    )
+    with pytest.raises(PackitException) as excinfo:
+        distgit_mock.create_pull(
+            pr_title="Update to 0.4.0",
+            pr_description="Upstream update",
+            source_branch="f36-update",
+            target_branch="f36",
+        )
+    assert "You need to add an API key for Pagure in your packit config file" in str(
+        excinfo.value,
+    )


### PR DESCRIPTION
When running commands like `packit pull-from-upstream` without a configured Pagure API key, an unhandled 401 response during the `/api/0/-/whoami` check resulted in a connection retry failure:

```
HTTPSConnectionPool(host='src.fedoraproject.org', port=443): Max retries exceeded with url: /api/0/-/whoami (Caused by ResponseError('too many 401 error responses'))
Unexpected exception occurred,
please file an issue here:
https://github.com/packit/packit/issues
```

This PR handles Pagure authentication errors cleanly:
1. Adds `USER_CONFIG_FILE_DOCS_URL` and `PAGURE_API_KEY_ERROR_MSG` constants in `packit/constants.py`.
2. Catches Pagure authentication errors in `DistGit.push_to_fork()` and `DistGit.create_pull()` when retrieving or creating forks, raising a clear `PackitException` directing the user to the documentation.
3. Catches Pagure authentication exceptions in the `cover_packit_exception` CLI decorator, outputting the helpful error message and exiting cleanly with code 2 instead of reporting an unexpected internal exception.
4. Adds unit tests in `tests/unit/test_dg.py` and `tests/unit/test_cli_utils.py` covering both code paths.

Fixes #2737